### PR TITLE
Abstract API source type from method model

### DIFF
--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
@@ -97,10 +97,10 @@ public class GapicContext extends CodegenContext {
    * Returns the list of optional fields from the given GapicMethodConfig, excluding the Page Token
    * field
    */
-  public List<FieldType> removePageTokenFromFields(
-      Iterable<FieldType> fields, MethodConfig methodConfig) {
-    List<FieldType> newFields = new ArrayList<>();
-    for (FieldType field : fields) {
+  public List<FieldModel> removePageTokenFromFields(
+      Iterable<FieldModel> fields, MethodConfig methodConfig) {
+    List<FieldModel> newFields = new ArrayList<>();
+    for (FieldModel field : fields) {
       if (methodConfig.isPageStreaming()
           && field.equals(methodConfig.getPageStreaming().getRequestTokenField())) {
         continue;

--- a/src/main/java/com/google/api/codegen/config/BatchingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/BatchingConfig.java
@@ -34,15 +34,14 @@ public abstract class BatchingConfig {
    * collector.
    */
   @Nullable
-  public static BatchingConfig createBatching(
+  static BatchingConfig createBatching(
       DiagCollector diagCollector, BatchingConfigProto batchingConfig, MethodModel method) {
 
     BatchingDescriptorProto batchDescriptor = batchingConfig.getBatchDescriptor();
     String batchedFieldName = batchDescriptor.getBatchedField();
-    FieldType batchedField = null;
-    try {
-      batchedField = method.lookupInputField(batchedFieldName);
-    } catch (NullPointerException e) {
+    FieldType batchedField;
+    batchedField = method.lookupInputField(batchedFieldName);
+    if (batchedField == null) {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,

--- a/src/main/java/com/google/api/codegen/config/BatchingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/BatchingConfig.java
@@ -19,9 +19,6 @@ import com.google.api.codegen.BatchingDescriptorProto;
 import com.google.api.codegen.BatchingSettingsProto;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
-import com.google.api.tools.framework.model.Field;
-import com.google.api.tools.framework.model.FieldSelector;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
@@ -38,25 +35,26 @@ public abstract class BatchingConfig {
    */
   @Nullable
   public static BatchingConfig createBatching(
-      DiagCollector diagCollector, BatchingConfigProto batchingConfig, Method method) {
+      DiagCollector diagCollector, BatchingConfigProto batchingConfig, MethodModel method) {
 
     BatchingDescriptorProto batchDescriptor = batchingConfig.getBatchDescriptor();
     String batchedFieldName = batchDescriptor.getBatchedField();
-    Field batchedField = method.getInputType().getMessageType().lookupField(batchedFieldName);
-    if (batchedField == null) {
+    FieldType batchedField = null;
+    try {
+      batchedField = method.lookupInputField(batchedFieldName);
+    } catch (NullPointerException e) {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,
               "Batched field missing for batch config: method = %s, message type = %s, field = %s",
               method.getFullName(),
-              method.getInputType().getMessageType().getFullName(),
+              method.getInputFullName(),
               batchedFieldName));
     }
 
-    ImmutableList.Builder<FieldSelector> discriminatorsBuilder = ImmutableList.builder();
+    ImmutableList.Builder<GenericFieldSelector> discriminatorsBuilder = ImmutableList.builder();
     for (String discriminatorName : batchDescriptor.getDiscriminatorFieldsList()) {
-      FieldSelector selector =
-          FieldSelector.resolve(method.getInputType().getMessageType(), discriminatorName);
+      GenericFieldSelector selector = method.getInputFieldSelector(discriminatorName);
       if (selector == null) {
         diagCollector.addDiag(
             Diag.error(
@@ -64,18 +62,19 @@ public abstract class BatchingConfig {
                 "Discriminator field missing for batch config: method = %s, message type = %s, "
                     + "field = %s",
                 method.getFullName(),
-                method.getInputType().getMessageType().getFullName(),
+                method.getInputFullName(),
                 discriminatorName));
       }
       discriminatorsBuilder.add(selector);
     }
 
     String subresponseFieldName = batchDescriptor.getSubresponseField();
-    Field subresponseField;
+    FieldType subresponseField = null;
     if (!subresponseFieldName.isEmpty()) {
-      subresponseField = method.getOutputType().getMessageType().lookupField(subresponseFieldName);
-    } else {
-      subresponseField = null;
+      try {
+        subresponseField = method.lookupOutputField(subresponseFieldName);
+      } catch (NullPointerException e) {
+      }
     }
 
     BatchingSettingsProto batchingSettings = batchingConfig.getThresholds();
@@ -107,9 +106,9 @@ public abstract class BatchingConfig {
         elementCountLimit,
         requestByteLimit,
         delayThresholdMillis,
-        batchedField == null ? null : new ProtoField(batchedField),
+        batchedField,
         discriminatorsBuilder.build(),
-        subresponseField == null ? null : new ProtoField(subresponseField),
+        subresponseField,
         flowControlElementLimit,
         flowControlByteLimit,
         flowControlLimitConfig);
@@ -127,7 +126,7 @@ public abstract class BatchingConfig {
 
   public abstract FieldType getBatchedField();
 
-  public abstract ImmutableList<FieldSelector> getDiscriminatorFields();
+  public abstract ImmutableList<GenericFieldSelector> getDiscriminatorFields();
 
   @Nullable
   public abstract FieldType getSubresponseField();

--- a/src/main/java/com/google/api/codegen/config/BatchingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/BatchingConfig.java
@@ -39,7 +39,7 @@ public abstract class BatchingConfig {
 
     BatchingDescriptorProto batchDescriptor = batchingConfig.getBatchDescriptor();
     String batchedFieldName = batchDescriptor.getBatchedField();
-    FieldType batchedField;
+    FieldModel batchedField;
     batchedField = method.getInputField(batchedFieldName);
     if (batchedField == null) {
       diagCollector.addDiag(
@@ -68,7 +68,7 @@ public abstract class BatchingConfig {
     }
 
     String subresponseFieldName = batchDescriptor.getSubresponseField();
-    FieldType subresponseField = null;
+    FieldModel subresponseField = null;
     if (!subresponseFieldName.isEmpty()) {
       subresponseField = method.getOutputField(subresponseFieldName);
     }
@@ -120,12 +120,12 @@ public abstract class BatchingConfig {
 
   public abstract long getDelayThresholdMillis();
 
-  public abstract FieldType getBatchedField();
+  public abstract FieldModel getBatchedField();
 
   public abstract ImmutableList<GenericFieldSelector> getDiscriminatorFields();
 
   @Nullable
-  public abstract FieldType getSubresponseField();
+  public abstract FieldModel getSubresponseField();
 
   public boolean hasSubresponseField() {
     return getSubresponseField() != null;

--- a/src/main/java/com/google/api/codegen/config/BatchingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/BatchingConfig.java
@@ -40,7 +40,7 @@ public abstract class BatchingConfig {
     BatchingDescriptorProto batchDescriptor = batchingConfig.getBatchDescriptor();
     String batchedFieldName = batchDescriptor.getBatchedField();
     FieldType batchedField;
-    batchedField = method.lookupInputField(batchedFieldName);
+    batchedField = method.getInputField(batchedFieldName);
     if (batchedField == null) {
       diagCollector.addDiag(
           Diag.error(
@@ -70,10 +70,7 @@ public abstract class BatchingConfig {
     String subresponseFieldName = batchDescriptor.getSubresponseField();
     FieldType subresponseField = null;
     if (!subresponseFieldName.isEmpty()) {
-      try {
-        subresponseField = method.lookupOutputField(subresponseFieldName);
-      } catch (NullPointerException e) {
-      }
+      subresponseField = method.getOutputField(subresponseFieldName);
     }
 
     BatchingSettingsProto batchingSettings = batchingConfig.getThresholds();

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicInterfaceConfig.java
@@ -48,6 +48,9 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
   }
 
   @Override
+  public abstract DiscoInterfaceModel getInterfaceModel();
+
+  @Override
   public String getRawName() {
     // TODO(andrealin): Return actual simple name.
     return getName();
@@ -64,6 +67,11 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
   @Override
   @Nullable
   public abstract SmokeTestConfig getSmokeTestConfig();
+
+  @Override
+  public ImmutableList<FieldModel> getIamResources() {
+    return ImmutableList.of();
+  }
 
   static DiscoGapicInterfaceConfig createInterfaceConfig(
       Document document,
@@ -135,6 +143,7 @@ public abstract class DiscoGapicInterfaceConfig implements InterfaceConfig {
           retrySettingsDefinition,
           requiredConstructorParams,
           manualDoc,
+          new DiscoInterfaceModel(interfaceNameOverride),
           interfaceNameOverride,
           smokeTestConfig,
           methodConfigMap,

--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -14,13 +14,18 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.codegen.BatchingConfigProto;
+import com.google.api.codegen.FlatteningConfigProto;
+import com.google.api.codegen.FlatteningGroupProto;
 import com.google.api.codegen.MethodConfigProto;
+import com.google.api.codegen.PageStreamingConfigProto;
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.codegen.SurfaceTreatmentProto;
 import com.google.api.codegen.VisibilityProto;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.discovery.Method;
+import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
@@ -40,7 +45,6 @@ import org.joda.time.Duration;
  */
 @AutoValue
 public abstract class DiscoGapicMethodConfig extends MethodConfig {
-  public abstract Method getMethod();
 
   @Override
   public boolean isGrpcStreaming() {
@@ -74,13 +78,39 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       DiagCollector diagCollector,
       String language,
       MethodConfigProto methodConfigProto,
-      com.google.api.codegen.discovery.Method method,
+      Method method,
       ImmutableSet<String> retryCodesConfigNames,
       ImmutableSet<String> retryParamsConfigNames) {
 
     boolean error = false;
+    DiscoveryMethodModel methodModel = new DiscoveryMethodModel(method);
 
-    //TODO(andrealin): Paging, batching, and retry configs.
+    PageStreamingConfig pageStreaming = null;
+    if (!PageStreamingConfigProto.getDefaultInstance()
+        .equals(methodConfigProto.getPageStreaming())) {
+      pageStreaming = PageStreamingConfig.createPageStreaming(diagCollector, method);
+      if (pageStreaming == null) {
+        error = true;
+      }
+    }
+
+    ImmutableList<FlatteningConfig> flattening = null;
+    if (!FlatteningConfigProto.getDefaultInstance().equals(methodConfigProto.getFlattening())) {
+      flattening = createFlattening(diagCollector, methodConfigProto, method);
+      if (flattening == null) {
+        error = true;
+      }
+    }
+
+    BatchingConfig batching = null;
+    if (!BatchingConfigProto.getDefaultInstance().equals(methodConfigProto.getBatching())) {
+      batching =
+          BatchingConfig.createBatching(
+              diagCollector, methodConfigProto.getBatching(), methodModel);
+      if (batching == null) {
+        error = true;
+      }
+    }
 
     String retryCodesName = methodConfigProto.getRetryCodesName();
     if (!retryCodesName.isEmpty() && !retryCodesConfigNames.contains(retryCodesName)) {
@@ -89,7 +119,7 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
               SimpleLocation.TOPLEVEL,
               "Retry codes config used but not defined: '%s' (in method %s)",
               retryCodesName,
-              method.id()));
+              methodModel.getFullName()));
       error = true;
     }
 
@@ -100,7 +130,7 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
               SimpleLocation.TOPLEVEL,
               "Retry parameters config used but not defined: %s (in method %s)",
               retryParamsName,
-              method.id()));
+              methodModel.getFullName()));
       error = true;
     }
 
@@ -110,7 +140,7 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
           Diag.error(
               SimpleLocation.TOPLEVEL,
               "Default timeout not found or has invalid value (in method %s)",
-              method.id()));
+              methodModel.getFullName()));
       error = true;
     }
 
@@ -160,23 +190,91 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
       return null;
     } else {
       return new AutoValue_DiscoGapicMethodConfig(
-          null,
-          null,
+          new DiscoveryMethodModel(method),
+          pageStreaming,
+          flattening,
           retryCodesName,
           retryParamsName,
           timeout,
           requiredFieldConfigs,
           optionalFieldConfigs,
           defaultResourceNameTreatment,
-          null,
+          batching,
           hasRequestObjectMethod,
           fieldNamePatterns,
           sampleCodeInitFields,
           visibility,
           releaseLevel,
-          longRunningConfig,
-          method);
+          longRunningConfig);
     }
+  }
+
+  @Nullable
+  private static ImmutableList<FlatteningConfig> createFlattening(
+      DiagCollector diagCollector, MethodConfigProto methodConfigProto, Method method) {
+    boolean missing = false;
+    ImmutableList.Builder<FlatteningConfig> flatteningGroupsBuilder = ImmutableList.builder();
+    for (FlatteningGroupProto flatteningGroup : methodConfigProto.getFlattening().getGroupsList()) {
+      FlatteningConfig groupConfig =
+          FlatteningConfig.createFlattening(
+              diagCollector,
+              null,
+              null,
+              methodConfigProto,
+              flatteningGroup,
+              new DiscoveryMethodModel(method));
+      if (groupConfig == null) {
+        missing = true;
+      } else {
+        flatteningGroupsBuilder.add(groupConfig);
+      }
+    }
+    if (missing) {
+      return null;
+    }
+
+    return flatteningGroupsBuilder.build();
+  }
+
+  private static Iterable<Schema> getRequiredFields(
+      DiagCollector diagCollector,
+      com.google.api.codegen.discovery.Method method,
+      List<String> requiredFieldNames) {
+    ImmutableList.Builder<Schema> fieldsBuilder = ImmutableList.builder();
+    for (String fieldName : requiredFieldNames) {
+      Schema requiredField = method.parameters().get(fieldName);
+      if (requiredField == null) {
+        diagCollector.addDiag(
+            Diag.error(
+                SimpleLocation.TOPLEVEL,
+                "Required field '%s' not found (in method %s)",
+                fieldName,
+                method.id()));
+        return null;
+      }
+      fieldsBuilder.add(requiredField);
+    }
+    return fieldsBuilder.build();
+  }
+
+  private static Iterable<Schema> getOptionalFields(
+      com.google.api.codegen.discovery.Method method, List<String> requiredFieldNames) {
+    ImmutableList.Builder<Schema> fieldsBuilder = ImmutableList.builder();
+    for (Schema field : method.parameters().values()) {
+      if (requiredFieldNames.contains(field.getIdentifier())) {
+        continue;
+      }
+      fieldsBuilder.add(field);
+    }
+    return fieldsBuilder.build();
+  }
+
+  private static Iterable<FieldConfig> createFieldNameConfigs(Iterable<Schema> fields) {
+    ImmutableList.Builder<FieldConfig> fieldConfigsBuilder = ImmutableList.builder();
+    for (Schema field : fields) {
+      fieldConfigsBuilder.add(FieldConfig.createFieldConfig(field));
+    }
+    return fieldConfigsBuilder.build();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoInterfaceModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoInterfaceModel.java
@@ -1,0 +1,56 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
+
+/** Discovery-based InterfaceModel. */
+public class DiscoInterfaceModel implements InterfaceModel {
+  private final String interfaceName;
+
+  public DiscoInterfaceModel(String interfaceName) {
+    this.interfaceName = interfaceName;
+  }
+
+  @Override
+  public ApiSource getApiSource() {
+    return ApiSource.PROTO;
+  }
+
+  @Override
+  public String getSimpleName() {
+    return DiscoGapicNamer.getSimpleInterfaceName(interfaceName);
+  }
+
+  @Override
+  public String getFullName() {
+    return interfaceName;
+  }
+
+  @Override
+  public String getFileSimpleName() {
+    return interfaceName;
+  }
+
+  @Override
+  public String getFileFullName() {
+    return interfaceName;
+  }
+
+  @Override
+  public String getParentFullName() {
+    return interfaceName;
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/DiscoInterfaceModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoInterfaceModel.java
@@ -26,7 +26,7 @@ public class DiscoInterfaceModel implements InterfaceModel {
 
   @Override
   public ApiSource getApiSource() {
-    return ApiSource.PROTO;
+    return ApiSource.DISCOVERY;
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -107,7 +107,6 @@ public class DiscoveryField implements FieldModel {
 
   @Override
   public TypeName getParentTypeName(ImportTypeTable typeTable) {
-
     if (schema.parent() instanceof Schema) {
       DiscoveryField parent = new DiscoveryField((Schema) schema.parent());
       return typeTable.getTypeTable().getTypeName(typeTable.getFullNameFor(parent));

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -19,8 +19,10 @@ import static com.google.api.codegen.config.ApiSource.DISCOVERY;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.discovery.Schema.Format;
 import com.google.api.codegen.discovery.Schema.Type;
+import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.TypeName;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
 import com.google.common.base.Preconditions;
@@ -96,6 +98,21 @@ public class DiscoveryField implements FieldModel {
   @Override
   public String getParentFullName() {
     return schema.parent().id();
+  }
+
+  @Override
+  public String getParentSimpleName() {
+    return schema.parent().id();
+  }
+
+  @Override
+  public TypeName getParentTypeName(ImportTypeTable typeTable) {
+
+    if (schema.parent() instanceof Schema) {
+      DiscoveryField parent = new DiscoveryField((Schema) schema.parent());
+      return typeTable.getTypeTable().getTypeName(typeTable.getFullNameFor(parent));
+    }
+    return typeTable.getTypeTable().getTypeName(typeTable.getFullNameFor(this));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -20,6 +20,7 @@ import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.discovery.Schema.Format;
 import com.google.api.codegen.discovery.Schema.Type;
 import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.Name;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
 import com.google.common.base.Preconditions;
@@ -55,6 +56,11 @@ public class DiscoveryField implements FieldType {
   @Override
   public String getFullName() {
     return schema.getIdentifier();
+  }
+
+  @Override
+  public Name asName() {
+    return Name.anyCamel(getSimpleName());
   }
 
   @Override
@@ -127,7 +133,7 @@ public class DiscoveryField implements FieldType {
   @Override
   /* @Get the description of the element scoped to the visibility as currently set in the model. */
   public String getScopedDocumentation() {
-    return "Not yet implemented.";
+    return schema.description();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -28,10 +28,10 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /** Created by andrealin on 7/31/17. */
-public class DiscoveryField implements FieldType {
+public class DiscoveryField implements FieldModel {
   private final Schema schema;
 
-  /* Create a FieldType object from a non-null Schema object. */
+  /* Create a FieldModel object from a non-null Schema object. */
   public DiscoveryField(Schema schema) {
     Preconditions.checkNotNull(schema);
     this.schema = schema;
@@ -74,12 +74,12 @@ public class DiscoveryField implements FieldType {
   }
 
   @Override
-  public FieldType getMapKeyField() {
+  public FieldModel getMapKeyField() {
     throw new IllegalArgumentException("Discovery model types have no map keys.");
   }
 
   @Override
-  public FieldType getMapValueField() {
+  public FieldModel getMapValueField() {
     throw new IllegalArgumentException("Discovery model types have no map values.");
   }
 
@@ -115,7 +115,7 @@ public class DiscoveryField implements FieldType {
 
   @Override
   public String toString() {
-    return String.format("Discovery FieldType (%s): {%s}", getApiSource(), schema.toString());
+    return String.format("Discovery FieldModel (%s): {%s}", getApiSource(), schema.toString());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.config;
 
 import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.api.codegen.discovery.Method;
+import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.SchemaTypeFormatter;
 import com.google.api.codegen.transformer.SchemaTypeNameConverter;
@@ -49,7 +50,11 @@ public final class DiscoveryMethodModel implements MethodModel {
 
   @Override
   public FieldType lookupInputField(String fieldName) {
-    return new DiscoveryField(method.parameters().get(fieldName));
+    Schema targetSchema = method.parameters().get(fieldName);
+    if (targetSchema == null) {
+      return null;
+    }
+    return new DiscoveryField(targetSchema);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -49,7 +49,7 @@ public final class DiscoveryMethodModel implements MethodModel {
   }
 
   @Override
-  public FieldType lookupInputField(String fieldName) {
+  public FieldType getInputField(String fieldName) {
     Schema targetSchema = method.parameters().get(fieldName);
     if (targetSchema == null) {
       return null;
@@ -58,7 +58,7 @@ public final class DiscoveryMethodModel implements MethodModel {
   }
 
   @Override
-  public FieldType lookupOutputField(String fieldName) {
+  public FieldType getOutputField(String fieldName) {
     return null;
   }
 

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -27,7 +27,7 @@ import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.TypeName;
 import com.google.common.base.Preconditions;
 
-/** Created by andrealin on 8/1/17. */
+/** A wrapper around the model of a Discovery Method. */
 public final class DiscoveryMethodModel implements MethodModel {
   private final Method method;
 
@@ -82,11 +82,6 @@ public final class DiscoveryMethodModel implements MethodModel {
   @Override
   public String getInputTypeNickname(TypeFormatter typeFormatter) {
     return null;
-  }
-
-  @Override
-  public String getOutputTypeNickname(ImportTypeTable typeTable) {
-    return ((SchemaTypeTable) typeTable).getNicknameFor(method.response());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -18,11 +18,8 @@ import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.api.codegen.discovery.Method;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.SchemaTypeFormatter;
-import com.google.api.codegen.transformer.SchemaTypeNameConverter;
 import com.google.api.codegen.transformer.SchemaTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.codegen.transformer.TypeFormatter;
 import com.google.api.codegen.transformer.TypeNameConverter;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.TypeName;
@@ -79,19 +76,11 @@ public final class DiscoveryMethodModel implements MethodModel {
   }
 
   @Override
-  public String getOutputTypeFullName(TypeFormatter typeFormatter) {
+  public TypeName getOutputTypeName(ImportTypeTable typeTable) {
     // Maybe use Discogapic namer for this?
-    return ((SchemaTypeFormatter) typeFormatter).getFullNameFor(method.response());
-  }
-
-  @Override
-  public String getInputTypeNickname(TypeFormatter typeFormatter) {
-    return null;
-  }
-
-  @Override
-  public String getOutputTypeFullName(ImportTypeTable typeTable) {
-    return ((SchemaTypeTable) typeTable).getFullNameFor(method.response());
+    return typeTable
+        .getTypeTable()
+        .getTypeName(((SchemaTypeTable) typeTable).getFullNameFor(method.response()));
   }
 
   @Override
@@ -100,13 +89,10 @@ public final class DiscoveryMethodModel implements MethodModel {
   }
 
   @Override
-  public String getInputTypeFullName(ImportTypeTable typeTable) {
-    return ((SchemaTypeTable) typeTable).getFullNameFor(method.request());
-  }
-
-  @Override
-  public TypeName getOutputTypeName(TypeNameConverter typeFormatter) {
-    return ((SchemaTypeNameConverter) typeFormatter).getTypeName(method.response());
+  public TypeName getInputTypeName(ImportTypeTable typeTable) {
+    return typeTable
+        .getTypeTable()
+        .getTypeName(((SchemaTypeTable) typeTable).getFullNameFor(method.request()));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -46,7 +46,7 @@ public final class DiscoveryMethodModel implements MethodModel {
   }
 
   @Override
-  public FieldType getInputField(String fieldName) {
+  public FieldModel getInputField(String fieldName) {
     Schema targetSchema = method.parameters().get(fieldName);
     if (targetSchema == null) {
       return null;
@@ -55,7 +55,7 @@ public final class DiscoveryMethodModel implements MethodModel {
   }
 
   @Override
-  public FieldType getOutputField(String fieldName) {
+  public FieldModel getOutputField(String fieldName) {
     return null;
   }
 

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -1,0 +1,186 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
+import com.google.api.codegen.discovery.Method;
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.SchemaTypeFormatter;
+import com.google.api.codegen.transformer.SchemaTypeNameConverter;
+import com.google.api.codegen.transformer.SchemaTypeTable;
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.transformer.TypeFormatter;
+import com.google.api.codegen.transformer.TypeNameConverter;
+import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.TypeName;
+import com.google.common.base.Preconditions;
+
+/** Created by andrealin on 8/1/17. */
+public final class DiscoveryMethodModel implements MethodModel {
+  private final Method method;
+
+  /* Create a DiscoveryMethodModel from a non-null Discovery Method object. */
+  public DiscoveryMethodModel(Method method) {
+    Preconditions.checkNotNull(method);
+    this.method = method;
+  }
+
+  @Override
+  public String getOutputTypeSimpleName() {
+    return method.response() == null ? "none" : method.response().id();
+  }
+
+  @Override
+  public ApiSource getApiSource() {
+    return ApiSource.DISCOVERY;
+  }
+
+  @Override
+  public FieldType lookupInputField(String fieldName) {
+    return new DiscoveryField(method.parameters().get(fieldName));
+  }
+
+  @Override
+  public FieldType lookupOutputField(String fieldName) {
+    return null;
+  }
+
+  @Override
+  public String getFullName() {
+    return method.id();
+  }
+
+  @Override
+  public String getInputFullName() {
+    // TODO(andrealin): this could be wrong; it might require the discogapic namer
+    return method.request().getIdentifier();
+  }
+
+  @Override
+  public String getDescription() {
+    return method.description();
+  }
+
+  @Override
+  public String getOutputTypeFullName(TypeFormatter typeFormatter) {
+    // Maybe use Discogapic namer for this?
+    return ((SchemaTypeFormatter) typeFormatter).getFullNameFor(method.response());
+  }
+
+  @Override
+  public String getInputTypeNickname(TypeFormatter typeFormatter) {
+    return null;
+  }
+
+  @Override
+  public String getOutputTypeNickname(ImportTypeTable typeTable) {
+    return ((SchemaTypeTable) typeTable).getNicknameFor(method.response());
+  }
+
+  @Override
+  public String getOutputTypeFullName(ImportTypeTable typeTable) {
+    return ((SchemaTypeTable) typeTable).getFullNameFor(method.response());
+  }
+
+  @Override
+  public String getOutputFullName() {
+    return method.response() == null ? "none" : method.response().getIdentifier();
+  }
+
+  @Override
+  public String getInputTypeFullName(ImportTypeTable typeTable) {
+    return ((SchemaTypeTable) typeTable).getFullNameFor(method.request());
+  }
+
+  @Override
+  public TypeName getOutputTypeName(TypeNameConverter typeFormatter) {
+    return ((SchemaTypeNameConverter) typeFormatter).getTypeName(method.response());
+  }
+
+  @Override
+  public GenericFieldSelector getInputFieldSelector(String fieldName) {
+    // TODO(andrealin): implement.
+    return null;
+  }
+
+  @Override
+  public boolean getRequestStreaming() {
+    return false;
+  }
+
+  @Override
+  public boolean getResponseStreaming() {
+    return false;
+  }
+
+  @Override
+  public Name asName() {
+    return DiscoGapicNamer.methodAsName(method);
+  }
+
+  @Override
+  public boolean isOutputTypeEmpty() {
+    return method.response() == null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o != null
+        && o instanceof DiscoveryMethodModel
+        && ((DiscoveryMethodModel) o).method.equals(method);
+  }
+
+  @Override
+  public String getSimpleName() {
+    return DiscoGapicNamer.methodAsName(method).toLowerCamel();
+  }
+
+  @Override
+  public String getParentSimpleName() {
+    return "getParentSimpleName() not implemented.";
+  }
+
+  @Override
+  public String getParentNickname(TypeNameConverter typeNameConverter) {
+    return null;
+  }
+
+  @Override
+  public String getAndSaveRequestTypeName(ImportTypeTable typeTable, SurfaceNamer surfaceNamer) {
+    return typeTable.getAndSaveNicknameFor(
+        surfaceNamer.publicClassName(DiscoGapicNamer.getRequestName(method)));
+  }
+
+  @Override
+  public String getAndSaveResponseTypeName(ImportTypeTable typeTable, SurfaceNamer surfaceNamer) {
+    return typeTable.getAndSaveNicknameFor(
+        surfaceNamer.publicClassName((DiscoGapicNamer.getResponseName(method))));
+  }
+
+  @Override
+  public String getProtoMethodName() {
+    return getSimpleName();
+  }
+
+  @Override
+  public String getScopedDescription() {
+    return method.description();
+  }
+
+  @Override
+  public boolean hasReturnValue() {
+    return method.response() != null;
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/FieldConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FieldConfig.java
@@ -74,7 +74,7 @@ public abstract class FieldConfig {
         field, resourceNameTreatment, resourceNameConfig, messageResourceNameConfig);
   }
 
-  public static FieldConfig createFieldConfig(Schema field) {
+  static FieldConfig createFieldConfig(Schema field) {
     return new AutoValue_FieldConfig(
         new DiscoveryField(field), ResourceNameTreatment.NONE, null, null);
   }
@@ -85,7 +85,7 @@ public abstract class FieldConfig {
         new ProtoField(field), ResourceNameTreatment.NONE, null, null);
   }
 
-  public static FieldConfig createMessageFieldConfig(
+  static FieldConfig createMessageFieldConfig(
       ResourceNameMessageConfigs messageConfigs,
       Map<String, ResourceNameConfig> resourceNameConfigs,
       FieldType field,
@@ -96,21 +96,6 @@ public abstract class FieldConfig {
         null,
         resourceNameConfigs,
         field,
-        ResourceNameTreatment.UNSET_TREATMENT,
-        defaultResourceNameTreatment);
-  }
-
-  public static FieldConfig createMessageFieldConfig(
-      ResourceNameMessageConfigs messageConfigs,
-      Map<String, ResourceNameConfig> resourceNameConfigs,
-      Field field,
-      ResourceNameTreatment defaultResourceNameTreatment) {
-    return createFieldConfig(
-        null,
-        messageConfigs,
-        null,
-        resourceNameConfigs,
-        new ProtoField(field),
         ResourceNameTreatment.UNSET_TREATMENT,
         defaultResourceNameTreatment);
   }

--- a/src/main/java/com/google/api/codegen/config/FieldConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FieldConfig.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 /** FieldConfig represents a configuration for a Field, derived from the GAPIC config. */
 @AutoValue
 public abstract class FieldConfig {
-  public abstract FieldType getField();
+  public abstract FieldModel getField();
 
   @Nullable
   public abstract ResourceNameTreatment getResourceNameTreatment();
@@ -57,7 +57,7 @@ public abstract class FieldConfig {
   }
 
   private static FieldConfig createFieldConfig(
-      FieldType field,
+      FieldModel field,
       ResourceNameTreatment resourceNameTreatment,
       ResourceNameConfig resourceNameConfig,
       ResourceNameConfig messageResourceNameConfig) {
@@ -88,7 +88,7 @@ public abstract class FieldConfig {
   static FieldConfig createMessageFieldConfig(
       ResourceNameMessageConfigs messageConfigs,
       Map<String, ResourceNameConfig> resourceNameConfigs,
-      FieldType field,
+      FieldModel field,
       ResourceNameTreatment defaultResourceNameTreatment) {
     return createFieldConfig(
         null,
@@ -106,7 +106,7 @@ public abstract class FieldConfig {
       ResourceNameMessageConfigs messageConfigs,
       Map<String, String> fieldNamePatterns,
       Map<String, ResourceNameConfig> resourceNameConfigs,
-      FieldType field,
+      FieldModel field,
       ResourceNameTreatment treatment,
       ResourceNameTreatment defaultResourceNameTreatment) {
     String messageFieldEntityName = null;
@@ -239,7 +239,7 @@ public abstract class FieldConfig {
    */
   public static void validate(
       ResourceNameMessageConfigs messageConfigs,
-      FieldType field,
+      FieldModel field,
       ResourceNameTreatment treatment,
       ResourceNameConfig resourceNameConfig) {
     if (field.getApiSource().equals(ApiSource.DISCOVERY)) {
@@ -272,19 +272,19 @@ public abstract class FieldConfig {
     }
   }
 
-  private static Function<FieldConfig, FieldType> selectFieldFunction() {
-    return new Function<FieldConfig, FieldType>() {
+  private static Function<FieldConfig, FieldModel> selectFieldFunction() {
+    return new Function<FieldConfig, FieldModel>() {
       @Override
-      public FieldType apply(FieldConfig fieldConfig) {
+      public FieldModel apply(FieldConfig fieldConfig) {
         return fieldConfig.getField();
       }
     };
   }
 
-  private static Function<Field, FieldType> createFieldTypeFunction() {
-    return new Function<Field, FieldType>() {
+  private static Function<Field, FieldModel> createFieldTypeFunction() {
+    return new Function<Field, FieldModel>() {
       @Override
-      public FieldType apply(Field field) {
+      public FieldModel apply(Field field) {
         return new ProtoField(field);
       }
     };
@@ -299,11 +299,11 @@ public abstract class FieldConfig {
     };
   }
 
-  public static Iterable<FieldType> toFieldTypeIterable(Iterable<FieldConfig> fieldConfigs) {
+  public static Iterable<FieldModel> toFieldTypeIterable(Iterable<FieldConfig> fieldConfigs) {
     return Iterables.transform(fieldConfigs, selectFieldFunction());
   }
 
-  public static Iterable<FieldType> toFieldTypeIterableFromField(Iterable<Field> fieldConfigs) {
+  public static Iterable<FieldModel> toFieldTypeIterableFromField(Iterable<Field> fieldConfigs) {
     return Iterables.transform(fieldConfigs, createFieldTypeFunction());
   }
 

--- a/src/main/java/com/google/api/codegen/config/FieldModel.java
+++ b/src/main/java/com/google/api/codegen/config/FieldModel.java
@@ -15,16 +15,18 @@
 package com.google.api.codegen.config;
 
 import com.google.api.codegen.discovery.Schema;
+import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.TypeName;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
 
 /**
  * Wrapper class around the protobuf Field class and the Discovery-doc Schema class.
  *
- * <p>Each instance of this class contains exactly one of {Field, Schema}. This class abstracts the
- * format (protobuf, discovery, etc) of the source from a resource type definition.
+ * <p>This class abstracts the format (protobuf, discovery, etc) of the source from a resource type
+ * definition.
  */
 public interface FieldModel {
 
@@ -62,6 +64,12 @@ public interface FieldModel {
 
   /* @return the full name of the parent. */
   String getParentFullName();
+
+  /* @return the simple name of the parent. */
+  String getParentSimpleName();
+
+  /* @return the parent of this model, if the parent is a FieldModel, else return this object. */
+  TypeName getParentTypeName(ImportTypeTable typeTable);
 
   /* @return the cardinality of the resource. */
   Cardinality getCardinality();

--- a/src/main/java/com/google/api/codegen/config/FieldModel.java
+++ b/src/main/java/com/google/api/codegen/config/FieldModel.java
@@ -26,9 +26,9 @@ import com.google.api.tools.framework.model.TypeRef.Cardinality;
  * <p>Each instance of this class contains exactly one of {Field, Schema}. This class abstracts the
  * format (protobuf, discovery, etc) of the source from a resource type definition.
  */
-public interface FieldType {
+public interface FieldModel {
 
-  /* @return the type of source that this FieldType is based on. */
+  /* @return the type of source that this FieldModel is based on. */
   ApiSource getApiSource();
 
   String getSimpleName();
@@ -43,10 +43,10 @@ public interface FieldType {
   boolean isMap();
 
   /* @return the resource type of the map key. */
-  FieldType getMapKeyField();
+  FieldModel getMapKeyField();
 
   /* @return the resource type of the map value. */
-  FieldType getMapValueField();
+  FieldModel getMapValueField();
 
   /* @return if the underlying resource is a proto Messsage. */
   boolean isMessage();

--- a/src/main/java/com/google/api/codegen/config/FieldType.java
+++ b/src/main/java/com/google/api/codegen/config/FieldType.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.config;
 
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.Name;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
 
@@ -33,6 +34,8 @@ public interface FieldType {
   String getSimpleName();
 
   String getFullName();
+
+  Name asName();
 
   String getTypeFullName();
 

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -48,7 +48,7 @@ public abstract class FlatteningConfig {
     ImmutableMap.Builder<String, FieldConfig> flattenedFieldConfigBuilder = ImmutableMap.builder();
     for (String parameter : flatteningGroup.getParametersList()) {
 
-      FieldType parameterField = method.lookupInputField(parameter);
+      FieldType parameterField = method.getInputField(parameter);
       if (parameterField == null) {
         diagCollector.addDiag(
             Diag.error(

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -19,8 +19,6 @@ import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
-import com.google.api.tools.framework.model.Field;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
@@ -38,26 +36,26 @@ public abstract class FlatteningConfig {
    * provided method.
    */
   @Nullable
-  public static FlatteningConfig createFlattening(
+  static FlatteningConfig createFlattening(
       DiagCollector diagCollector,
       ResourceNameMessageConfigs messageConfigs,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
       MethodConfigProto methodConfigProto,
       FlatteningGroupProto flatteningGroup,
-      Method method) {
+      MethodModel method) {
 
     boolean missing = false;
     ImmutableMap.Builder<String, FieldConfig> flattenedFieldConfigBuilder = ImmutableMap.builder();
     for (String parameter : flatteningGroup.getParametersList()) {
 
-      Field parameterField = method.getInputMessage().lookupField(parameter);
+      FieldType parameterField = method.lookupInputField(parameter);
       if (parameterField == null) {
         diagCollector.addDiag(
             Diag.error(
                 SimpleLocation.TOPLEVEL,
                 "Field missing for flattening: method = %s, message type = %s, field = %s",
                 method.getFullName(),
-                method.getInputMessage().getFullName(),
+                method.getInputFullName(),
                 parameter));
         return null;
       }
@@ -69,15 +67,22 @@ public abstract class FlatteningConfig {
         defaultResourceNameTreatment = ResourceNameTreatment.VALIDATE;
       }
 
-      FieldConfig fieldConfig =
-          FieldConfig.createFieldConfig(
-              diagCollector,
-              messageConfigs,
-              methodConfigProto.getFieldNamePatterns(),
-              resourceNameConfigs,
-              new ProtoField(parameterField),
-              flatteningGroup.getParameterResourceNameTreatment().get(parameter),
-              defaultResourceNameTreatment);
+      FieldConfig fieldConfig;
+      if (resourceNameConfigs != null) {
+        fieldConfig =
+            FieldConfig.createFieldConfig(
+                diagCollector,
+                messageConfigs,
+                methodConfigProto.getFieldNamePatterns(),
+                resourceNameConfigs,
+                parameterField,
+                flatteningGroup.getParameterResourceNameTreatment().get(parameter),
+                defaultResourceNameTreatment);
+      } else {
+        fieldConfig =
+            FieldConfig.createMessageFieldConfig(
+                null, null, parameterField, ResourceNameTreatment.NONE);
+      }
       if (fieldConfig == null) {
         missing = true;
       } else {

--- a/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FlatteningConfig.java
@@ -48,7 +48,7 @@ public abstract class FlatteningConfig {
     ImmutableMap.Builder<String, FieldConfig> flattenedFieldConfigBuilder = ImmutableMap.builder();
     for (String parameter : flatteningGroup.getParametersList()) {
 
-      FieldType parameterField = method.getInputField(parameter);
+      FieldModel parameterField = method.getInputField(parameter);
       if (parameterField == null) {
         diagCollector.addDiag(
             Diag.error(
@@ -97,7 +97,7 @@ public abstract class FlatteningConfig {
         flattenedFieldConfigBuilder.build(), flatteningGroup.getFlatteningGroupName());
   }
 
-  public Iterable<FieldType> getFlattenedFields() {
+  public Iterable<FieldModel> getFlattenedFields() {
     return FieldConfig.toFieldTypeIterable(getFlattenedFieldConfigs().values());
   }
 }

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -98,6 +98,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
     return getInterface().getSimpleName();
   }
 
+  @Override
   public boolean hasInterfaceNameOverride() {
     return getInterfaceNameOverride() != null;
   }
@@ -317,20 +318,21 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
 
   /** Returns the GapicMethodConfig for the given method. */
   @Override
-  public GapicMethodConfig getMethodConfig(Method method) {
-    GapicMethodConfig methodConfig = getMethodConfigMap().get(method.getSimpleName());
-    if (methodConfig == null) {
-      throw new IllegalArgumentException(
-          "no method config for method '" + method.getFullName() + "'");
-    }
-    return methodConfig;
+  public GapicMethodConfig getMethodConfig(MethodModel method) {
+    return getMethodConfig(method.getSimpleName(), method.getFullName());
   }
 
   /** Returns the GapicMethodConfig for the given method. */
-  @Override
-  @Nullable
-  public DiscoGapicMethodConfig getMethodConfig(com.google.api.codegen.discovery.Method method) {
-    return null;
+  public GapicMethodConfig getMethodConfig(Method method) {
+    return getMethodConfig(method.getSimpleName(), method.getFullName());
+  }
+
+  public GapicMethodConfig getMethodConfig(String methodSimpleName, String fullName) {
+    GapicMethodConfig methodConfig = getMethodConfigMap().get(methodSimpleName);
+    if (methodConfig == null) {
+      throw new IllegalArgumentException("no method config for method '" + fullName + "'");
+    }
+    return methodConfig;
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -57,7 +57,12 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
   private static final ImmutableSet<String> CONSTRUCTOR_PARAMS =
       ImmutableSet.<String>of(SERVICE_ADDRESS_PARAM, SCOPES_PARAM);
 
-  public abstract Interface getInterface();
+  public Interface getInterface() {
+    return getInterfaceModel().getInterface();
+  }
+
+  @Override
+  public abstract ProtoInterfaceModel getInterfaceModel();
 
   @Override
   public abstract List<GapicMethodConfig> getMethodConfigs();
@@ -74,7 +79,8 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
   @Override
   public abstract ImmutableMap<String, RetrySettings> getRetrySettingsDefinition();
 
-  public abstract ImmutableList<Field> getIamResources();
+  @Override
+  public abstract ImmutableList<FieldModel> getIamResources();
 
   @Override
   public abstract ImmutableList<String> getRequiredConstructorParams();
@@ -142,7 +148,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
     SmokeTestConfig smokeTestConfig =
         createSmokeTestConfig(diagCollector, apiInterface, interfaceConfigProto);
 
-    ImmutableList<Field> iamResources =
+    ImmutableList<FieldModel> iamResources =
         createIamResources(
             apiInterface.getModel(),
             interfaceConfigProto.getExperimentalFeatures().getIamResourcesList());
@@ -179,7 +185,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
       return null;
     } else {
       return new AutoValue_GapicInterfaceConfig(
-          apiInterface,
+          new ProtoInterfaceModel(apiInterface),
           methodConfigs,
           smokeTestConfig,
           methodConfigMap,
@@ -369,9 +375,9 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
   }
 
   /** Creates a list of fields that can be turned into IAM resources */
-  private static ImmutableList<Field> createIamResources(
+  private static ImmutableList<FieldModel> createIamResources(
       Model model, List<IamResourceProto> resources) {
-    ImmutableList.Builder<Field> fields = ImmutableList.builder();
+    ImmutableList.Builder<FieldModel> fields = ImmutableList.builder();
     for (IamResourceProto resource : resources) {
       TypeRef type = model.getSymbolTable().lookupType(resource.getType());
       if (type == null) {
@@ -386,7 +392,7 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
             String.format(
                 "type %s does not have field %s", resource.getType(), resource.getField()));
       }
-      fields.add(field);
+      fields.add(new ProtoField(field));
     }
     return fields.build();
   }

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -24,7 +24,6 @@ import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.codegen.SurfaceTreatmentProto;
 import com.google.api.codegen.VisibilityProto;
-import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
@@ -50,7 +49,9 @@ import org.joda.time.Duration;
  */
 @AutoValue
 public abstract class GapicMethodConfig extends MethodConfig {
-  public abstract Method getMethod();
+  public Method getMethod() {
+    return ((ProtoMethodModel) getMethodModel()).getProtoMethod();
+  }
 
   /**
    * Creates an instance of GapicMethodConfig based on MethodConfigProto, linking it up with the
@@ -58,7 +59,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
    * collector.
    */
   @Nullable
-  public static GapicMethodConfig createMethodConfig(
+  static GapicMethodConfig createMethodConfig(
       DiagCollector diagCollector,
       String language,
       MethodConfigProto methodConfigProto,
@@ -69,13 +70,14 @@ public abstract class GapicMethodConfig extends MethodConfig {
       ImmutableSet<String> retryParamsConfigNames) {
 
     boolean error = false;
+    ProtoMethodModel methodModel = new ProtoMethodModel(method);
 
     PageStreamingConfig pageStreaming = null;
     if (!PageStreamingConfigProto.getDefaultInstance()
         .equals(methodConfigProto.getPageStreaming())) {
       pageStreaming =
           PageStreamingConfig.createPageStreaming(
-              diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, method);
+              diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
       if (pageStreaming == null) {
         error = true;
       }
@@ -109,7 +111,8 @@ public abstract class GapicMethodConfig extends MethodConfig {
     BatchingConfig batching = null;
     if (!BatchingConfigProto.getDefaultInstance().equals(methodConfigProto.getBatching())) {
       batching =
-          BatchingConfig.createBatching(diagCollector, methodConfigProto.getBatching(), method);
+          BatchingConfig.createBatching(
+              diagCollector, methodConfigProto.getBatching(), new ProtoMethodModel(method));
       if (batching == null) {
         error = true;
       }
@@ -212,6 +215,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
       return null;
     } else {
       return new AutoValue_GapicMethodConfig(
+          methodModel,
           pageStreaming,
           grpcStreaming,
           flattening,
@@ -228,8 +232,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
           rerouteToGrpcInterface,
           visibility,
           releaseLevel,
-          longRunningConfig,
-          method);
+          longRunningConfig);
     }
   }
 
@@ -241,6 +244,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
       MethodConfigProto methodConfigProto,
       Method method) {
     boolean missing = false;
+    ProtoMethodModel methodModel = new ProtoMethodModel(method);
     ImmutableList.Builder<FlatteningConfig> flatteningGroupsBuilder = ImmutableList.builder();
     for (FlatteningGroupProto flatteningGroup : methodConfigProto.getFlattening().getGroupsList()) {
       FlatteningConfig groupConfig =
@@ -250,7 +254,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
               resourceNameConfigs,
               methodConfigProto,
               flatteningGroup,
-              method);
+              methodModel);
       if (groupConfig == null) {
         missing = true;
       } else {
@@ -318,7 +322,7 @@ public abstract class GapicMethodConfig extends MethodConfig {
   }
 
   /** Returns true if the method is a streaming method */
-  public static boolean isGrpcStreamingMethod(Method method) {
+  public static boolean isGrpcStreamingMethod(MethodModel method) {
     return method.getRequestStreaming() || method.getResponseStreaming();
   }
 
@@ -338,16 +342,6 @@ public abstract class GapicMethodConfig extends MethodConfig {
   @Override
   public boolean isGrpcStreaming() {
     return getGrpcStreaming() != null;
-  }
-
-  /** Returns the grpc streaming configuration of the method. */
-  @Override
-  public GrpcStreamingType getGrpcStreamingType() {
-    if (isGrpcStreaming()) {
-      return getGrpcStreaming().getType();
-    } else {
-      return GrpcStreamingType.NonStreaming;
-    }
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicMethodConfig.java
@@ -268,9 +268,9 @@ public abstract class GapicMethodConfig extends MethodConfig {
     return flatteningGroupsBuilder.build();
   }
 
-  private static Iterable<FieldType> getRequiredFields(
+  private static Iterable<FieldModel> getRequiredFields(
       DiagCollector diagCollector, Method method, List<String> requiredFieldNames) {
-    ImmutableList.Builder<FieldType> fieldsBuilder = ImmutableList.builder();
+    ImmutableList.Builder<FieldModel> fieldsBuilder = ImmutableList.builder();
     for (String fieldName : requiredFieldNames) {
       Field requiredField = method.getInputMessage().lookupField(fieldName);
       if (requiredField == null) {
@@ -287,9 +287,9 @@ public abstract class GapicMethodConfig extends MethodConfig {
     return fieldsBuilder.build();
   }
 
-  private static Iterable<FieldType> getOptionalFields(
+  private static Iterable<FieldModel> getOptionalFields(
       Method method, List<String> requiredFieldNames) {
-    ImmutableList.Builder<FieldType> fieldsBuilder = ImmutableList.builder();
+    ImmutableList.Builder<FieldModel> fieldsBuilder = ImmutableList.builder();
     for (Field field : method.getInputType().getMessageType().getFields()) {
       if (requiredFieldNames.contains(field.getSimpleName())) {
         continue;
@@ -305,9 +305,9 @@ public abstract class GapicMethodConfig extends MethodConfig {
       ResourceNameTreatment defaultResourceNameTreatment,
       ImmutableMap<String, String> fieldNamePatterns,
       ImmutableMap<String, ResourceNameConfig> resourceNameConfigs,
-      Iterable<FieldType> fields) {
+      Iterable<FieldModel> fields) {
     ImmutableList.Builder<FieldConfig> fieldConfigsBuilder = ImmutableList.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       fieldConfigsBuilder.add(
           FieldConfig.createFieldConfig(
               diagCollector,
@@ -360,12 +360,12 @@ public abstract class GapicMethodConfig extends MethodConfig {
   }
 
   @Override
-  public Iterable<FieldType> getRequiredFields() {
+  public Iterable<FieldModel> getRequiredFields() {
     return FieldConfig.toFieldTypeIterable(getRequiredFieldConfigs());
   }
 
   @Override
-  public Iterable<FieldType> getOptionalFields() {
+  public Iterable<FieldModel> getOptionalFields() {
     return FieldConfig.toFieldTypeIterable(getOptionalFieldConfigs());
   }
 

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -51,9 +51,10 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 public abstract class GapicProductConfig implements ProductConfig {
-  public abstract ImmutableMap<String, InterfaceConfig> getInterfaceConfigMap();
+  public abstract ImmutableMap<String, ? extends InterfaceConfig> getInterfaceConfigMap();
 
   /** Returns the package name. */
+  @Override
   public abstract String getPackageName();
 
   /** Returns the location of the domain layer, if any. */
@@ -177,7 +178,7 @@ public abstract class GapicProductConfig implements ProductConfig {
 
     ImmutableMap<String, InterfaceConfig> interfaceConfigMap =
         createDiscoGapicInterfaceConfigMap(
-            document, new BoundedDiagCollector(), configProto, settings);
+            document, new BoundedDiagCollector(), configProto, settings, resourceNameConfigs);
 
     ImmutableList<String> copyrightLines;
     ImmutableList<String> licenseLines;
@@ -279,7 +280,8 @@ public abstract class GapicProductConfig implements ProductConfig {
       Document document,
       DiagCollector diagCollector,
       ConfigProto configProto,
-      LanguageSettingsProto languageSettings) {
+      LanguageSettingsProto languageSettings,
+      ImmutableMap<String, ResourceNameConfig> resourceNameConfigs) {
     ImmutableMap.Builder<String, InterfaceConfig> interfaceConfigMap = ImmutableMap.builder();
     for (InterfaceConfigProto interfaceConfigProto : configProto.getInterfacesList()) {
       String interfaceNameOverride =
@@ -291,7 +293,8 @@ public abstract class GapicProductConfig implements ProductConfig {
               diagCollector,
               configProto.getLanguage(),
               interfaceConfigProto,
-              interfaceNameOverride);
+              interfaceNameOverride,
+              resourceNameConfigs);
       if (interfaceConfig == null) {
         continue;
       }

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -463,7 +463,7 @@ public abstract class GapicProductConfig implements ProductConfig {
     if (messageConfig == null) {
       return builder.build();
     }
-    for (FieldType field : messageConfig.getFieldsWithResourceNamesByMessage().values()) {
+    for (FieldModel field : messageConfig.getFieldsWithResourceNamesByMessage().values()) {
       builder.put(
           field.getFullName(),
           FieldConfig.createMessageFieldConfig(

--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -477,6 +477,12 @@ public abstract class GapicProductConfig implements ProductConfig {
     return (GapicInterfaceConfig) getInterfaceConfigMap().get(apiInterface.getFullName());
   }
 
+  /** Returns the GapicInterfaceConfig for the given API interface. */
+  @Override
+  public GapicInterfaceConfig getInterfaceConfig(InterfaceModel apiInterface) {
+    return (GapicInterfaceConfig) getInterfaceConfigMap().get(apiInterface.getFullName());
+  }
+
   /** Returns the GapicInterfaceConfig for the given API method. */
   public InterfaceConfig getInterfaceConfig(String fullName) {
     return getInterfaceConfigMap().get(fullName);

--- a/src/main/java/com/google/api/codegen/config/GenericFieldSelector.java
+++ b/src/main/java/com/google/api/codegen/config/GenericFieldSelector.java
@@ -17,10 +17,10 @@ package com.google.api.codegen.config;
 /** API source-agnostic interface for FieldSelectors. */
 public interface GenericFieldSelector {
 
-  /* @return the type of source that this FieldType is based on. */
+  /* @return the type of source that this FieldModel is based on. */
   ApiSource getApiSource();
 
   String getParamName();
 
-  FieldType getLastField();
+  FieldModel getLastField();
 }

--- a/src/main/java/com/google/api/codegen/config/GenericFieldSelector.java
+++ b/src/main/java/com/google/api/codegen/config/GenericFieldSelector.java
@@ -12,14 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.api.codegen.discogapic.transformer.java;
+package com.google.api.codegen.config;
 
-import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
-import com.google.api.codegen.util.java.JavaNameFormatter;
+/** API source-agnostic interface for FieldSelectors. */
+public interface GenericFieldSelector {
 
-class JavaDiscoGapicNamer extends DiscoGapicNamer {
+  /* @return the type of source that this FieldType is based on. */
+  ApiSource getApiSource();
 
-  public JavaDiscoGapicNamer() {
-    super(new JavaNameFormatter());
-  }
+  String getParamName();
+
+  FieldType getLastField();
 }

--- a/src/main/java/com/google/api/codegen/config/GrpcStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GrpcStreamingConfig.java
@@ -33,7 +33,7 @@ public class GrpcStreamingConfig {
     BidiStreaming
   }
 
-  private final Field resourcesField;
+  private final FieldType resourcesField;
   private final GrpcStreamingType type;
 
   /**
@@ -89,7 +89,7 @@ public class GrpcStreamingConfig {
   }
 
   private GrpcStreamingConfig(Field resourcesField, GrpcStreamingType type) {
-    this.resourcesField = resourcesField;
+    this.resourcesField = resourcesField == null ? null : new ProtoField(resourcesField);
     this.type = type;
   }
 
@@ -99,7 +99,7 @@ public class GrpcStreamingConfig {
   }
 
   /** Returns the field used in the response to hold the resource being returned. */
-  public Field getResourcesField() {
+  public FieldType getResourcesField() {
     return resourcesField;
   }
 

--- a/src/main/java/com/google/api/codegen/config/GrpcStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GrpcStreamingConfig.java
@@ -33,7 +33,7 @@ public class GrpcStreamingConfig {
     BidiStreaming
   }
 
-  private final FieldType resourcesField;
+  private final FieldModel resourcesField;
   private final GrpcStreamingType type;
 
   /**
@@ -99,7 +99,7 @@ public class GrpcStreamingConfig {
   }
 
   /** Returns the field used in the response to hold the resource being returned. */
-  public FieldType getResourcesField() {
+  public FieldModel getResourcesField() {
     return resourcesField;
   }
 

--- a/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
 public interface InterfaceConfig {
   String getName();
 
+  InterfaceModel getInterfaceModel();
+
   @Nullable
   SmokeTestConfig getSmokeTestConfig();
 
@@ -57,6 +59,8 @@ public interface InterfaceConfig {
   boolean hasGrpcStreamingMethods();
 
   boolean hasDefaultInstance();
+
+  ImmutableList<? extends FieldModel> getIamResources();
 
   ImmutableList<SingleResourceNameConfig> getSingleResourceNameConfigs();
 

--- a/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.config;
 
 import com.google.api.gax.core.RetrySettings;
-import com.google.api.tools.framework.model.Method;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -43,9 +42,7 @@ public interface InterfaceConfig {
 
   String getManualDoc();
 
-  MethodConfig getMethodConfig(Method method);
-
-  MethodConfig getMethodConfig(com.google.api.codegen.discovery.Method method);
+  MethodConfig getMethodConfig(MethodModel method);
 
   boolean hasPageStreamingMethods();
 
@@ -61,7 +58,6 @@ public interface InterfaceConfig {
 
   boolean hasDefaultInstance();
 
-  @Nullable
   ImmutableList<SingleResourceNameConfig> getSingleResourceNameConfigs();
 
   boolean hasInterfaceNameOverride();

--- a/src/main/java/com/google/api/codegen/config/InterfaceModel.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceModel.java
@@ -14,16 +14,18 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.common.collect.ImmutableList;
+/** API-source-agnostic wrapper classes for Interfaces. */
+public interface InterfaceModel {
+  /* @return the type of source that this FieldModel is based on. */
+  ApiSource getApiSource();
 
-/** ProductConfig represents client code-gen config for an API product in an input-agnostic way. */
-public interface ProductConfig {
+  String getSimpleName();
 
-  String getPackageName();
+  String getFullName();
 
-  ImmutableList<String> getCopyrightLines();
+  String getParentFullName();
 
-  ImmutableList<String> getLicenseLines();
+  String getFileSimpleName();
 
-  InterfaceConfig getInterfaceConfig(InterfaceModel interfaceModel);
+  String getFileFullName();
 }

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -156,6 +156,7 @@ public abstract class LongRunningConfig {
   }
 
   public String getLongRunningOperationReturnTypeName(ImportTypeTable typeTable) {
+    // TODO(andrealin): Support Discovery
     return ((ModelTypeTable) typeTable).getAndSaveNicknameFor(getReturnType());
   }
 

--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -15,6 +15,8 @@
 package com.google.api.codegen.config;
 
 import com.google.api.codegen.LongRunningConfigProto;
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Model;
@@ -151,5 +153,17 @@ public abstract class LongRunningConfig {
           maxPollDelay,
           totalPollTimeout);
     }
+  }
+
+  public String getLongRunningOperationReturnTypeName(ImportTypeTable typeTable) {
+    return ((ModelTypeTable) typeTable).getAndSaveNicknameFor(getReturnType());
+  }
+
+  public String getLongRunningOperationReturnTypeFullName(ImportTypeTable typeTable) {
+    return ((ModelTypeTable) typeTable).getFullNameFor(getReturnType());
+  }
+
+  public String getLongRunningOperationMetadataTypeFullName(ImportTypeTable typeTable) {
+    return ((ModelTypeTable) typeTable).getFullNameFor(getMetadataType());
   }
 }

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -17,12 +17,8 @@ package com.google.api.codegen.config;
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
-import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.tools.framework.model.Diag;
-import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Method;
-import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
@@ -36,6 +32,8 @@ import org.joda.time.Duration;
  * <p>Subclasses should have a field to contain the method for which this a config.
  */
 public abstract class MethodConfig {
+  // TODO(andrealin): Consider combining this with MethodModel.
+  public abstract MethodModel getMethodModel();
 
   @Nullable
   public abstract PageStreamingConfig getPageStreaming();
@@ -76,47 +74,6 @@ public abstract class MethodConfig {
 
   @Nullable
   public abstract LongRunningConfig getLongRunningConfig();
-
-  static Iterable<Schema> getRequiredFields(
-      DiagCollector diagCollector,
-      com.google.api.codegen.discovery.Method method,
-      List<String> requiredFieldNames) {
-    ImmutableList.Builder<Schema> fieldsBuilder = ImmutableList.builder();
-    for (String fieldName : requiredFieldNames) {
-      Schema requiredField = method.parameters().get(fieldName);
-      if (requiredField == null) {
-        diagCollector.addDiag(
-            Diag.error(
-                SimpleLocation.TOPLEVEL,
-                "Required field '%s' not found (in method %s)",
-                fieldName,
-                method.id()));
-        return null;
-      }
-      fieldsBuilder.add(requiredField);
-    }
-    return fieldsBuilder.build();
-  }
-
-  static Iterable<Schema> getOptionalFields(
-      com.google.api.codegen.discovery.Method method, List<String> requiredFieldNames) {
-    ImmutableList.Builder<Schema> fieldsBuilder = ImmutableList.builder();
-    for (Schema field : method.parameters().values()) {
-      if (requiredFieldNames.contains(field.getIdentifier())) {
-        continue;
-      }
-      fieldsBuilder.add(field);
-    }
-    return fieldsBuilder.build();
-  }
-
-  static Iterable<FieldConfig> createFieldNameConfigs(Iterable<Schema> fields) {
-    ImmutableList.Builder<FieldConfig> fieldConfigsBuilder = ImmutableList.builder();
-    for (Schema field : fields) {
-      fieldConfigsBuilder.add(FieldConfig.createFieldConfig(field));
-    }
-    return fieldConfigsBuilder.build();
-  }
 
   /** Returns true if the method is a streaming method */
   public static boolean isGrpcStreamingMethod(Method method) {

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -113,11 +113,11 @@ public abstract class MethodConfig {
     return getLongRunningConfig() != null;
   }
 
-  public Iterable<FieldType> getRequiredFields() {
+  public Iterable<FieldModel> getRequiredFields() {
     return FieldConfig.toFieldTypeIterable(getRequiredFieldConfigs());
   }
 
-  public Iterable<FieldType> getOptionalFields() {
+  public Iterable<FieldModel> getOptionalFields() {
     return FieldConfig.toFieldTypeIterable(getOptionalFieldConfigs());
   }
 

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -16,7 +16,6 @@ package com.google.api.codegen.config;
 
 import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.codegen.transformer.TypeFormatter;
 import com.google.api.codegen.transformer.TypeNameConverter;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.TypeName;
@@ -54,24 +53,16 @@ public interface MethodModel {
   /* @return the description of this method. */
   String getDescription();
 
-  /* @return the formatted full name of the output type. */
-  String getOutputTypeFullName(TypeFormatter typeFormatter);
+  /* @return theTypeName for the output type. Save it in the table. */
+  TypeName getOutputTypeName(ImportTypeTable typeTable);
 
-  /* @return the formatted full name of the output type. Save it in the table. */
-  String getOutputTypeFullName(ImportTypeTable typeTable);
-
-  /* @return the formatted nickname of the input type. */
-  String getInputTypeNickname(TypeFormatter typeFormatter);
-
-  /* @return the formatted full name of the input type. Save it in the table. */
-  String getInputTypeFullName(ImportTypeTable typeTable);
+  /* @return the TypeName for the input type. Save it in the table. */
+  TypeName getInputTypeName(ImportTypeTable typeTable);
 
   /* @return a short name for the output type. */
   String getOutputTypeSimpleName();
 
   String getScopedDescription();
-
-  TypeName getOutputTypeName(TypeNameConverter typeNameConverter);
 
   GenericFieldSelector getInputFieldSelector(String fieldName);
 

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -23,14 +23,14 @@ import com.google.api.codegen.util.TypeName;
 /** Input-agnostic model of a method. */
 public interface MethodModel {
 
-  /* @return the type of source that this FieldType is based on. */
+  /* @return the type of source that this FieldModel is based on. */
   ApiSource getApiSource();
 
   /* @return find a nested field in the method's input type by the nested field's name. */
-  FieldType getInputField(String fieldName);
+  FieldModel getInputField(String fieldName);
 
   /* @return find a nested field in the method's output type by the nested field's name. */
-  FieldType getOutputField(String fieldName);
+  FieldModel getOutputField(String fieldName);
 
   /* @return the full name of this method. */
   String getFullName();

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -1,0 +1,81 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.transformer.TypeFormatter;
+import com.google.api.codegen.transformer.TypeNameConverter;
+import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.TypeName;
+
+/** Input-agnostic model of a method. */
+public interface MethodModel {
+
+  /* @return the type of source that this FieldType is based on. */
+  ApiSource getApiSource();
+
+  FieldType lookupInputField(String fieldName);
+
+  FieldType lookupOutputField(String fieldName);
+
+  String getFullName();
+
+  String getInputFullName();
+
+  String getOutputFullName();
+
+  String getSimpleName();
+
+  String getParentSimpleName();
+
+  String getParentNickname(TypeNameConverter typeNameConverter);
+
+  String getDescription();
+
+  String getOutputTypeFullName(TypeFormatter typeFormatter);
+
+  String getOutputTypeFullName(ImportTypeTable typeTable);
+
+  String getOutputTypeNickname(ImportTypeTable typeTable);
+
+  String getInputTypeNickname(TypeFormatter typeFormatter);
+
+  String getInputTypeFullName(ImportTypeTable typeTable);
+
+  String getOutputTypeSimpleName();
+
+  String getScopedDescription();
+
+  TypeName getOutputTypeName(TypeNameConverter typeNameConverter);
+
+  GenericFieldSelector getInputFieldSelector(String fieldName);
+
+  boolean getRequestStreaming();
+
+  boolean getResponseStreaming();
+
+  String getAndSaveRequestTypeName(ImportTypeTable typeTable, SurfaceNamer surfaceNamer);
+
+  String getAndSaveResponseTypeName(ImportTypeTable typeTable, SurfaceNamer surfaceNamer);
+
+  Name asName();
+
+  boolean isOutputTypeEmpty();
+
+  boolean hasReturnValue();
+
+  String getProtoMethodName();
+}

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -27,34 +27,46 @@ public interface MethodModel {
   /* @return the type of source that this FieldType is based on. */
   ApiSource getApiSource();
 
+  /* @return find a nested field in the method's input type by the nested field's name. */
   FieldType lookupInputField(String fieldName);
 
+  /* @return find a nested field in the method's output type by the nested field's name. */
   FieldType lookupOutputField(String fieldName);
 
+  /* @return the full name of this method. */
   String getFullName();
 
+  /* @return the full name of the method's input. */
   String getInputFullName();
 
+  /* @return the full name of the method's output. */
   String getOutputFullName();
 
+  /* @return a short name for this method. */
   String getSimpleName();
 
+  /* @return a short name for the parent. */
   String getParentSimpleName();
 
+  /* @return the nickname for the parent. */
   String getParentNickname(TypeNameConverter typeNameConverter);
 
+  /* @return the description of this method. */
   String getDescription();
 
+  /* @return the formatted full name of the output type. */
   String getOutputTypeFullName(TypeFormatter typeFormatter);
 
+  /* @return the formatted full name of the output type. Save it in the table. */
   String getOutputTypeFullName(ImportTypeTable typeTable);
 
-  String getOutputTypeNickname(ImportTypeTable typeTable);
-
+  /* @return the formatted nickname of the input type. */
   String getInputTypeNickname(TypeFormatter typeFormatter);
 
+  /* @return the formatted full name of the input type. Save it in the table. */
   String getInputTypeFullName(ImportTypeTable typeTable);
 
+  /* @return a short name for the output type. */
   String getOutputTypeSimpleName();
 
   String getScopedDescription();

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -28,10 +28,10 @@ public interface MethodModel {
   ApiSource getApiSource();
 
   /* @return find a nested field in the method's input type by the nested field's name. */
-  FieldType lookupInputField(String fieldName);
+  FieldType getInputField(String fieldName);
 
   /* @return find a nested field in the method's output type by the nested field's name. */
-  FieldType lookupOutputField(String fieldName);
+  FieldType getOutputField(String fieldName);
 
   /* @return the full name of this method. */
   String getFullName();

--- a/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
@@ -29,12 +29,12 @@ import javax.annotation.Nullable;
 /** PageStreamingConfig represents the page streaming configuration for a method. */
 @AutoValue
 public abstract class PageStreamingConfig {
-  public abstract FieldType getRequestTokenField();
+  public abstract FieldModel getRequestTokenField();
 
   @Nullable
-  public abstract FieldType getPageSizeField();
+  public abstract FieldModel getPageSizeField();
 
-  public abstract FieldType getResponseTokenField();
+  public abstract FieldModel getResponseTokenField();
 
   public abstract FieldConfig getResourcesFieldConfig();
 
@@ -52,7 +52,7 @@ public abstract class PageStreamingConfig {
       MethodModel method) {
     PageStreamingConfigProto pageStreaming = methodConfigProto.getPageStreaming();
     String requestTokenFieldName = pageStreaming.getRequest().getTokenField();
-    FieldType requestTokenField = method.getInputField(requestTokenFieldName);
+    FieldModel requestTokenField = method.getInputField(requestTokenFieldName);
     if (requestTokenField == null) {
       diagCollector.addDiag(
           Diag.error(
@@ -64,7 +64,7 @@ public abstract class PageStreamingConfig {
     }
 
     String pageSizeFieldName = pageStreaming.getRequest().getPageSizeField();
-    FieldType pageSizeField = null;
+    FieldModel pageSizeField = null;
     if (!Strings.isNullOrEmpty(pageSizeFieldName)) {
       pageSizeField = method.getInputField(pageSizeFieldName);
       if (pageSizeField == null) {
@@ -79,7 +79,7 @@ public abstract class PageStreamingConfig {
     }
 
     String responseTokenFieldName = pageStreaming.getResponse().getTokenField();
-    FieldType responseTokenField = method.getOutputField(responseTokenFieldName);
+    FieldModel responseTokenField = method.getOutputField(responseTokenFieldName);
     if (responseTokenField == null) {
       diagCollector.addDiag(
           Diag.error(
@@ -91,7 +91,7 @@ public abstract class PageStreamingConfig {
     }
 
     String resourcesFieldName = pageStreaming.getResponse().getResourcesField();
-    FieldType resourcesField = method.getOutputField(resourcesFieldName);
+    FieldModel resourcesField = method.getOutputField(resourcesFieldName);
     FieldConfig resourcesFieldConfig;
 
     if (resourcesField == null) {
@@ -208,7 +208,7 @@ public abstract class PageStreamingConfig {
     return getPageSizeField() != null;
   }
 
-  public FieldType getResourcesField() {
+  public FieldModel getResourcesField() {
     return getResourcesFieldConfig().getField();
   }
 

--- a/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
@@ -20,7 +20,6 @@ import com.google.api.codegen.discovery.Document;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
@@ -53,7 +52,7 @@ public abstract class PageStreamingConfig {
       MethodModel method) {
     PageStreamingConfigProto pageStreaming = methodConfigProto.getPageStreaming();
     String requestTokenFieldName = pageStreaming.getRequest().getTokenField();
-    FieldType requestTokenField = method.lookupInputField(requestTokenFieldName);
+    FieldType requestTokenField = method.getInputField(requestTokenFieldName);
     if (requestTokenField == null) {
       diagCollector.addDiag(
           Diag.error(
@@ -67,7 +66,7 @@ public abstract class PageStreamingConfig {
     String pageSizeFieldName = pageStreaming.getRequest().getPageSizeField();
     FieldType pageSizeField = null;
     if (!Strings.isNullOrEmpty(pageSizeFieldName)) {
-      pageSizeField = method.lookupInputField(pageSizeFieldName);
+      pageSizeField = method.getInputField(pageSizeFieldName);
       if (pageSizeField == null) {
         diagCollector.addDiag(
             Diag.error(
@@ -80,7 +79,7 @@ public abstract class PageStreamingConfig {
     }
 
     String responseTokenFieldName = pageStreaming.getResponse().getTokenField();
-    FieldType responseTokenField = method.lookupOutputField(responseTokenFieldName);
+    FieldType responseTokenField = method.getOutputField(responseTokenFieldName);
     if (responseTokenField == null) {
       diagCollector.addDiag(
           Diag.error(
@@ -92,7 +91,7 @@ public abstract class PageStreamingConfig {
     }
 
     String resourcesFieldName = pageStreaming.getResponse().getResourcesField();
-    FieldType resourcesField = method.lookupOutputField(resourcesFieldName);
+    FieldType resourcesField = method.getOutputField(resourcesFieldName);
     FieldConfig resourcesFieldConfig;
 
     if (resourcesField == null) {

--- a/src/main/java/com/google/api/codegen/config/ProductServiceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ProductServiceConfig.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.config;
 import com.google.api.Authentication;
 import com.google.api.AuthenticationRule;
 import com.google.api.Service;
+import com.google.api.codegen.discovery.Document;
 import com.google.api.tools.framework.model.Model;
 import java.util.ArrayList;
 import java.util.List;
@@ -59,5 +60,10 @@ public class ProductServiceConfig {
       }
     }
     return new ArrayList<>(result);
+  }
+
+  /** Return a list of scopes for authentication. */
+  public List<String> getAuthScopes(Document document) {
+    return document.authScopes();
   }
 }

--- a/src/main/java/com/google/api/codegen/config/ProtoField.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoField.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /** Created by andrealin on 7/31/17. */
-public class ProtoField implements FieldType {
+public class ProtoField implements FieldModel {
   private final Field protoField;
 
   @Override
@@ -40,7 +40,7 @@ public class ProtoField implements FieldType {
     return PROTO;
   }
 
-  /* Create a FieldType object from a non-null Field object. */
+  /* Create a FieldModel object from a non-null Field object. */
   public ProtoField(Field protoField) {
     Preconditions.checkNotNull(protoField);
     this.protoField = protoField;
@@ -113,7 +113,7 @@ public class ProtoField implements FieldType {
 
   @Override
   public String toString() {
-    return String.format("Protobuf FieldType (%s): {%s}", getApiSource(), protoField.toString());
+    return String.format("Protobuf FieldModel (%s): {%s}", getApiSource(), protoField.toString());
   }
 
   @Override
@@ -139,9 +139,9 @@ public class ProtoField implements FieldType {
   }
 
   public static Iterable<Iterable<String>> getOneofFieldsNames(
-      Iterable<FieldType> fields, SurfaceNamer namer) {
+      Iterable<FieldModel> fields, SurfaceNamer namer) {
     ImmutableSet.Builder<Oneof> oneOfsBuilder = ImmutableSet.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       Oneof oneof = ((ProtoField) field).protoField.getOneof();
       if (oneof == null) {
         continue;

--- a/src/main/java/com/google/api/codegen/config/ProtoField.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoField.java
@@ -20,6 +20,7 @@ import static com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYP
 
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.Name;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Oneof;
@@ -53,6 +54,11 @@ public class ProtoField implements FieldType {
   @Override
   public String getFullName() {
     return protoField.getFullName();
+  }
+
+  @Override
+  public Name asName() {
+    return Name.from(protoField.getSimpleName());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ProtoField.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoField.java
@@ -19,10 +19,14 @@ import static com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYP
 import static com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING;
 
 import com.google.api.codegen.discovery.Schema;
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.TypeName;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.model.Field;
+import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.Oneof;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
@@ -94,6 +98,20 @@ public class ProtoField implements FieldModel {
   @Override
   public String getParentFullName() {
     return protoField.getParent().getFullName();
+  }
+
+  @Override
+  public String getParentSimpleName() {
+    return protoField.getParent().getSimpleName();
+  }
+
+  @Override
+  public TypeName getParentTypeName(ImportTypeTable typeTable) {
+    return typeTable
+        .getTypeTable()
+        .getTypeName(
+            ((ModelTypeTable) typeTable)
+                .getFullNameFor(TypeRef.of((MessageType) protoField.getParent())));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ProtoFieldSelector.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoFieldSelector.java
@@ -27,7 +27,7 @@ public final class ProtoFieldSelector implements GenericFieldSelector {
   }
 
   @Override
-  /* @return the type of source that this FieldType is based on. */
+  /* @return the type of source that this FieldModel is based on. */
   public ApiSource getApiSource() {
     return ApiSource.PROTO;
   }
@@ -38,7 +38,7 @@ public final class ProtoFieldSelector implements GenericFieldSelector {
   }
 
   @Override
-  public FieldType getLastField() {
+  public FieldModel getLastField() {
     return new ProtoField(fieldSelector.getLastField());
   }
 }

--- a/src/main/java/com/google/api/codegen/config/ProtoFieldSelector.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoFieldSelector.java
@@ -1,0 +1,44 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.tools.framework.model.FieldSelector;
+import com.google.common.base.Preconditions;
+
+/** Proto-based wrapper around FieldSelector. */
+public final class ProtoFieldSelector implements GenericFieldSelector {
+  private final FieldSelector fieldSelector;
+
+  public ProtoFieldSelector(FieldSelector fieldSelector) {
+    Preconditions.checkNotNull(fieldSelector);
+    this.fieldSelector = fieldSelector;
+  }
+
+  @Override
+  /* @return the type of source that this FieldType is based on. */
+  public ApiSource getApiSource() {
+    return ApiSource.PROTO;
+  }
+
+  @Override
+  public String getParamName() {
+    return fieldSelector.getParamName();
+  }
+
+  @Override
+  public FieldType getLastField() {
+    return new ProtoField(fieldSelector.getLastField());
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/ProtoInterfaceModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoInterfaceModel.java
@@ -1,0 +1,67 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.tools.framework.model.Interface;
+
+/** Protobuf-based InterfaceModel. */
+public class ProtoInterfaceModel implements InterfaceModel {
+  private final Interface protoInterface;
+
+  public ProtoInterfaceModel(Interface protoInterface) {
+    this.protoInterface = protoInterface;
+  }
+
+  public Interface getInterface() {
+    return protoInterface;
+  }
+
+  @Override
+  public ApiSource getApiSource() {
+    return ApiSource.PROTO;
+  }
+
+  @Override
+  public String getSimpleName() {
+    return protoInterface.getSimpleName();
+  }
+
+  @Override
+  public String getFullName() {
+    return protoInterface.getFullName();
+  }
+
+  @Override
+  public String getParentFullName() {
+    return protoInterface.getParent().getFullName();
+  }
+
+  @Override
+  public String getFileSimpleName() {
+    return protoInterface.getFile().getSimpleName();
+  }
+
+  @Override
+  public String getFileFullName() {
+    return protoInterface.getFile().getFullName();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o != null
+        && o instanceof ProtoInterfaceModel
+        && ((ProtoInterfaceModel) o).protoInterface.equals(this.protoInterface);
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -29,7 +29,7 @@ import com.google.api.tools.framework.model.FieldSelector;
 import com.google.api.tools.framework.model.Method;
 import com.google.common.base.Preconditions;
 
-/** Created by andrealin on 8/1/17. */
+/** A wrapper around the model of a protobuf-defined Method. */
 public final class ProtoMethodModel implements MethodModel {
   private final Method method;
 
@@ -118,11 +118,6 @@ public final class ProtoMethodModel implements MethodModel {
   @Override
   public String getParentNickname(TypeNameConverter converter) {
     return ((ModelTypeNameConverter) converter).getTypeName(method.getParent()).getNickname();
-  }
-
-  @Override
-  public String getOutputTypeNickname(ImportTypeTable typeTable) {
-    return ((ModelTypeTable) typeTable).getAndSaveNicknameFor(method.getOutputType());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -43,12 +43,12 @@ public final class ProtoMethodModel implements MethodModel {
   }
 
   @Override
-  public FieldType getInputField(String fieldName) {
+  public FieldModel getInputField(String fieldName) {
     return new ProtoField(method.getInputType().getMessageType().lookupField(fieldName));
   }
 
   @Override
-  public FieldType getOutputField(String fieldName) {
+  public FieldModel getOutputField(String fieldName) {
     return new ProtoField(method.getOutputType().getMessageType().lookupField(fieldName));
   }
 

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -16,11 +16,9 @@ package com.google.api.codegen.config;
 
 import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.ModelTypeFormatter;
 import com.google.api.codegen.transformer.ModelTypeNameConverter;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.codegen.transformer.TypeFormatter;
 import com.google.api.codegen.transformer.TypeNameConverter;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.TypeName;
@@ -70,13 +68,17 @@ public final class ProtoMethodModel implements MethodModel {
   }
 
   @Override
-  public String getInputTypeFullName(ImportTypeTable typeTable) {
-    return ((ModelTypeTable) typeTable).getFullNameFor(method.getInputType());
+  public TypeName getInputTypeName(ImportTypeTable typeTable) {
+    return typeTable
+        .getTypeTable()
+        .getTypeName(((ModelTypeTable) typeTable).getFullNameFor(method.getInputType()));
   }
 
   @Override
-  public String getOutputTypeFullName(ImportTypeTable typeTable) {
-    return ((ModelTypeTable) typeTable).getFullNameFor(method.getOutputType());
+  public TypeName getOutputTypeName(ImportTypeTable typeTable) {
+    return typeTable
+        .getTypeTable()
+        .getTypeName(((ModelTypeTable) typeTable).getFullNameFor(method.getOutputType()));
   }
 
   @Override
@@ -87,21 +89,6 @@ public final class ProtoMethodModel implements MethodModel {
   @Override
   public String getDescription() {
     return DocumentationUtil.getDescription(method);
-  }
-
-  @Override
-  public String getOutputTypeFullName(TypeFormatter typeFormatter) {
-    return ((ModelTypeFormatter) typeFormatter).getFullNameFor(method.getOutputType());
-  }
-
-  @Override
-  public String getInputTypeNickname(TypeFormatter typeFormatter) {
-    return ((ModelTypeFormatter) typeFormatter).getNicknameFor(method.getInputType());
-  }
-
-  @Override
-  public TypeName getOutputTypeName(TypeNameConverter typeFormatter) {
-    return ((ModelTypeNameConverter) typeFormatter).getTypeName(method.getOutputType());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -45,12 +45,12 @@ public final class ProtoMethodModel implements MethodModel {
   }
 
   @Override
-  public FieldType lookupInputField(String fieldName) {
+  public FieldType getInputField(String fieldName) {
     return new ProtoField(method.getInputType().getMessageType().lookupField(fieldName));
   }
 
   @Override
-  public FieldType lookupOutputField(String fieldName) {
+  public FieldType getOutputField(String fieldName) {
     return new ProtoField(method.getOutputType().getMessageType().lookupField(fieldName));
   }
 

--- a/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoMethodModel.java
@@ -1,0 +1,190 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.config;
+
+import com.google.api.codegen.ServiceMessages;
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.ModelTypeFormatter;
+import com.google.api.codegen.transformer.ModelTypeNameConverter;
+import com.google.api.codegen.transformer.ModelTypeTable;
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.transformer.TypeFormatter;
+import com.google.api.codegen.transformer.TypeNameConverter;
+import com.google.api.codegen.util.Name;
+import com.google.api.codegen.util.TypeName;
+import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
+import com.google.api.tools.framework.model.FieldSelector;
+import com.google.api.tools.framework.model.Method;
+import com.google.common.base.Preconditions;
+
+/** Created by andrealin on 8/1/17. */
+public final class ProtoMethodModel implements MethodModel {
+  private final Method method;
+
+  /* Create a MethodModel object from a non-null Method object. */
+  public ProtoMethodModel(Method method) {
+    Preconditions.checkNotNull(method);
+    this.method = method;
+  }
+
+  @Override
+  public ApiSource getApiSource() {
+    return ApiSource.PROTO;
+  }
+
+  @Override
+  public FieldType lookupInputField(String fieldName) {
+    return new ProtoField(method.getInputType().getMessageType().lookupField(fieldName));
+  }
+
+  @Override
+  public FieldType lookupOutputField(String fieldName) {
+    return new ProtoField(method.getOutputType().getMessageType().lookupField(fieldName));
+  }
+
+  @Override
+  public String getFullName() {
+    return method.getFullName();
+  }
+
+  @Override
+  public String getInputFullName() {
+    return method.getInputType().getMessageType().getFullName();
+  }
+
+  @Override
+  public String getOutputFullName() {
+    return method.getOutputType().getMessageType().getFullName();
+  }
+
+  @Override
+  public String getInputTypeFullName(ImportTypeTable typeTable) {
+    return ((ModelTypeTable) typeTable).getFullNameFor(method.getInputType());
+  }
+
+  @Override
+  public String getOutputTypeFullName(ImportTypeTable typeTable) {
+    return ((ModelTypeTable) typeTable).getFullNameFor(method.getOutputType());
+  }
+
+  @Override
+  public String getParentSimpleName() {
+    return method.getParent().getSimpleName();
+  }
+
+  @Override
+  public String getDescription() {
+    return DocumentationUtil.getDescription(method);
+  }
+
+  @Override
+  public String getOutputTypeFullName(TypeFormatter typeFormatter) {
+    return ((ModelTypeFormatter) typeFormatter).getFullNameFor(method.getOutputType());
+  }
+
+  @Override
+  public String getInputTypeNickname(TypeFormatter typeFormatter) {
+    return ((ModelTypeFormatter) typeFormatter).getNicknameFor(method.getInputType());
+  }
+
+  @Override
+  public TypeName getOutputTypeName(TypeNameConverter typeFormatter) {
+    return ((ModelTypeNameConverter) typeFormatter).getTypeName(method.getOutputType());
+  }
+
+  @Override
+  public GenericFieldSelector getInputFieldSelector(String fieldName) {
+    return new ProtoFieldSelector(
+        FieldSelector.resolve(method.getInputType().getMessageType(), fieldName));
+  }
+
+  @Override
+  public boolean getRequestStreaming() {
+    return method.getRequestStreaming();
+  }
+
+  @Override
+  public String getParentNickname(TypeNameConverter converter) {
+    return ((ModelTypeNameConverter) converter).getTypeName(method.getParent()).getNickname();
+  }
+
+  @Override
+  public String getOutputTypeNickname(ImportTypeTable typeTable) {
+    return ((ModelTypeTable) typeTable).getAndSaveNicknameFor(method.getOutputType());
+  }
+
+  @Override
+  public String getOutputTypeSimpleName() {
+    return method.getOutputType().getMessageType().getSimpleName();
+  }
+
+  @Override
+  public boolean getResponseStreaming() {
+    return method.getResponseStreaming();
+  }
+
+  // TODO(andrealin): Eliminate all uses of this function.
+  @Deprecated
+  public Method getProtoMethod() {
+    return method;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return o != null
+        && o instanceof ProtoMethodModel
+        && ((ProtoMethodModel) o).method.equals(method);
+  }
+
+  @Override
+  public Name asName() {
+    return Name.upperCamel(method.getSimpleName());
+  }
+
+  @Override
+  public String getSimpleName() {
+    return method.getSimpleName();
+  }
+
+  @Override
+  public boolean isOutputTypeEmpty() {
+    return new ServiceMessages().isEmptyType(method.getOutputType());
+  }
+
+  @Override
+  public String getAndSaveRequestTypeName(ImportTypeTable typeTable, SurfaceNamer surfaceNamer) {
+    return ((ModelTypeTable) typeTable).getAndSaveNicknameFor(method.getInputType());
+  }
+
+  @Override
+  public String getAndSaveResponseTypeName(ImportTypeTable typeTable, SurfaceNamer surfaceNamer) {
+    return ((ModelTypeTable) typeTable).getAndSaveNicknameFor(method.getOutputType());
+  }
+
+  @Override
+  public String getProtoMethodName() {
+    return method.getSimpleName();
+  }
+
+  @Override
+  public String getScopedDescription() {
+    return DocumentationUtil.getScopedDescription(method);
+  }
+
+  @Override
+  public boolean hasReturnValue() {
+    return !(new ServiceMessages()).isEmptyType(method.getOutputType());
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameMessageConfigs.java
@@ -42,7 +42,7 @@ public abstract class ResourceNameMessageConfigs {
    * Get a map from fully qualified message names to Fields, where each field has a resource name
    * defined.
    */
-  public abstract ListMultimap<String, FieldType> getFieldsWithResourceNamesByMessage();
+  public abstract ListMultimap<String, FieldModel> getFieldsWithResourceNamesByMessage();
 
   @Nullable
   public static ResourceNameMessageConfigs createMessageResourceTypesConfig(
@@ -57,7 +57,7 @@ public abstract class ResourceNameMessageConfigs {
     }
     ImmutableMap<String, ResourceNameMessageConfig> messageResourceTypeConfigMap = builder.build();
 
-    ListMultimap<String, FieldType> fieldsByMessage = ArrayListMultimap.create();
+    ListMultimap<String, FieldModel> fieldsByMessage = ArrayListMultimap.create();
 
     Set<String> seenProtoFiles = new HashSet<>();
     for (ProtoFile protoFile : model.getFiles()) {
@@ -96,7 +96,7 @@ public abstract class ResourceNameMessageConfigs {
     }
     ImmutableMap<String, ResourceNameMessageConfig> messageResourceTypeConfigMap = builder.build();
 
-    ListMultimap<String, FieldType> fieldsByMessage = ArrayListMultimap.create();
+    ListMultimap<String, FieldModel> fieldsByMessage = ArrayListMultimap.create();
 
     // TODO(andrealin): implementation.
     for (Map.Entry<String, Schema> schemaEntry : document.schemas().entrySet()) {
@@ -109,7 +109,7 @@ public abstract class ResourceNameMessageConfigs {
     return getResourceTypeConfigMap().isEmpty();
   }
 
-  public boolean fieldHasResourceName(FieldType field) {
+  public boolean fieldHasResourceName(FieldModel field) {
     return fieldHasResourceName(field.getParentFullName(), field.getSimpleName());
   }
 
@@ -117,7 +117,7 @@ public abstract class ResourceNameMessageConfigs {
     return getResourceNameOrNullForField(messageFullName, fieldSimpleName) != null;
   }
 
-  public String getFieldResourceName(FieldType field) {
+  public String getFieldResourceName(FieldModel field) {
     return getFieldResourceName(field.getParentFullName(), field.getSimpleName());
   }
 

--- a/src/main/java/com/google/api/codegen/discogapic/MainDiscoGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discogapic/MainDiscoGapicProviderFactory.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.discogapic.transformer.DocumentToViewTransformer;
 import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicRequestToViewTransformer;
 import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicSchemaToViewTransformer;
+import com.google.api.codegen.discogapic.transformer.java.JavaDiscoGapicSurfaceTransformer;
 import com.google.api.codegen.discovery.Document;
 import com.google.api.codegen.gapic.CommonGapicCodePathMapper;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -55,8 +56,8 @@ public class MainDiscoGapicProviderFactory implements DiscoGapicProviderFactory 
         List<DocumentToViewTransformer> transformers =
             Arrays.asList(
                 new JavaDiscoGapicSchemaToViewTransformer(javaPathMapper, packageConfig),
-                new JavaDiscoGapicRequestToViewTransformer(javaPathMapper, packageConfig));
-        // TODO(andrealin): Implement and use the JavaDiscoGapicSurfaceTransformer.
+                new JavaDiscoGapicRequestToViewTransformer(javaPathMapper, packageConfig),
+                new JavaDiscoGapicSurfaceTransformer(javaPathMapper, packageConfig));
         DiscoGapicProvider provider =
             DiscoGapicProvider.newBuilder()
                 .setDocument(document)

--- a/src/main/java/com/google/api/codegen/discogapic/SchemaTransformationContext.java
+++ b/src/main/java/com/google/api/codegen/discogapic/SchemaTransformationContext.java
@@ -15,17 +15,14 @@
 package com.google.api.codegen.discogapic;
 
 import com.google.api.codegen.config.GapicProductConfig;
-import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.api.codegen.transformer.DiscoGapicInterfaceContext;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.SchemaTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.auto.value.AutoValue;
 import java.util.Comparator;
-import javax.annotation.Nullable;
-
 /**
  * The context for transforming a single top-level schema from Discovery Doc API into a top-level
  * view for client library generation.
@@ -33,7 +30,7 @@ import javax.annotation.Nullable;
  * <p>This context contains a reference to the parent Document context.
  */
 @AutoValue
-public abstract class SchemaInterfaceContext implements InterfaceContext {
+public abstract class SchemaTransformationContext implements TransformationContext {
   /**
    * Create a context for transforming a schema.
    *
@@ -41,9 +38,9 @@ public abstract class SchemaInterfaceContext implements InterfaceContext {
    * @param typeTable Manages the imports for the schema view.
    * @param docContext The context for the parent Document.
    */
-  public static SchemaInterfaceContext create(
+  public static SchemaTransformationContext create(
       String id, SchemaTypeTable typeTable, DiscoGapicInterfaceContext docContext) {
-    return new AutoValue_SchemaInterfaceContext(id, typeTable, docContext);
+    return new AutoValue_SchemaTransformationContext(id, typeTable, docContext);
   }
 
   public abstract String id();
@@ -72,17 +69,11 @@ public abstract class SchemaInterfaceContext implements InterfaceContext {
     return getSchemaTypeTable();
   }
 
-  public static Comparator<SchemaInterfaceContext> comparator =
-      new Comparator<SchemaInterfaceContext>() {
+  public static Comparator<SchemaTransformationContext> comparator =
+      new Comparator<SchemaTransformationContext>() {
         @Override
-        public int compare(SchemaInterfaceContext o1, SchemaInterfaceContext o2) {
+        public int compare(SchemaTransformationContext o1, SchemaTransformationContext o2) {
           return String.CASE_INSENSITIVE_ORDER.compare(o1.id(), o2.id());
         }
       };
-
-  @Nullable
-  @Override
-  public InterfaceConfig getInterfaceConfig() {
-    return null;
-  }
 }

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
@@ -78,19 +78,13 @@ public class DiscoGapicNamer {
     return pieces[pieces.length - 1];
   }
 
-  /**
-   * Returns the last substring after the input is split by periods. Ex: Input
-   * "compute.addresses.aggregatedList" returns "aggregatedList".
-   */
+  /** Get the request type name from a method. */
   public static Name getRequestName(Method method) {
     String[] pieces = method.id().split(regexDelimiter);
     return Name.anyCamel(pieces[pieces.length - 2], pieces[pieces.length - 1], "http", "request");
   }
 
-  /**
-   * Returns the last substring after the input is split by periods. Ex: Input
-   * "compute.addresses.aggregatedList" returns "aggregatedList".
-   */
+  /** Get the response type name from a method. */
   public static Name getResponseName(Method method) {
     String[] pieces = method.id().split(regexDelimiter);
     return Name.anyCamel(pieces[pieces.length - 2], pieces[pieces.length - 1], "http", "response");

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
@@ -73,7 +73,7 @@ public class DiscoGapicNamer {
     return result;
   }
 
-  public String getSimpleInterfaceName(String interfaceName) {
+  public static String getSimpleInterfaceName(String interfaceName) {
     String[] pieces = interfaceName.split(regexDelimiter);
     return pieces[pieces.length - 1];
   }

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
@@ -18,7 +18,7 @@ import com.google.api.codegen.discovery.Method;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
 
-/** Provides language-specific names for variables and classes. */
+/** Provides language-specific names for variables and classes of Discovery-Document models. */
 public class DiscoGapicNamer {
   private final SurfaceNamer languageNamer;
   private static final String regexDelimiter = "\\.";
@@ -49,7 +49,7 @@ public class DiscoGapicNamer {
     return languageNamer.publicMethodName(Name.anyCamel("get").join(name));
   }
 
-  /** Returns the resource getter method name for a resource field. */
+  /** Returns the resource setter method name for a resource field. */
   public String getResourceSetterName(String fieldName) {
     Name name;
     if (fieldName.contains("_")) {

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/DiscoGapicNamer.java
@@ -14,15 +14,28 @@
  */
 package com.google.api.codegen.discogapic.transformer;
 
+import com.google.api.codegen.discovery.Method;
+import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
-import com.google.api.codegen.util.NameFormatter;
-import com.google.api.codegen.util.NameFormatterDelegator;
 
 /** Provides language-specific names for variables and classes. */
-public class DiscoGapicNamer extends NameFormatterDelegator {
+public class DiscoGapicNamer {
+  private final SurfaceNamer languageNamer;
+  private static final String regexDelimiter = "\\.";
 
-  public DiscoGapicNamer(NameFormatter nameFormatter) {
-    super(nameFormatter);
+  /* Create a JavaSurfaceNamer for a Discovery-based API. */
+  public DiscoGapicNamer(SurfaceNamer parentNamer) {
+    this.languageNamer = parentNamer;
+  }
+
+  /* @return the underlying language surface namer. */
+  public SurfaceNamer getLanguageNamer() {
+    return languageNamer;
+  }
+
+  /** Returns the variable name for a field. */
+  public String getFieldVarName(String fieldName) {
+    return languageNamer.privateFieldName(Name.anyCamel(fieldName));
   }
 
   /** Returns the resource getter method name for a resource field. */
@@ -33,7 +46,7 @@ public class DiscoGapicNamer extends NameFormatterDelegator {
     } else {
       name = Name.anyCamel(fieldName);
     }
-    return publicMethodName(Name.anyCamel("get").join(name));
+    return languageNamer.publicMethodName(Name.anyCamel("get").join(name));
   }
 
   /** Returns the resource getter method name for a resource field. */
@@ -44,22 +57,44 @@ public class DiscoGapicNamer extends NameFormatterDelegator {
     } else {
       name = Name.anyCamel(fieldName);
     }
-    return publicMethodName(Name.anyCamel("set").join(name));
+    return languageNamer.publicMethodName(Name.anyCamel("set").join(name));
+  }
+
+  /**
+   * Formats the method as a Name. Methods are generally in the format
+   * "[api].[resource].[function]".
+   */
+  public static Name methodAsName(Method method) {
+    String[] pieces = method.id().split(regexDelimiter);
+    Name result = Name.anyCamel(pieces[1]);
+    for (int i = 2; i < pieces.length; i++) {
+      result = result.join(Name.anyCamel(pieces[i]));
+    }
+    return result;
+  }
+
+  public String getSimpleInterfaceName(String interfaceName) {
+    String[] pieces = interfaceName.split(regexDelimiter);
+    return pieces[pieces.length - 1];
   }
 
   /**
    * Returns the last substring after the input is split by periods. Ex: Input
    * "compute.addresses.aggregatedList" returns "aggregatedList".
    */
-  public String getRequestName(String fullMethodName) {
-    String[] pieces = fullMethodName.split("\\.");
-    if (pieces.length < 3) {
-      throw new IllegalArgumentException(
-          "Fully qualified method name must be in the form [api].[resource].[method]");
-    }
-    return privateFieldName(
-        Name.anyCamel(pieces[pieces.length - 2], pieces[pieces.length - 1], "http", "request"));
+  public static Name getRequestName(Method method) {
+    String[] pieces = method.id().split(regexDelimiter);
+    return Name.anyCamel(pieces[pieces.length - 2], pieces[pieces.length - 1], "http", "request");
   }
 
-  //TODO(andrealin): Naming methods for responses, service name.
+  /**
+   * Returns the last substring after the input is split by periods. Ex: Input
+   * "compute.addresses.aggregatedList" returns "aggregatedList".
+   */
+  public static Name getResponseName(Method method) {
+    String[] pieces = method.id().split(regexDelimiter);
+    return Name.anyCamel(pieces[pieces.length - 2], pieces[pieces.length - 1], "http", "response");
+  }
+
+  //TODO(andrealin): Naming methods for service name.
 }

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
@@ -15,31 +15,57 @@
 package com.google.api.codegen.discogapic.transformer.java;
 
 import com.google.api.codegen.ReleaseLevel;
+import com.google.api.codegen.TargetLanguage;
+import com.google.api.codegen.config.DiscoGapicInterfaceConfig;
+import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProductServiceConfig;
+import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.api.codegen.discogapic.transformer.DocumentToViewTransformer;
 import com.google.api.codegen.discovery.Document;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.ApiCallableTransformer;
+import com.google.api.codegen.transformer.BatchingTransformer;
 import com.google.api.codegen.transformer.DiscoGapicInterfaceContext;
+import com.google.api.codegen.transformer.DiscoGapicMethodContext;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
+import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
+import com.google.api.codegen.transformer.PageStreamingTransformer;
+import com.google.api.codegen.transformer.PathTemplateTransformer;
+import com.google.api.codegen.transformer.RetryDefinitionsTransformer;
 import com.google.api.codegen.transformer.SchemaTypeTable;
 import com.google.api.codegen.transformer.ServiceTransformer;
 import com.google.api.codegen.transformer.StandardImportSectionTransformer;
+import com.google.api.codegen.transformer.StaticLangApiMethodTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.transformer.java.JavaFeatureConfig;
 import com.google.api.codegen.transformer.java.JavaSchemaTypeNameConverter;
 import com.google.api.codegen.transformer.java.JavaSurfaceNamer;
 import com.google.api.codegen.util.java.JavaNameFormatter;
 import com.google.api.codegen.util.java.JavaTypeTable;
-import com.google.api.codegen.viewmodel.ApiCallableView;
-import com.google.api.codegen.viewmodel.FormatResourceFunctionView;
-import com.google.api.codegen.viewmodel.ParseResourceFunctionView;
-import com.google.api.codegen.viewmodel.PathTemplateView;
+import com.google.api.codegen.viewmodel.ApiCallSettingsView;
+import com.google.api.codegen.viewmodel.ApiMethodView;
+import com.google.api.codegen.viewmodel.ClientMethodType;
+import com.google.api.codegen.viewmodel.ImportSectionView;
+import com.google.api.codegen.viewmodel.PackageInfoView;
+import com.google.api.codegen.viewmodel.PagedResponseIterateMethodView;
 import com.google.api.codegen.viewmodel.ServiceDocView;
+import com.google.api.codegen.viewmodel.SettingsDocView;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
 import com.google.api.codegen.viewmodel.StaticLangApiView;
 import com.google.api.codegen.viewmodel.StaticLangFileView;
+import com.google.api.codegen.viewmodel.StaticLangPagedResponseView;
+import com.google.api.codegen.viewmodel.StaticLangPagedResponseWrappersView;
+import com.google.api.codegen.viewmodel.StaticLangSettingsView;
+import com.google.api.codegen.viewmodel.StaticLangStubInterfaceView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import java.io.File;
 import java.util.ArrayList;
@@ -51,17 +77,27 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
   private final GapicCodePathMapper pathMapper;
   private final PackageMetadataConfig packageMetadataConfig;
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();
+  private final PathTemplateTransformer pathTemplateTransformer = new PathTemplateTransformer();
+  private final ApiCallableTransformer apiCallableTransformer = new ApiCallableTransformer();
+  private final StaticLangApiMethodTransformer apiMethodTransformer =
+      new StaticLangApiMethodTransformer();
+  private final PageStreamingTransformer pageStreamingTransformer = new PageStreamingTransformer();
+  private final BatchingTransformer batchingTransformer = new BatchingTransformer();
   private final StandardImportSectionTransformer importSectionTransformer =
       new StandardImportSectionTransformer();
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(importSectionTransformer);
+  private final RetryDefinitionsTransformer retryDefinitionsTransformer =
+      new RetryDefinitionsTransformer();
+  private final ProductServiceConfig productServiceConfig = new ProductServiceConfig();
+
   private final JavaNameFormatter nameFormatter = new JavaNameFormatter();
-  private final ApiCallableTransformer apiCallableTransformer = new ApiCallableTransformer();
 
   // TODO(andrealin) Create the service, page streaming, batching, etc transformers.
 
-  private static final String XAPI_TEMPLATE_FILENAME = "java/main.snip";
-  private static final String XSETTINGS_TEMPLATE_FILENAME = "java/settings.snip";
+  private static final String API_TEMPLATE_FILENAME = "java/main.snip";
+  private static final String SETTINGS_TEMPLATE_FILENAME = "java/settings.snip";
+  private static final String STUB_INTERFACE_TEMPLATE_FILENAME = "java/stub_interface.snip";
   private static final String PACKAGE_INFO_TEMPLATE_FILENAME = "java/package-info.snip";
   private static final String PAGE_STREAMING_RESPONSE_TEMPLATE_FILENAME =
       "java/page_streaming_response.snip";
@@ -69,15 +105,15 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
   public JavaDiscoGapicSurfaceTransformer(
       GapicCodePathMapper pathMapper, PackageMetadataConfig packageMetadataConfig) {
     this.pathMapper = pathMapper;
-    // TODO use packageMetadataConfig
     this.packageMetadataConfig = packageMetadataConfig;
   }
 
   @Override
   public List<String> getTemplateFileNames() {
     return Arrays.asList(
-        XAPI_TEMPLATE_FILENAME,
-        XSETTINGS_TEMPLATE_FILENAME,
+        API_TEMPLATE_FILENAME,
+        SETTINGS_TEMPLATE_FILENAME,
+        STUB_INTERFACE_TEMPLATE_FILENAME,
         PACKAGE_INFO_TEMPLATE_FILENAME,
         PAGE_STREAMING_RESPONSE_TEMPLATE_FILENAME);
   }
@@ -85,31 +121,50 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
   @Override
   public List<ViewModel> transform(Document document, GapicProductConfig productConfig) {
     List<ViewModel> surfaceDocs = new ArrayList<>();
-
-    SurfaceNamer namer =
-        new JavaSurfaceNamer(productConfig.getPackageName(), productConfig.getPackageName());
+    JavaNameFormatter javaNameFormatter = new JavaNameFormatter();
+    String packageName = productConfig.getPackageName();
+    SurfaceNamer namer = new JavaSurfaceNamer(packageName, packageName, javaNameFormatter);
+    DiscoGapicNamer discoGapicNamer = new DiscoGapicNamer(namer);
 
     List<ServiceDocView> serviceDocs = new ArrayList<>();
-
     for (String interfaceName : productConfig.getInterfaceConfigMap().keySet()) {
+      boolean enableStringFormatFunctions = productConfig.getResourceNameMessageConfigs().isEmpty();
       DiscoGapicInterfaceContext context =
           DiscoGapicInterfaceContext.createWithInterface(
               document,
               interfaceName,
               productConfig,
               createTypeTable(productConfig.getPackageName()),
-              new JavaDiscoGapicNamer(),
-              namer,
-              JavaFeatureConfig.newBuilder().enableStringFormatFunctions(false).build());
+              discoGapicNamer,
+              JavaFeatureConfig.newBuilder()
+                  .enableStringFormatFunctions(enableStringFormatFunctions)
+                  .build());
       StaticLangFileView<StaticLangApiView> apiFile = generateApiFile(context);
+      surfaceDocs.add(apiFile);
 
       serviceDocs.add(apiFile.classView().doc());
 
-      surfaceDocs.add(apiFile);
-      // TODO(andrealin): Service doc.
-
-      // TODO(andrealin): Settings file.
+      context = context.withNewTypeTable();
+      StaticLangApiMethodView exampleApiMethod =
+          getExampleApiMethod(apiFile.classView().apiMethods());
+      StaticLangFileView<StaticLangSettingsView> settingsFile =
+          generateSettingsFile(context, exampleApiMethod);
+      surfaceDocs.add(settingsFile);
+      context = context.withNewTypeTable(namer.getStubPackageName());
+      StaticLangFileView<StaticLangStubInterfaceView> stubInterfaceFile =
+          generateStubInterfaceFile(context);
+      surfaceDocs.add(stubInterfaceFile);
     }
+
+    StaticLangPagedResponseWrappersView pagedResponseWrappers =
+        generatePagedResponseWrappers(
+            document, productConfig, packageMetadataConfig.releaseLevel(TargetLanguage.JAVA));
+    if (pagedResponseWrappers != null) {
+      surfaceDocs.add(pagedResponseWrappers);
+    }
+
+    PackageInfoView packageInfo = generatePackageInfo(document, productConfig, namer, serviceDocs);
+    surfaceDocs.add(packageInfo);
 
     return surfaceDocs;
   }
@@ -123,7 +178,7 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
   private StaticLangFileView generateApiFile(DiscoGapicInterfaceContext context) {
     StaticLangFileView.Builder apiFile = StaticLangFileView.newBuilder();
 
-    apiFile.templateFileName(XAPI_TEMPLATE_FILENAME);
+    apiFile.templateFileName(API_TEMPLATE_FILENAME);
 
     apiFile.classView(generateApiClass(context));
 
@@ -138,39 +193,527 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
   }
 
   private StaticLangApiView generateApiClass(DiscoGapicInterfaceContext context) {
+    SurfaceNamer namer = context.getNamer();
+    DiscoGapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
     addApiImports(context);
 
-    List<StaticLangApiMethodView> methods = new ArrayList<>();
+    List<StaticLangApiMethodView> methods = generateApiMethods(context);
 
     StaticLangApiView.Builder xapiClass = StaticLangApiView.newBuilder();
 
-    String name = context.getNamer().getApiWrapperClassName(context.getDocument());
-    xapiClass.releaseLevelAnnotation(context.getNamer().getReleaseAnnotation(ReleaseLevel.ALPHA));
+    ApiMethodView exampleApiMethod = getExampleApiMethod(methods);
+    xapiClass.doc(serviceTransformer.generateServiceDoc(context, exampleApiMethod));
+
+    String name = context.getNamer().getApiWrapperClassName(context.getInterfaceConfig());
+    xapiClass.releaseLevelAnnotation(
+        context
+            .getNamer()
+            .getReleaseAnnotation(packageMetadataConfig.releaseLevel(TargetLanguage.JAVA)));
     xapiClass.name(name);
-    xapiClass.settingsClassName(
-        context.getNamer().getApiSettingsClassName(context.getInterfaceConfig()));
-    xapiClass.apiCallableMembers(new ArrayList<ApiCallableView>());
-    xapiClass.pathTemplates(new ArrayList<PathTemplateView>());
-    xapiClass.formatResourceFunctions(new ArrayList<FormatResourceFunctionView>());
-    xapiClass.parseResourceFunctions(new ArrayList<ParseResourceFunctionView>());
+    xapiClass.settingsClassName(namer.getApiSettingsClassName(context.getInterfaceConfig()));
+    xapiClass.stubInterfaceName(namer.getApiStubInterfaceName(interfaceConfig));
+    xapiClass.stubInterfaceName(
+        getAndSaveNicknameForStubType(context, namer.getApiStubInterfaceName(interfaceConfig)));
+    xapiClass.apiCallableMembers(apiCallableTransformer.generateStaticLangApiCallables(context));
+    xapiClass.pathTemplates(pathTemplateTransformer.generatePathTemplates(context));
+    xapiClass.formatResourceFunctions(
+        pathTemplateTransformer.generateFormatResourceFunctions(context));
+    xapiClass.parseResourceFunctions(
+        pathTemplateTransformer.generateParseResourceFunctions(context));
     xapiClass.apiMethods(methods);
-    xapiClass.hasDefaultInstance(true);
+    xapiClass.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
     xapiClass.hasLongRunningOperations(false);
 
     return xapiClass.build();
   }
 
-  private void addApiImports(DiscoGapicInterfaceContext context) {
-    SchemaTypeTable typeTable = context.getSchemaTypeTable();
+  private StaticLangPagedResponseWrappersView generatePagedResponseWrappers(
+      Document model, GapicProductConfig productConfig, ReleaseLevel releaseLevel) {
+    String packageName = productConfig.getPackageName();
+
+    SurfaceNamer namer = new JavaSurfaceNamer(packageName, packageName, nameFormatter);
+    DiscoGapicNamer discoGapicNamer = new DiscoGapicNamer(namer);
+    SchemaTypeTable typeTable = createTypeTable(productConfig.getPackageName());
+
+    addPagedResponseWrapperImports(typeTable);
+
+    StaticLangPagedResponseWrappersView.Builder pagedResponseWrappers =
+        StaticLangPagedResponseWrappersView.newBuilder();
+
+    pagedResponseWrappers.releaseLevelAnnotation(namer.getReleaseAnnotation(releaseLevel));
+    pagedResponseWrappers.templateFileName(PAGE_STREAMING_RESPONSE_TEMPLATE_FILENAME);
+
+    String name = namer.getPagedResponseWrappersClassName();
+    pagedResponseWrappers.name(name);
+
+    List<StaticLangPagedResponseView> pagedResponseWrappersList = new ArrayList<>();
+    for (String interfaceName : productConfig.getInterfaceConfigMap().keySet()) {
+      DiscoGapicInterfaceContext context =
+          DiscoGapicInterfaceContext.createWithInterface(
+              model,
+              interfaceName,
+              productConfig,
+              typeTable,
+              discoGapicNamer,
+              JavaFeatureConfig.newBuilder()
+                  .enableStringFormatFunctions(
+                      productConfig.getResourceNameMessageConfigs().isEmpty())
+                  .build());
+      for (MethodModel method : context.getSupportedMethods()) {
+        if (context.getMethodConfig(method).isPageStreaming()) {
+          pagedResponseWrappersList.add(
+              generatePagedResponseWrapper(context.asRequestMethodContext(method), typeTable));
+        }
+      }
+    }
+
+    if (pagedResponseWrappersList.size() == 0) {
+      return null;
+    }
+
+    pagedResponseWrappers.pagedResponseWrapperList(pagedResponseWrappersList);
+
+    // must be done as the last step to catch all imports
+    ImportSectionView importSection =
+        importSectionTransformer.generateImportSection(typeTable.getImports());
+    pagedResponseWrappers.fileHeader(
+        fileHeaderTransformer.generateFileHeader(productConfig, importSection, namer));
+
+    String outputPath = pathMapper.getOutputPath(null, productConfig);
+    pagedResponseWrappers.outputPath(outputPath + File.separator + name + ".java");
+
+    return pagedResponseWrappers.build();
+  }
+
+  private StaticLangPagedResponseView generatePagedResponseWrapper(
+      MethodContext context, SchemaTypeTable typeTable) {
+    MethodModel method = context.getMethodModel();
+    FieldType resourceField = context.getMethodConfig().getPageStreaming().getResourcesField();
+
+    StaticLangPagedResponseView.Builder pagedResponseWrapper =
+        StaticLangPagedResponseView.newBuilder();
+
+    String pagedResponseTypeName =
+        context.getNamer().getPagedResponseTypeInnerName(method, typeTable, resourceField);
+    pagedResponseWrapper.pagedResponseTypeName(pagedResponseTypeName);
+    pagedResponseWrapper.pageTypeName(
+        context.getNamer().getPageTypeInnerName(method, typeTable, resourceField));
+    pagedResponseWrapper.fixedSizeCollectionTypeName(
+        context.getNamer().getFixedSizeCollectionTypeInnerName(method, typeTable, resourceField));
+    pagedResponseWrapper.requestTypeName(
+        typeTable.getAndSaveNicknameFor(
+            context
+                .getMethodModel()
+                .getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer())));
+    pagedResponseWrapper.responseTypeName(
+        context
+            .getMethodModel()
+            .getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer()));
+    pagedResponseWrapper.resourceTypeName(
+        typeTable.getAndSaveNicknameForElementType(resourceField));
+    pagedResponseWrapper.iterateMethods(getIterateMethods(context));
+
+    return pagedResponseWrapper.build();
+  }
+
+  private List<PagedResponseIterateMethodView> getIterateMethods(MethodContext context) {
+
+    SurfaceNamer namer = context.getNamer();
+
+    List<PagedResponseIterateMethodView> iterateMethods = new ArrayList<>();
+
+    FieldConfig resourceFieldConfig =
+        context.getMethodConfig().getPageStreaming().getResourcesFieldConfig();
+
+    if (context.getFeatureConfig().useResourceNameFormatOption(resourceFieldConfig)) {
+
+      String resourceTypeName =
+          namer.getAndSaveElementResourceTypeName(context.getTypeTable(), resourceFieldConfig);
+      String resourceTypeIterateMethodName =
+          namer.getPagedResponseIterateMethod(context.getFeatureConfig(), resourceFieldConfig);
+      String resourceTypeGetValuesMethodName =
+          namer.getPageGetValuesMethod(context.getFeatureConfig(), resourceFieldConfig);
+      String parseMethodName =
+          namer.getResourceTypeParseMethodName(context.getTypeTable(), resourceFieldConfig);
+
+      PagedResponseIterateMethodView.Builder iterateMethod =
+          PagedResponseIterateMethodView.newBuilder()
+              .overloadResourceTypeName(resourceTypeName)
+              .overloadResourceTypeParseFunctionName(parseMethodName)
+              .overloadResourceTypeIterateMethodName(resourceTypeIterateMethodName)
+              .overloadResourceTypeGetValuesMethodName(resourceTypeGetValuesMethodName)
+              .iterateMethodName(namer.getPagedResponseIterateMethod())
+              .getValuesMethodName(namer.getPageGetValuesMethod());
+
+      iterateMethods.add(iterateMethod.build());
+    }
+
+    return iterateMethods;
+  }
+
+  private StaticLangApiMethodView getExampleApiMethod(List<StaticLangApiMethodView> methods) {
+    StaticLangApiMethodView exampleApiMethod =
+        searchExampleMethod(methods, ClientMethodType.FlattenedMethod);
+    if (exampleApiMethod == null) {
+      exampleApiMethod = searchExampleMethod(methods, ClientMethodType.PagedFlattenedMethod);
+    }
+    if (exampleApiMethod == null) {
+      exampleApiMethod = searchExampleMethod(methods, ClientMethodType.RequestObjectMethod);
+    }
+    if (exampleApiMethod == null) {
+      exampleApiMethod =
+          searchExampleMethod(methods, ClientMethodType.AsyncOperationFlattenedMethod);
+    }
+    if (exampleApiMethod == null) {
+      throw new RuntimeException("Could not find method to use as an example method");
+    }
+    return exampleApiMethod;
+  }
+
+  private StaticLangApiMethodView searchExampleMethod(
+      List<StaticLangApiMethodView> methods, ClientMethodType methodType) {
+    for (StaticLangApiMethodView method : methods) {
+      if (method.type().equals(methodType)) {
+        return method;
+      }
+    }
+    return null;
+  }
+
+  private StaticLangFileView<StaticLangSettingsView> generateSettingsFile(
+      DiscoGapicInterfaceContext context, StaticLangApiMethodView exampleApiMethod) {
+    StaticLangFileView.Builder<StaticLangSettingsView> settingsFile =
+        StaticLangFileView.<StaticLangSettingsView>newBuilder();
+
+    settingsFile.classView(generateSettingsClass(context, exampleApiMethod));
+    settingsFile.templateFileName(SETTINGS_TEMPLATE_FILENAME);
+
+    String outputPath =
+        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+    String className = context.getNamer().getApiSettingsClassName(context.getInterfaceConfig());
+    settingsFile.outputPath(outputPath + File.separator + className + ".java");
+
+    // must be done as the last step to catch all imports
+    settingsFile.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+
+    return settingsFile.build();
+  }
+
+  private StaticLangSettingsView generateSettingsClass(
+      DiscoGapicInterfaceContext context, StaticLangApiMethodView exampleApiMethod) {
+    addSettingsImports(context);
+
+    SurfaceNamer namer = context.getNamer();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+
+    StaticLangSettingsView.Builder xsettingsClass = StaticLangSettingsView.newBuilder();
+    xsettingsClass.releaseLevelAnnotation(
+        context
+            .getNamer()
+            .getReleaseAnnotation(packageMetadataConfig.releaseLevel(TargetLanguage.JAVA)));
+    xsettingsClass.doc(generateSettingsDoc(context, exampleApiMethod));
+    String name = namer.getApiSettingsClassName(context.getInterfaceConfig());
+    xsettingsClass.name(name);
+
+    // TODO(andrealin): Service address.
+    xsettingsClass.serviceAddress("Service address.");
+    xsettingsClass.servicePort(productServiceConfig.getServicePort());
+    xsettingsClass.authScopes(productServiceConfig.getAuthScopes(context.getDocument()));
+
+    List<ApiCallSettingsView> apiCallSettings =
+        apiCallableTransformer.generateCallSettings(context);
+    xsettingsClass.callSettings(apiCallSettings);
+    xsettingsClass.pageStreamingDescriptors(
+        pageStreamingTransformer.generateDescriptorClasses(context));
+    xsettingsClass.pagedListResponseFactories(
+        pageStreamingTransformer.generateFactoryClasses(context));
+    xsettingsClass.batchingDescriptors(batchingTransformer.generateDescriptorClasses(context));
+    xsettingsClass.retryCodesDefinitions(
+        retryDefinitionsTransformer.generateRetryCodesDefinitions(context));
+    xsettingsClass.retryParamsDefinitions(
+        retryDefinitionsTransformer.generateRetryParamsDefinitions(context));
+
+    xsettingsClass.hasDefaultServiceAddress(interfaceConfig.hasDefaultServiceAddress());
+    xsettingsClass.hasDefaultServiceScopes(interfaceConfig.hasDefaultServiceScopes());
+    xsettingsClass.hasDefaultInstance(interfaceConfig.hasDefaultInstance());
+    xsettingsClass.packagePath(namer.getPackagePath());
+    xsettingsClass.stubInterfaceName(
+        getAndSaveNicknameForStubType(context, namer.getApiStubInterfaceName(interfaceConfig)));
+    xsettingsClass.grpcStubClassName(
+        getAndSaveNicknameForStubType(context, namer.getApiGrpcStubClassName(interfaceConfig)));
+
+    return xsettingsClass.build();
+  }
+
+  private StaticLangFileView<StaticLangStubInterfaceView> generateStubInterfaceFile(
+      DiscoGapicInterfaceContext context) {
+    StaticLangFileView.Builder<StaticLangStubInterfaceView> fileView =
+        StaticLangFileView.<StaticLangStubInterfaceView>newBuilder();
+
+    fileView.classView(generateStubInterface(context));
+    fileView.templateFileName(STUB_INTERFACE_TEMPLATE_FILENAME);
+
+    String outputPath =
+        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+    String className = context.getNamer().getApiStubInterfaceName(context.getInterfaceConfig());
+    fileView.outputPath(
+        outputPath + File.separator + "stub" + File.separator + className + ".java");
+
+    // must be done as the last step to catch all imports
+    fileView.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+
+    return fileView.build();
+  }
+
+  private StaticLangStubInterfaceView generateStubInterface(DiscoGapicInterfaceContext context) {
+    DiscoGapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
+
+    addStubInterfaceImports(context);
+
+    List<StaticLangApiMethodView> methods = generateApiMethods(context);
+
+    StaticLangStubInterfaceView.Builder stubInterface = StaticLangStubInterfaceView.newBuilder();
+
+    stubInterface.doc(serviceTransformer.generateServiceDoc(context, null));
+
+    String name = context.getNamer().getApiStubInterfaceName(context.getInterfaceConfig());
+    stubInterface.releaseLevelAnnotation(
+        context
+            .getNamer()
+            .getReleaseAnnotation(packageMetadataConfig.releaseLevel(TargetLanguage.JAVA)));
+    stubInterface.name(name);
+    stubInterface.callableMethods(filterIncludeCallableMethods(methods));
+    stubInterface.hasLongRunningOperations(interfaceConfig.hasLongRunningOperations());
+
+    return stubInterface.build();
+  }
+
+  private String getAndSaveNicknameForStubType(InterfaceContext context, String nickname) {
+    SurfaceNamer namer = context.getNamer();
+    ImportTypeTable typeTable = context.getImportTypeTable();
+
+    String fullyQualifiedTypeName = namer.getStubPackageName() + "." + nickname;
+    return typeTable.getAndSaveNicknameFor(fullyQualifiedTypeName);
+  }
+
+  private List<StaticLangApiMethodView> filterIncludeCallableMethods(
+      List<StaticLangApiMethodView> inMethods) {
+    List<StaticLangApiMethodView> outMethods = new ArrayList<>();
+
+    for (StaticLangApiMethodView methodView : inMethods) {
+      switch (methodView.type()) {
+        case PagedCallableMethod:
+        case UnpagedListCallableMethod:
+        case CallableMethod:
+        case OperationCallableMethod:
+          outMethods.add(methodView);
+        default:
+          // don't include
+      }
+    }
+
+    return outMethods;
+  }
+
+  private PackageInfoView generatePackageInfo(
+      Document model,
+      GapicProductConfig productConfig,
+      SurfaceNamer namer,
+      List<ServiceDocView> serviceDocs) {
+    PackageInfoView.Builder packageInfo = PackageInfoView.newBuilder();
+
+    packageInfo.templateFileName(PACKAGE_INFO_TEMPLATE_FILENAME);
+
+    // TODO(andrealin): Service title.
+    packageInfo.serviceTitle("Service title.");
+    packageInfo.serviceDocs(serviceDocs);
+    packageInfo.domainLayerLocation(productConfig.getDomainLayerLocation());
+    packageInfo.authScopes(productServiceConfig.getAuthScopes(model));
+
+    packageInfo.fileHeader(
+        fileHeaderTransformer.generateFileHeader(
+            productConfig, ImportSectionView.newBuilder().build(), namer));
+
+    String outputPath = pathMapper.getOutputPath(null, productConfig);
+    packageInfo.outputPath(outputPath + "/package-info.java");
+
+    return packageInfo.build();
+  }
+
+  private void addApiImports(InterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
     // TODO several of these can be deleted (e.g. DiscoGapic doesn't use grpc)
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
-    typeTable.saveNicknameFor("com.google.auth.Credentials");
-    typeTable.saveNicknameFor("io.grpc.ManagedChannel");
+    typeTable.saveNicknameFor("com.google.api.gax.core.BackgroundResource");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallable");
+    typeTable.saveNicknameFor("com.google.api.pathtemplate.PathTemplate");
+    typeTable.saveNicknameFor("java.util.concurrent.TimeUnit");
     typeTable.saveNicknameFor("java.io.Closeable");
     typeTable.saveNicknameFor("java.io.IOException");
     typeTable.saveNicknameFor("java.util.ArrayList");
     typeTable.saveNicknameFor("java.util.List");
     typeTable.saveNicknameFor("java.util.concurrent.ScheduledExecutorService");
     typeTable.saveNicknameFor("javax.annotation.Generated");
+  }
+
+  private void addSettingsImports(InterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
+    typeTable.saveNicknameFor("com.google.api.core.ApiFunction");
+    typeTable.saveNicknameFor("com.google.api.core.BetaApi");
+    typeTable.saveNicknameFor("com.google.api.gax.core.CredentialsProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.core.ExecutorProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.core.GoogleCredentialsProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.core.InstantiatingExecutorProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.core.PropertiesProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.ChannelProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcStatusCode");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcTransport");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcTransportProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.InstantiatingChannelProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.retrying.RetrySettings");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientContext");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientSettings");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.StatusCode");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.SimpleCallSettings");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.TransportProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallSettings");
+    typeTable.saveNicknameFor("com.google.auth.Credentials");
+    typeTable.saveNicknameFor("com.google.common.collect.ImmutableList");
+    typeTable.saveNicknameFor("com.google.common.collect.ImmutableMap");
+    typeTable.saveNicknameFor("com.google.common.collect.ImmutableSet");
+    typeTable.saveNicknameFor("com.google.common.collect.Lists");
+    typeTable.saveNicknameFor("com.google.common.collect.Sets");
+    typeTable.saveNicknameFor("io.grpc.ManagedChannel");
+    typeTable.saveNicknameFor("io.grpc.Status");
+    typeTable.saveNicknameFor("java.io.IOException");
+    typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("java.util.concurrent.ScheduledExecutorService");
+    typeTable.saveNicknameFor("javax.annotation.Generated");
+    typeTable.saveNicknameFor("org.threeten.bp.Duration");
+
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    if (interfaceConfig.hasPageStreamingMethods()) {
+      typeTable.saveNicknameFor("com.google.api.core.ApiFuture");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiCallContext");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.PageContext");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.PagedCallSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.PagedListDescriptor");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.PagedListResponseFactory");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallable");
+    }
+    if (interfaceConfig.hasBatchingMethods()) {
+      typeTable.saveNicknameFor("com.google.api.gax.batching.BatchingSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.FlowController");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.FlowController.LimitExceededBehavior");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.FlowControlSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.PartitionKey");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.RequestBuilder");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.BatchedRequestIssuer");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.BatchingCallSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.BatchingDescriptor");
+      typeTable.saveNicknameFor("java.util.ArrayList");
+      typeTable.saveNicknameFor("java.util.Collection");
+    }
+    if (interfaceConfig.hasGrpcStreamingMethods()) {
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.StreamingCallSettings");
+    }
+    if (interfaceConfig.hasLongRunningOperations()) {
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.OperationCallSettings");
+      typeTable.saveNicknameFor("com.google.longrunning.Operation");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.OperationTimedPollAlgorithm");
+    }
+  }
+
+  private void addStubInterfaceImports(DiscoGapicInterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
+
+    typeTable.saveNicknameFor("com.google.api.core.BetaApi");
+    typeTable.saveNicknameFor("com.google.api.gax.core.BackgroundResource");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallable");
+    typeTable.saveNicknameFor("javax.annotation.Generated");
+
+    DiscoGapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    if (interfaceConfig.hasLongRunningOperations()) {
+      typeTable.saveNicknameFor("com.google.longrunning.Operation");
+      typeTable.saveNicknameFor("com.google.longrunning.stub.OperationsStub");
+    }
+  }
+
+  private void addPagedResponseWrapperImports(ImportTypeTable typeTable) {
+    typeTable.saveNicknameFor("com.google.api.core.ApiFunction");
+    typeTable.saveNicknameFor("com.google.api.core.ApiFuture");
+    typeTable.saveNicknameFor("com.google.api.core.ApiFutures");
+    typeTable.saveNicknameFor("com.google.api.core.BetaApi");
+    typeTable.saveNicknameFor("com.google.api.gax.paging.AbstractPage");
+    typeTable.saveNicknameFor("com.google.api.gax.paging.AbstractPagedListResponse");
+    typeTable.saveNicknameFor("com.google.api.gax.paging.AbstractFixedSizeCollection");
+    typeTable.saveNicknameFor("com.google.api.gax.paging.FixedSizeCollection");
+    typeTable.saveNicknameFor("com.google.api.gax.paging.Page");
+    typeTable.saveNicknameFor("com.google.api.gax.paging.PagedListResponse");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiExceptions");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.PageContext");
+    typeTable.saveNicknameFor("com.google.common.base.Function");
+    typeTable.saveNicknameFor("com.google.common.collect.Iterables");
+    typeTable.saveNicknameFor("javax.annotation.Generated");
+    typeTable.saveNicknameFor("java.util.Iterator");
+    typeTable.saveNicknameFor("java.util.List");
+  }
+
+  public SettingsDocView generateSettingsDoc(
+      DiscoGapicInterfaceContext context, StaticLangApiMethodView exampleApiMethod) {
+    SurfaceNamer namer = context.getNamer();
+    SettingsDocView.Builder settingsDoc = SettingsDocView.newBuilder();
+    ProductServiceConfig productServiceConfig = new ProductServiceConfig();
+
+    // TODO(andrealin): Service address.
+    settingsDoc.serviceAddress("Service address.");
+    settingsDoc.servicePort(productServiceConfig.getServicePort());
+    settingsDoc.exampleApiMethodName(exampleApiMethod.name());
+    settingsDoc.exampleApiMethodSettingsGetter(exampleApiMethod.settingsGetterName());
+    settingsDoc.apiClassName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
+    settingsDoc.settingsVarName(namer.getApiSettingsVariableName(context.getInterfaceConfig()));
+    settingsDoc.settingsClassName(namer.getApiSettingsClassName(context.getInterfaceConfig()));
+    settingsDoc.settingsBuilderVarName(
+        namer.getApiSettingsBuilderVarName(context.getInterfaceConfig()));
+    settingsDoc.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
+    return settingsDoc.build();
+  }
+
+  private List<StaticLangApiMethodView> generateApiMethods(DiscoGapicInterfaceContext context) {
+    List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
+
+    for (MethodModel method : context.getSupportedMethods()) {
+      MethodConfig methodConfig = context.getMethodConfig(method);
+      DiscoGapicMethodContext requestMethodContext = context.asRequestMethodContext(method);
+
+      if (methodConfig.isPageStreaming()) {
+        if (methodConfig.isFlattening()) {
+          for (FlatteningConfig flatteningGroup : methodConfig.getFlatteningConfigs()) {
+            DiscoGapicMethodContext flattenedMethodContext =
+                context.asFlattenedMethodContext(
+                    method, flatteningGroup, context.getInterfaceName());
+            apiMethods.add(
+                apiMethodTransformer.generatePagedFlattenedMethod(flattenedMethodContext));
+          }
+        }
+        apiMethods.add(apiMethodTransformer.generatePagedRequestObjectMethod(requestMethodContext));
+        apiMethods.add(apiMethodTransformer.generatePagedCallableMethod(requestMethodContext));
+        apiMethods.add(
+            apiMethodTransformer.generateUnpagedListCallableMethod(requestMethodContext));
+      } else {
+        if (methodConfig.isFlattening()) {
+          for (FlatteningConfig flatteningGroup : methodConfig.getFlatteningConfigs()) {
+            DiscoGapicMethodContext flattenedMethodContext =
+                context.asFlattenedMethodContext(
+                    method, flatteningGroup, context.getInterfaceName());
+            apiMethods.add(apiMethodTransformer.generateFlattenedMethod(flattenedMethodContext));
+          }
+        }
+        apiMethods.add(apiMethodTransformer.generateRequestObjectMethod(requestMethodContext));
+        apiMethods.add(apiMethodTransformer.generateCallableMethod(requestMethodContext));
+      }
+    }
+
+    return apiMethods;
   }
 }

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
@@ -93,8 +93,6 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
 
   private final JavaNameFormatter nameFormatter = new JavaNameFormatter();
 
-  // TODO(andrealin) Create the service, page streaming, batching, etc transformers.
-
   private static final String API_TEMPLATE_FILENAME = "java/main.snip";
   private static final String SETTINGS_TEMPLATE_FILENAME = "java/settings.snip";
   private static final String STUB_INTERFACE_TEMPLATE_FILENAME = "java/stub_interface.snip";
@@ -150,6 +148,7 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
       StaticLangFileView<StaticLangSettingsView> settingsFile =
           generateSettingsFile(context, exampleApiMethod);
       surfaceDocs.add(settingsFile);
+
       context = context.withNewTypeTable(namer.getStubPackageName());
       StaticLangFileView<StaticLangStubInterfaceView> stubInterfaceFile =
           generateStubInterfaceFile(context);
@@ -175,14 +174,18 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
         new JavaSchemaTypeNameConverter(implicitPackageName, nameFormatter));
   }
 
-  private StaticLangFileView generateApiFile(DiscoGapicInterfaceContext context) {
-    StaticLangFileView.Builder apiFile = StaticLangFileView.newBuilder();
+  private StaticLangFileView<StaticLangApiView> generateApiFile(
+      DiscoGapicInterfaceContext context) {
+    StaticLangFileView.Builder<StaticLangApiView> apiFile =
+        StaticLangFileView.<StaticLangApiView>newBuilder();
 
     apiFile.templateFileName(API_TEMPLATE_FILENAME);
 
     apiFile.classView(generateApiClass(context));
 
-    String outputPath = pathMapper.getOutputPath(null, context.getProductConfig());
+    String outputPath =
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiWrapperClassName(context.getInterfaceConfig());
     apiFile.outputPath(outputPath + File.separator + className + ".java");
 

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
@@ -389,7 +389,8 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
     settingsFile.templateFileName(SETTINGS_TEMPLATE_FILENAME);
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiSettingsClassName(context.getInterfaceConfig());
     settingsFile.outputPath(outputPath + File.separator + className + ".java");
 
@@ -454,7 +455,8 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
     fileView.templateFileName(STUB_INTERFACE_TEMPLATE_FILENAME);
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiStubInterfaceName(context.getInterfaceConfig());
     fileView.outputPath(
         outputPath + File.separator + "stub" + File.separator + className + ".java");

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
@@ -684,6 +684,7 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
     return settingsDoc.build();
   }
 
+  // TODO(andrealin): Stick this in a util class shared with the Java gapic transformer.
   private List<StaticLangApiMethodView> generateApiMethods(DiscoGapicInterfaceContext context) {
     List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
 

--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicSurfaceTransformer.java
@@ -18,7 +18,7 @@ import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.DiscoGapicInterfaceConfig;
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
@@ -288,7 +288,7 @@ public class JavaDiscoGapicSurfaceTransformer implements DocumentToViewTransform
   private StaticLangPagedResponseView generatePagedResponseWrapper(
       MethodContext context, SchemaTypeTable typeTable) {
     MethodModel method = context.getMethodModel();
-    FieldType resourceField = context.getMethodConfig().getPageStreaming().getResourcesField();
+    FieldModel resourceField = context.getMethodConfig().getPageStreaming().getResourcesField();
 
     StaticLangPagedResponseView.Builder pagedResponseWrapper =
         StaticLangPagedResponseView.newBuilder();

--- a/src/main/java/com/google/api/codegen/discovery/Method.java
+++ b/src/main/java/com/google/api/codegen/discovery/Method.java
@@ -150,4 +150,13 @@ public abstract class Method implements Comparable<Method>, Node {
 
   /** @return whether or not the method supports media upload. */
   public abstract boolean supportsMediaUpload();
+
+  /** @return the parent Document node. Returns null if there is no parent Document. */
+  public Document getRootDocument() {
+    Node node = this;
+    while (!(node.parent() instanceof Document)) {
+      node = node.parent();
+    }
+    return (Document) node.parent();
+  }
 }

--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicCodePathMapper.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.gapic;
 import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.NameFormatter;
-import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import java.util.ArrayList;
@@ -41,7 +40,7 @@ public class CommonGapicCodePathMapper implements GapicCodePathMapper {
   }
 
   @Override
-  public String getOutputPath(ProtoElement element, ProductConfig config) {
+  public String getOutputPath(String elementFullName, ProductConfig config) {
     ArrayList<String> dirs = new ArrayList<>();
     if (!Strings.isNullOrEmpty(prefix)) {
       dirs.add(prefix);

--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
@@ -103,7 +103,9 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
       // Note on usage of instanceof: there is one case (as of this writing)
       // where the element is an Iterable<> instead of a ProtoElement.
       if (element instanceof ProtoElement) {
-        subPath = pathMapper.getOutputPath((ProtoElement) element, context.getApiConfig());
+        subPath =
+            pathMapper.getOutputPath(
+                ((ProtoElement) element).getFullName(), context.getApiConfig());
       } else {
         subPath = pathMapper.getOutputPath(null, context.getApiConfig());
       }

--- a/src/main/java/com/google/api/codegen/gapic/PackageNameCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/gapic/PackageNameCodePathMapper.java
@@ -15,12 +15,11 @@
 package com.google.api.codegen.gapic;
 
 import com.google.api.codegen.config.ProductConfig;
-import com.google.api.tools.framework.model.ProtoElement;
 
 /** An implementation of GapicCodePathMapper where the output path is simply the package name. */
 public class PackageNameCodePathMapper implements GapicCodePathMapper {
   @Override
-  public String getOutputPath(ProtoElement element, ProductConfig config) {
+  public String getOutputPath(String elementFullName, ProductConfig config) {
     return config.getPackageName();
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeContext.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
@@ -48,7 +48,7 @@ public abstract class InitCodeContext {
    * Contains the fields that require initialization. Must be set if the output type is FieldList.
    */
   @Nullable
-  public abstract Iterable<FieldType> initFields();
+  public abstract Iterable<FieldModel> initFields();
 
   /** Returns the output type of the init code. Default to SingleObject. */
   public abstract InitCodeOutputType outputType();
@@ -93,7 +93,7 @@ public abstract class InitCodeContext {
 
     public abstract Builder symbolTable(SymbolTable table);
 
-    public abstract Builder initFields(Iterable<FieldType> fields);
+    public abstract Builder initFields(Iterable<FieldModel> fields);
 
     public abstract Builder outputType(InitCodeOutputType val);
 

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.OneofConfig;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.util.Name;
@@ -213,7 +213,7 @@ public class InitCodeNode {
       // Add items in fieldSet to newSubTrees in case they were not included in
       // sampleCodeInitFields, and to ensure the order is determined by initFields
       List<InitCodeNode> newSubTrees = new ArrayList<>();
-      for (FieldType field : context.initFields()) {
+      for (FieldModel field : context.initFields()) {
         String nameString = field.getSimpleName();
         InitValueConfig initValueConfig = context.initValueConfigMap().get(nameString);
         if (initValueConfig == null) {
@@ -224,7 +224,7 @@ public class InitCodeNode {
       }
       // Filter subTrees using fieldSet
       Set<String> fieldSet = new HashSet<>();
-      for (FieldType field : context.initFields()) {
+      for (FieldModel field : context.initFields()) {
         fieldSet.add(field.getSimpleName());
       }
       for (InitCodeNode subTree : subTrees) {

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
@@ -16,15 +16,14 @@ package com.google.api.codegen.nodejs;
 
 import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
-import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.base.Splitter;
 import java.util.List;
 
 public class NodeJSCodePathMapper implements GapicCodePathMapper {
   @Override
-  public String getOutputPath(ProtoElement element, ProductConfig config) {
+  public String getOutputPath(String elementFullName, ProductConfig config) {
     String apiVersion = "";
-    List<String> packages = Splitter.on(".").splitToList(element.getFullName());
+    List<String> packages = Splitter.on(".").splitToList(elementFullName);
     if (packages.size() > 2) {
       String parentName = packages.get(packages.size() - 2);
       if (parentName.matches("v[0-9]+((alpha|beta)[0-9]+)?")) {

--- a/src/main/java/com/google/api/codegen/php/PhpGapicCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/php/PhpGapicCodePathMapper.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.php;
 import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.util.php.PhpPackageUtil;
-import com.google.api.tools.framework.model.ProtoElement;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
@@ -38,7 +37,7 @@ public abstract class PhpGapicCodePathMapper implements GapicCodePathMapper {
   public abstract String getSuffix();
 
   @Override
-  public String getOutputPath(ProtoElement element, ProductConfig config) {
+  public String getOutputPath(String elementFullName, ProductConfig config) {
     ArrayList<String> dirs = new ArrayList<>();
     String prefix = getPrefix();
     if (!Strings.isNullOrEmpty(prefix)) {

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PageStreamingConfig;
@@ -242,7 +242,7 @@ public class ApiCallableTransformer {
     if (methodConfig.isGrpcStreaming()) {
       settings.type(ApiCallableImplType.StreamingApiCallable);
       if (methodConfig.getGrpcStreaming().hasResourceField()) {
-        FieldType resourceType = methodConfig.getGrpcStreaming().getResourcesField();
+        FieldModel resourceType = methodConfig.getGrpcStreaming().getResourcesField();
         settings.resourceTypeName(typeTable.getAndSaveNicknameForElementType(resourceType));
       }
       settings.grpcStreamingType(methodConfig.getGrpcStreaming().getType());

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -310,7 +310,7 @@ public class ApiCallableTransformer {
         method.getAndSaveResponseTypeName(typeTable, context.getNamer()));
     callableBuilder.name(namer.getDirectCallableName(method));
     callableBuilder.protoMethodName(method.getSimpleName());
-    callableBuilder.fullServiceName(context.getTargetInterfaceFullName());
+    callableBuilder.fullServiceName(context.getTargetInterface().getFullName());
 
     return callableBuilder.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -273,7 +273,7 @@ public class ApiCallableTransformer {
     return Arrays.asList(settings.build());
   }
 
-  public List<DirectCallableView> generateStaticLangDirectCallables(GapicInterfaceContext context) {
+  public List<DirectCallableView> generateStaticLangDirectCallables(InterfaceContext context) {
     List<DirectCallableView> callables = new ArrayList<>();
     boolean excludeMixins = !context.getFeatureConfig().enableMixins();
 

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -14,7 +14,9 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.FieldType;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.viewmodel.ApiCallSettingsView;
@@ -25,8 +27,6 @@ import com.google.api.codegen.viewmodel.LongRunningOperationDetailView;
 import com.google.api.codegen.viewmodel.RetryCodesDefinitionView;
 import com.google.api.codegen.viewmodel.RetryParamsDefinitionView;
 import com.google.api.codegen.viewmodel.ServiceMethodType;
-import com.google.api.tools.framework.model.Method;
-import com.google.api.tools.framework.model.TypeRef;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,11 +45,11 @@ public class ApiCallableTransformer {
     this.lroTransformer = new LongRunningTransformer();
   }
 
-  public List<ApiCallableView> generateStaticLangApiCallables(GapicInterfaceContext context) {
+  public List<ApiCallableView> generateStaticLangApiCallables(InterfaceContext context) {
     List<ApiCallableView> callableMembers = new ArrayList<>();
     boolean excludeMixins = !context.getFeatureConfig().enableMixins();
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       if (excludeMixins && context.getMethodConfig(method).getRerouteToGrpcInterface() != null) {
         continue;
       }
@@ -60,17 +60,17 @@ public class ApiCallableTransformer {
     return callableMembers;
   }
 
-  public List<ApiCallSettingsView> generateCallSettings(GapicInterfaceContext context) {
+  public List<ApiCallSettingsView> generateCallSettings(InterfaceContext context) {
     List<ApiCallSettingsView> settingsMembers = new ArrayList<>();
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       settingsMembers.addAll(generateApiCallableSettings(context.asRequestMethodContext(method)));
     }
 
     return settingsMembers;
   }
 
-  private List<ApiCallableView> generateStaticLangApiCallables(GapicMethodContext context) {
+  private List<ApiCallableView> generateStaticLangApiCallables(MethodContext context) {
     List<ApiCallableView> apiCallables = new ArrayList<>();
 
     apiCallables.add(generateMainApiCallable(context));
@@ -80,23 +80,32 @@ public class ApiCallableTransformer {
     }
 
     if (context.getMethodConfig().isLongRunningOperation()) {
-      apiCallables.add(generateOperationApiCallable(context));
+      // Only Protobuf-based APIs have LongRunningOperations.
+      apiCallables.add(generateOperationApiCallable((GapicMethodContext) context));
     }
 
     return apiCallables;
   }
 
-  private ApiCallableView generateMainApiCallable(GapicMethodContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    Method method = context.getMethod();
+  private ApiCallableView generateMainApiCallable(MethodContext context) {
     MethodConfig methodConfig = context.getMethodConfig();
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
 
     ApiCallableView.Builder apiCallableBuilder = ApiCallableView.newBuilder();
 
-    apiCallableBuilder.requestTypeName(typeTable.getAndSaveNicknameFor(method.getInputType()));
-    apiCallableBuilder.responseTypeName(typeTable.getAndSaveNicknameFor(method.getOutputType()));
+    apiCallableBuilder.requestTypeName(
+        method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer()));
+    apiCallableBuilder.responseTypeName(
+        method.getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer()));
     apiCallableBuilder.name(namer.getCallableName(method));
+    apiCallableBuilder.methodName(
+        namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
+    apiCallableBuilder.asyncMethodName(
+        namer.getAsyncApiMethodName(method, VisibilityConfig.PUBLIC));
+    apiCallableBuilder.memberName(namer.getSettingsMemberName(method));
+    apiCallableBuilder.settingsFunctionName(namer.getSettingsFunctionName(method));
+    apiCallableBuilder.grpcClientVarName(namer.getReroutedGrpcClientVarName(methodConfig));
 
     setCommonApiCallableFields(context, apiCallableBuilder);
 
@@ -116,11 +125,10 @@ public class ApiCallableTransformer {
     return apiCallableBuilder.build();
   }
 
-  private ApiCallableView generatePagedApiCallable(GapicMethodContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    Method method = context.getMethod();
+  private ApiCallableView generatePagedApiCallable(MethodContext context) {
     MethodConfig methodConfig = context.getMethodConfig();
     SurfaceNamer namer = context.getNamer();
+    MethodModel method = context.getMethodModel();
 
     PageStreamingConfig pageStreaming = methodConfig.getPageStreaming();
 
@@ -130,22 +138,26 @@ public class ApiCallableTransformer {
         namer.getApiCallableTypeName(ServiceMethodType.UnaryMethod));
 
     String pagedResponseTypeName =
-        namer.getAndSavePagedResponseTypeName(
-            method, typeTable, pageStreaming.getResourcesFieldConfig());
+        namer.getAndSavePagedResponseTypeName(context, pageStreaming.getResourcesFieldConfig());
 
-    pagedApiCallableBuilder.requestTypeName(typeTable.getAndSaveNicknameFor(method.getInputType()));
+    pagedApiCallableBuilder.requestTypeName(
+        method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer()));
     pagedApiCallableBuilder.responseTypeName(pagedResponseTypeName);
     pagedApiCallableBuilder.name(namer.getPagedCallableName(method));
-
+    pagedApiCallableBuilder.methodName(
+        namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
+    pagedApiCallableBuilder.asyncMethodName(
+        namer.getAsyncApiMethodName(method, VisibilityConfig.PUBLIC));
+    pagedApiCallableBuilder.memberName(namer.getSettingsMemberName(method));
+    pagedApiCallableBuilder.settingsFunctionName(namer.getSettingsFunctionName(method));
+    pagedApiCallableBuilder.grpcClientVarName(namer.getReroutedGrpcClientVarName(methodConfig));
     setCommonApiCallableFields(context, pagedApiCallableBuilder);
 
     return pagedApiCallableBuilder.build();
   }
 
   private ApiCallableView generateOperationApiCallable(GapicMethodContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    Method method = context.getMethod();
-    MethodConfig methodConfig = context.getMethodConfig();
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
 
     ApiCallableView.Builder operationApiCallableBuilder = ApiCallableView.newBuilder();
@@ -154,9 +166,8 @@ public class ApiCallableTransformer {
         namer.getApiCallableTypeName(ServiceMethodType.LongRunningMethod));
 
     LongRunningOperationDetailView lroView = lroTransformer.generateDetailView(context);
-
     operationApiCallableBuilder.requestTypeName(
-        typeTable.getAndSaveNicknameFor(method.getInputType()));
+        method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer()));
     operationApiCallableBuilder.responseTypeName(lroView.operationPayloadTypeName());
     operationApiCallableBuilder.metadataTypeName(lroView.metadataTypeName());
     operationApiCallableBuilder.name(namer.getOperationCallableName(method));
@@ -167,8 +178,8 @@ public class ApiCallableTransformer {
   }
 
   private void setCommonApiCallableFields(
-      GapicMethodContext context, ApiCallableView.Builder apiCallableBuilder) {
-    Method method = context.getMethod();
+      MethodContext context, ApiCallableView.Builder apiCallableBuilder) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     MethodConfig methodConfig = context.getMethodConfig();
 
@@ -182,21 +193,21 @@ public class ApiCallableTransformer {
     apiCallableBuilder.grpcDirectCallableName(namer.getDirectCallableName(method));
   }
 
-  public List<ApiCallSettingsView> generateApiCallableSettings(GapicMethodContext context) {
+  public List<ApiCallSettingsView> generateApiCallableSettings(MethodContext context) {
     SurfaceNamer namer = context.getNamer();
-    ModelTypeTable typeTable = context.getTypeTable();
-    Method method = context.getMethod();
+    ImportTypeTable typeTable = context.getTypeTable();
+    MethodModel method = context.getMethodModel();
     MethodConfig methodConfig = context.getMethodConfig();
     Map<String, RetryCodesDefinitionView> retryCodesByKey = new HashMap<>();
     for (RetryCodesDefinitionView retryCodes :
         retryDefinitionsTransformer.generateRetryCodesDefinitions(
-            context.getSurfaceTransformerContext())) {
+            context.getSurfaceInterfaceContext())) {
       retryCodesByKey.put(retryCodes.key(), retryCodes);
     }
     Map<String, RetryParamsDefinitionView> retryParamsByKey = new HashMap<>();
     for (RetryParamsDefinitionView retryParams :
         retryDefinitionsTransformer.generateRetryParamsDefinitions(
-            context.getSurfaceTransformerContext())) {
+            context.getSurfaceInterfaceContext())) {
       retryParamsByKey.put(retryParams.key(), retryParams);
     }
 
@@ -204,12 +215,12 @@ public class ApiCallableTransformer {
 
     settings.methodName(namer.getApiMethodName(method, VisibilityConfig.PUBLIC));
     settings.asyncMethodName(namer.getAsyncApiMethodName(method, VisibilityConfig.PUBLIC));
-    settings.requestTypeName(typeTable.getAndSaveNicknameFor(method.getInputType()));
-    settings.responseTypeName(typeTable.getAndSaveNicknameFor(method.getOutputType()));
+    settings.requestTypeName(
+        method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer()));
+    settings.responseTypeName(
+        method.getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer()));
 
-    settings.grpcTypeName(
-        typeTable.getAndSaveNicknameFor(
-            namer.getGrpcContainerTypeName(context.getTargetInterface())));
+    settings.grpcTypeName(typeTable.getAndSaveNicknameFor(context.getGrpcContainerTypeName()));
     settings.grpcMethodConstant(namer.getGrpcMethodConstant(method));
     settings.retryCodesName(methodConfig.getRetryCodesConfigName());
     settings.retryCodesView(retryCodesByKey.get(methodConfig.getRetryCodesConfigName()));
@@ -231,7 +242,7 @@ public class ApiCallableTransformer {
     if (methodConfig.isGrpcStreaming()) {
       settings.type(ApiCallableImplType.StreamingApiCallable);
       if (methodConfig.getGrpcStreaming().hasResourceField()) {
-        TypeRef resourceType = methodConfig.getGrpcStreaming().getResourcesField().getType();
+        FieldType resourceType = methodConfig.getGrpcStreaming().getResourcesField();
         settings.resourceTypeName(typeTable.getAndSaveNicknameForElementType(resourceType));
       }
       settings.grpcStreamingType(methodConfig.getGrpcStreaming().getType());
@@ -242,9 +253,7 @@ public class ApiCallableTransformer {
               methodConfig.getPageStreaming().getResourcesField()));
       settings.pagedListResponseTypeName(
           namer.getAndSavePagedResponseTypeName(
-              context.getMethod(),
-              context.getTypeTable(),
-              methodConfig.getPageStreaming().getResourcesFieldConfig()));
+              context, methodConfig.getPageStreaming().getResourcesFieldConfig()));
       settings.pageStreamingDescriptorName(namer.getPageStreamingDescriptorConstName(method));
       settings.pagedListResponseFactoryName(namer.getPagedListResponseFactoryConstName(method));
     } else if (methodConfig.isBatching()) {
@@ -268,7 +277,7 @@ public class ApiCallableTransformer {
     List<DirectCallableView> callables = new ArrayList<>();
     boolean excludeMixins = !context.getFeatureConfig().enableMixins();
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       if (excludeMixins && context.getMethodConfig(method).getRerouteToGrpcInterface() != null) {
         continue;
       }
@@ -278,9 +287,9 @@ public class ApiCallableTransformer {
     return callables;
   }
 
-  private DirectCallableView generateDirectCallable(GapicMethodContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    Method method = context.getMethod();
+  private DirectCallableView generateDirectCallable(MethodContext context) {
+    ImportTypeTable typeTable = context.getTypeTable();
+    MethodModel method = context.getMethodModel();
     MethodConfig methodConfig = context.getMethodConfig();
     SurfaceNamer namer = context.getNamer();
 
@@ -295,11 +304,13 @@ public class ApiCallableTransformer {
     callableBuilder.interfaceTypeName(namer.getDirectCallableTypeName(callableInterfaceType));
     callableBuilder.createCallableFunctionName(
         namer.getCreateCallableFunctionName(callableInterfaceType));
-    callableBuilder.requestTypeName(typeTable.getAndSaveNicknameFor(method.getInputType()));
-    callableBuilder.responseTypeName(typeTable.getAndSaveNicknameFor(method.getOutputType()));
+    callableBuilder.requestTypeName(
+        method.getAndSaveRequestTypeName(typeTable, context.getNamer()));
+    callableBuilder.responseTypeName(
+        method.getAndSaveResponseTypeName(typeTable, context.getNamer()));
     callableBuilder.name(namer.getDirectCallableName(method));
     callableBuilder.protoMethodName(method.getSimpleName());
-    callableBuilder.fullServiceName(context.getTargetInterface().getFullName());
+    callableBuilder.fullServiceName(context.getTargetInterfaceFullName());
 
     return callableBuilder.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/BatchingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/BatchingTransformer.java
@@ -16,29 +16,27 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.BatchingConfig;
 import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.GenericFieldSelector;
 import com.google.api.codegen.config.MethodConfig;
-import com.google.api.codegen.util.Name;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.viewmodel.BatchingConfigView;
 import com.google.api.codegen.viewmodel.BatchingDescriptorClassView;
 import com.google.api.codegen.viewmodel.BatchingDescriptorView;
 import com.google.api.codegen.viewmodel.BatchingPartitionKeyView;
 import com.google.api.codegen.viewmodel.FieldCopyView;
-import com.google.api.tools.framework.model.FieldSelector;
-import com.google.api.tools.framework.model.Method;
-import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 
 public class BatchingTransformer {
 
-  public List<BatchingDescriptorView> generateDescriptors(GapicInterfaceContext context) {
+  public List<BatchingDescriptorView> generateDescriptors(InterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
     ImmutableList.Builder<BatchingDescriptorView> descriptors = ImmutableList.builder();
-    for (Method method : context.getBatchingMethods()) {
+    for (MethodModel method : context.getBatchingMethods()) {
       BatchingConfig batching = context.getMethodConfig(method).getBatching();
       BatchingDescriptorView.Builder descriptor = BatchingDescriptorView.newBuilder();
-      descriptor.methodName(namer.getMethodKey(method));
+      descriptor.methodName(context.getNamer().getMethodKey(method));
       descriptor.batchedFieldName(namer.getFieldName(batching.getBatchedField()));
       descriptor.discriminatorFieldNames(generateDiscriminatorFieldNames(batching));
 
@@ -53,11 +51,10 @@ public class BatchingTransformer {
     return descriptors.build();
   }
 
-  public List<BatchingDescriptorClassView> generateDescriptorClasses(
-      GapicInterfaceContext context) {
+  public List<BatchingDescriptorClassView> generateDescriptorClasses(InterfaceContext context) {
     List<BatchingDescriptorClassView> descriptors = new ArrayList<>();
 
-    for (Method method : context.getInterface().getMethods()) {
+    for (MethodModel method : context.getInterfaceConfigMethods()) {
       MethodConfig methodConfig = context.getMethodConfig(method);
       if (!methodConfig.isBatching()) {
         continue;
@@ -68,7 +65,7 @@ public class BatchingTransformer {
     return descriptors;
   }
 
-  public BatchingConfigView generateBatchingConfig(GapicMethodContext context) {
+  public BatchingConfigView generateBatchingConfig(MethodContext context) {
     BatchingConfig batchingConfig = context.getMethodConfig().getBatching();
     BatchingConfigView.Builder batchingConfigView = BatchingConfigView.newBuilder();
 
@@ -87,15 +84,15 @@ public class BatchingTransformer {
 
   private List<String> generateDiscriminatorFieldNames(BatchingConfig batching) {
     ImmutableList.Builder<String> fieldNames = ImmutableList.builder();
-    for (FieldSelector fieldSelector : batching.getDiscriminatorFields()) {
+    for (GenericFieldSelector fieldSelector : batching.getDiscriminatorFields()) {
       fieldNames.add(fieldSelector.getParamName());
     }
     return fieldNames.build();
   }
 
-  private BatchingDescriptorClassView generateDescriptorClass(GapicMethodContext context) {
+  private BatchingDescriptorClassView generateDescriptorClass(MethodContext context) {
     SurfaceNamer namer = context.getNamer();
-    Method method = context.getMethod();
+    MethodModel method = context.getMethodModel();
     BatchingConfig batching = context.getMethodConfig().getBatching();
 
     FieldType batchedField = batching.getBatchedField();
@@ -104,9 +101,11 @@ public class BatchingTransformer {
 
     BatchingDescriptorClassView.Builder desc = BatchingDescriptorClassView.newBuilder();
 
-    desc.name(namer.getBatchingDescriptorConstName(method));
-    desc.requestTypeName(context.getAndSaveRequestTypeName());
-    desc.responseTypeName(context.getAndSaveResponseTypeName());
+    desc.name(context.getNamer().getBatchingDescriptorConstName(context.getMethodModel()));
+    desc.requestTypeName(
+        method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer()));
+    desc.responseTypeName(
+        method.getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer()));
     desc.batchedFieldTypeName(context.getTypeTable().getAndSaveNicknameFor(batchedField));
 
     desc.partitionKeys(generatePartitionKeys(context));
@@ -125,34 +124,29 @@ public class BatchingTransformer {
     return desc.build();
   }
 
-  private List<BatchingPartitionKeyView> generatePartitionKeys(GapicMethodContext context) {
+  private List<BatchingPartitionKeyView> generatePartitionKeys(MethodContext context) {
     List<BatchingPartitionKeyView> keys = new ArrayList<>();
     BatchingConfig batching = context.getMethodConfig().getBatching();
-    for (FieldSelector fieldSelector : batching.getDiscriminatorFields()) {
-      TypeRef selectedType = fieldSelector.getLastField().getType();
-      Name selectedTypeName = Name.from(fieldSelector.getLastField().getSimpleName());
+    for (GenericFieldSelector fieldSelector : batching.getDiscriminatorFields()) {
+      FieldType selectedType = fieldSelector.getLastField();
       BatchingPartitionKeyView key =
           BatchingPartitionKeyView.newBuilder()
-              .fieldGetFunction(
-                  context.getNamer().getFieldGetFunctionName(selectedType, selectedTypeName))
+              .fieldGetFunction(context.getNamer().getFieldGetFunctionName(selectedType))
               .build();
       keys.add(key);
     }
     return keys;
   }
 
-  private List<FieldCopyView> generateDiscriminatorFieldCopies(GapicMethodContext context) {
+  private List<FieldCopyView> generateDiscriminatorFieldCopies(MethodContext context) {
     List<FieldCopyView> fieldCopies = new ArrayList<>();
     BatchingConfig batching = context.getMethodConfig().getBatching();
-    for (FieldSelector fieldSelector : batching.getDiscriminatorFields()) {
-      TypeRef selectedType = fieldSelector.getLastField().getType();
-      Name selectedTypeName = Name.from(fieldSelector.getLastField().getSimpleName());
+    for (GenericFieldSelector fieldSelector : batching.getDiscriminatorFields()) {
+      FieldType selectedType = fieldSelector.getLastField();
       FieldCopyView fieldCopy =
           FieldCopyView.newBuilder()
-              .fieldGetFunction(
-                  context.getNamer().getFieldGetFunctionName(selectedType, selectedTypeName))
-              .fieldSetFunction(
-                  context.getNamer().getFieldSetFunctionName(selectedType, selectedTypeName))
+              .fieldGetFunction(context.getNamer().getFieldGetFunctionName(selectedType))
+              .fieldSetFunction(context.getNamer().getFieldSetFunctionName(selectedType))
               .build();
       fieldCopies.add(fieldCopy);
     }

--- a/src/main/java/com/google/api/codegen/transformer/BatchingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/BatchingTransformer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.BatchingConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GenericFieldSelector;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -95,9 +95,9 @@ public class BatchingTransformer {
     MethodModel method = context.getMethodModel();
     BatchingConfig batching = context.getMethodConfig().getBatching();
 
-    FieldType batchedField = batching.getBatchedField();
+    FieldModel batchedField = batching.getBatchedField();
 
-    FieldType subresponseField = batching.getSubresponseField();
+    FieldModel subresponseField = batching.getSubresponseField();
 
     BatchingDescriptorClassView.Builder desc = BatchingDescriptorClassView.newBuilder();
 
@@ -128,7 +128,7 @@ public class BatchingTransformer {
     List<BatchingPartitionKeyView> keys = new ArrayList<>();
     BatchingConfig batching = context.getMethodConfig().getBatching();
     for (GenericFieldSelector fieldSelector : batching.getDiscriminatorFields()) {
-      FieldType selectedType = fieldSelector.getLastField();
+      FieldModel selectedType = fieldSelector.getLastField();
       BatchingPartitionKeyView key =
           BatchingPartitionKeyView.newBuilder()
               .fieldGetFunction(context.getNamer().getFieldGetFunctionName(selectedType))
@@ -142,7 +142,7 @@ public class BatchingTransformer {
     List<FieldCopyView> fieldCopies = new ArrayList<>();
     BatchingConfig batching = context.getMethodConfig().getBatching();
     for (GenericFieldSelector fieldSelector : batching.getDiscriminatorFields()) {
-      FieldType selectedType = fieldSelector.getLastField();
+      FieldModel selectedType = fieldSelector.getLastField();
       FieldCopyView fieldCopy =
           FieldCopyView.newBuilder()
               .fieldGetFunction(context.getNamer().getFieldGetFunctionName(selectedType))

--- a/src/main/java/com/google/api/codegen/transformer/DiscoGapicInterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/DiscoGapicInterfaceContext.java
@@ -14,20 +14,25 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.ApiSource;
+import com.google.api.codegen.config.DiscoGapicInterfaceConfig;
 import com.google.api.codegen.config.DiscoGapicMethodConfig;
+import com.google.api.codegen.config.DiscoveryMethodModel;
+import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.api.codegen.discovery.Document;
-import com.google.api.codegen.discovery.Method;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * The context for transforming a Discovery Doc API into a view model to use for client library
@@ -35,22 +40,16 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
+  private ImmutableList<MethodModel> interfaceMethods;
+
   public static DiscoGapicInterfaceContext createWithoutInterface(
       Document document,
       GapicProductConfig productConfig,
       SchemaTypeTable typeTable,
       DiscoGapicNamer discoGapicNamer,
-      SurfaceNamer surfaceNamer,
       FeatureConfig featureConfig) {
     return new AutoValue_DiscoGapicInterfaceContext(
-        document,
-        productConfig,
-        typeTable,
-        discoGapicNamer,
-        (new ImmutableList.Builder<Method>()).build(),
-        "",
-        surfaceNamer,
-        featureConfig);
+        document, productConfig, typeTable, discoGapicNamer, "", featureConfig);
   }
 
   public static DiscoGapicInterfaceContext createWithInterface(
@@ -59,23 +58,15 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
       GapicProductConfig productConfig,
       SchemaTypeTable typeTable,
       DiscoGapicNamer discoGapicNamer,
-      SurfaceNamer surfaceNamer,
       FeatureConfig featureConfig) {
-    ImmutableList.Builder<Method> interfaceMethods = new ImmutableList.Builder<>();
+    ImmutableList.Builder<MethodModel> interfaceMethods = new ImmutableList.Builder<>();
 
     for (MethodConfig method : productConfig.getInterfaceConfig(interfaceName).getMethodConfigs()) {
-      interfaceMethods.add(((DiscoGapicMethodConfig) method).getMethod());
+      interfaceMethods.add(method.getMethodModel());
     }
 
     return new AutoValue_DiscoGapicInterfaceContext(
-        document,
-        productConfig,
-        typeTable,
-        discoGapicNamer,
-        interfaceMethods.build(),
-        interfaceName,
-        surfaceNamer,
-        featureConfig);
+        document, productConfig, typeTable, discoGapicNamer, interfaceName, featureConfig);
   }
 
   public abstract Document getDocument();
@@ -87,61 +78,114 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
 
   public abstract DiscoGapicNamer getDiscoGapicNamer();
 
-  public List<Method> getMethods() {
-    List<Method> methods = new LinkedList<>();
-    for (InterfaceConfig config : getProductConfig().getInterfaceConfigMap().values()) {
-      for (MethodConfig methodConfig : config.getMethodConfigs()) {
-        methods.add(((DiscoGapicMethodConfig) methodConfig).getMethod());
+  /** Returns a list of methods for this interface. Memoize the result. */
+  @Override
+  public List<MethodModel> getInterfaceConfigMethods() {
+    if (interfaceMethods != null) {
+      return interfaceMethods;
+    }
+
+    ImmutableList.Builder<MethodModel> methodBuilder = ImmutableList.builder();
+    for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
+      MethodModel method = methodConfig.getMethodModel();
+      if (isSupported(method)) {
+        methodBuilder.add(method);
       }
     }
-    return methods;
+    interfaceMethods = methodBuilder.build();
+    return interfaceMethods;
   }
 
-  public abstract List<Method> getInterfaceMethods();
+  /** Returns a list of methods for this interface. Memoize the result. */
+  @Override
+  public List<MethodModel> getInterfaceMethods() {
+    // TODO(andrealin): Should this be different from getInterfaceConfigMethods()?
+    return getInterfaceConfigMethods();
+  }
+
+  @Override
+  public String getInterfaceSimpleName() {
+    return getInterfaceName();
+  }
+
+  @Override
+  public String getInterfaceFullName() {
+    return getInterfaceName();
+  }
+
+  @Override
+  public String getInterfaceDescription() {
+    return getDocument().description();
+  }
 
   public abstract String getInterfaceName();
 
   @Override
-  public abstract SurfaceNamer getNamer();
-
-  public abstract FeatureConfig getFeatureConfig();
-
-  /** Returns a list of supported methods, configured by FeatureConfig. */
-  public List<Method> getSupportedMethods() {
-    List<Method> methods = new ArrayList<>(getInterfaceConfig().getMethodConfigs().size());
-
-    for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
-      Method method = ((DiscoGapicMethodConfig) methodConfig).getMethod();
-      if (isSupported(method)) {
-        methods.add(method);
-      }
-    }
-    return methods;
+  public SurfaceNamer getNamer() {
+    return getDiscoGapicNamer().getLanguageNamer();
   }
 
-  private boolean isSupported(Method method) {
+  @Override
+  public abstract FeatureConfig getFeatureConfig();
+
+  @Override
+  public DiscoGapicInterfaceContext withNewTypeTable() {
+    return createWithInterface(
+        getDocument(),
+        getInterfaceName(),
+        getProductConfig(),
+        (SchemaTypeTable) getImportTypeTable().cloneEmpty(),
+        getDiscoGapicNamer(),
+        getFeatureConfig());
+  }
+
+  public DiscoGapicInterfaceContext withNewTypeTable(String packageName) {
+    return createWithInterface(
+        getDocument(),
+        getInterfaceName(),
+        getProductConfig(),
+        getSchemaTypeTable().cloneEmpty(packageName),
+        getDiscoGapicNamer(),
+        getFeatureConfig());
+  }
+
+  @Override
+  /* Returns a list of supported methods, configured by FeatureConfig. Memoize the result. */
+  public Iterable<MethodModel> getSupportedMethods() {
+    return Iterables.filter(
+        getInterfaceConfigMethods(),
+        new Predicate<MethodModel>() {
+          @Override
+          public boolean apply(MethodModel methodModel) {
+            return isSupported(methodModel);
+          }
+        });
+  }
+
+  public boolean isSupported(MethodModel method) {
     return getInterfaceConfig().getMethodConfig(method).getVisibility()
         != VisibilityConfig.DISABLED;
   }
 
-  /** Returns the GapicMethodConfig for the given method. */
-  public DiscoGapicMethodConfig getMethodConfig(Method method) {
+  @Override
+  /* Returns the GapicMethodConfig for the given method. */
+  public DiscoGapicMethodConfig getMethodConfig(MethodModel method) {
     for (InterfaceConfig config : getProductConfig().getInterfaceConfigMap().values()) {
       for (MethodConfig methodConfig : config.getMethodConfigs()) {
-        DiscoGapicMethodConfig discoMethodConfig = (DiscoGapicMethodConfig) methodConfig;
-        if (discoMethodConfig.getMethod().equals(method)) {
-          return discoMethodConfig;
+        if (methodConfig.getMethodModel().getFullName().equals(method.getFullName())) {
+          return (DiscoGapicMethodConfig) methodConfig;
         }
       }
     }
 
     throw new IllegalArgumentException(
-        "Interface config does not exist for method: " + method.id());
+        "Interface config does not exist for method: " + method.getFullName());
   }
 
-  public List<Method> getPageStreamingMethods() {
-    List<Method> methods = new ArrayList<>();
-    for (Method method : getSupportedMethods()) {
+  @Override
+  public List<MethodModel> getPageStreamingMethods() {
+    List<MethodModel> methods = new ArrayList<>();
+    for (MethodModel method : getSupportedMethods()) {
       if (getMethodConfig(method).isPageStreaming()) {
         methods.add(method);
       }
@@ -149,9 +193,10 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
     return methods;
   }
 
-  public List<Method> getBatchingMethods() {
-    List<Method> methods = new ArrayList<>();
-    for (Method method : getSupportedMethods()) {
+  @Override
+  public List<MethodModel> getBatchingMethods() {
+    List<MethodModel> methods = new ArrayList<>();
+    for (MethodModel method : getSupportedMethods()) {
       if (getMethodConfig(method).isBatching()) {
         methods.add(method);
       }
@@ -159,27 +204,89 @@ public abstract class DiscoGapicInterfaceContext implements InterfaceContext {
     return methods;
   }
 
-  public DiscoGapicMethodContext asRequestMethodContext(Method method) {
+  @Override
+  public Iterable<MethodModel> getLongRunningMethods() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public DiscoGapicMethodContext asFlattenedMethodContext(
+      MethodModel method, FlatteningConfig flatteningConfig) {
+    Preconditions.checkArgument(method.getApiSource().equals(ApiSource.DISCOVERY));
     return DiscoGapicMethodContext.create(
         this,
-        null,
+        getInterfaceName(),
         getProductConfig(),
         getSchemaTypeTable(),
-        getNamer(),
-        method,
+        getDiscoGapicNamer(),
+        (DiscoveryMethodModel) method,
+        getMethodConfig(method),
+        flatteningConfig,
+        getFeatureConfig());
+  }
+
+  @Override
+  public DiscoGapicMethodContext asRequestMethodContext(MethodModel method) {
+    Preconditions.checkArgument(method.getApiSource().equals(ApiSource.DISCOVERY));
+    return DiscoGapicMethodContext.create(
+        this,
+        getInterfaceName(),
+        getProductConfig(),
+        getSchemaTypeTable(),
+        getDiscoGapicNamer(),
+        (DiscoveryMethodModel) method,
         getMethodConfig(method),
         null,
         getFeatureConfig());
   }
 
   @Override
-  public InterfaceConfig getInterfaceConfig() {
-    return getProductConfig().getInterfaceConfig(getInterfaceName());
+  public DiscoGapicMethodContext asDynamicMethodContext(MethodModel method) {
+    Preconditions.checkArgument(method.getApiSource().equals(ApiSource.DISCOVERY));
+    return DiscoGapicMethodContext.create(
+        this,
+        getInterfaceName(),
+        getProductConfig(),
+        getSchemaTypeTable(),
+        getDiscoGapicNamer(),
+        (DiscoveryMethodModel) method,
+        getMethodConfig(method),
+        null,
+        getFeatureConfig());
   }
 
-  @Nullable
+  @Override
+  public DiscoGapicInterfaceConfig getInterfaceConfig() {
+    return (DiscoGapicInterfaceConfig) getProductConfig().getInterfaceConfig(getInterfaceName());
+  }
+
   @Override
   public ImportTypeTable getImportTypeTable() {
     return getSchemaTypeTable();
+  }
+
+  public DiscoGapicMethodContext asFlattenedMethodContext(
+      MethodModel method, FlatteningConfig flatteningConfig, String interfaceName) {
+    Preconditions.checkArgument(method.getApiSource().equals(ApiSource.DISCOVERY));
+    return DiscoGapicMethodContext.create(
+        this,
+        interfaceName,
+        getProductConfig(),
+        getSchemaTypeTable(),
+        getDiscoGapicNamer(),
+        (DiscoveryMethodModel) method,
+        getMethodConfig(method),
+        flatteningConfig,
+        getFeatureConfig());
+  }
+
+  @Override
+  public String getInterfaceFileName() {
+    return getInterfaceName();
+  }
+
+  @Override
+  public String serviceTitle() {
+    return getDocument().name();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/DiscoGapicMethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/DiscoGapicMethodContext.java
@@ -14,47 +14,46 @@
  */
 package com.google.api.codegen.transformer;
 
+import static com.google.api.codegen.config.ApiSource.DISCOVERY;
+
+import com.google.api.codegen.config.ApiSource;
 import com.google.api.codegen.config.DiscoGapicMethodConfig;
+import com.google.api.codegen.config.DiscoveryMethodModel;
 import com.google.api.codegen.config.FlatteningConfig;
-import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
-import com.google.api.codegen.discovery.Method;
-import com.google.api.tools.framework.model.Interface;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 
 /** The context for transforming a method to a view model object. */
 @AutoValue
 public abstract class DiscoGapicMethodContext implements MethodContext {
   public static DiscoGapicMethodContext create(
-      InterfaceContext surfaceTransformerContext,
-      Interface apiInterface,
+      DiscoGapicInterfaceContext surfaceTransformerContext,
+      String interfaceName,
       GapicProductConfig productConfig,
       SchemaTypeTable typeTable,
-      SurfaceNamer namer,
-      Method method,
+      DiscoGapicNamer discoNamer,
+      DiscoveryMethodModel method,
       DiscoGapicMethodConfig methodConfig,
       FlatteningConfig flatteningConfig,
       FeatureConfig featureConfig) {
+    Preconditions.checkArgument(method != null && method.getApiSource().equals(DISCOVERY));
     return new AutoValue_DiscoGapicMethodContext(
-        surfaceTransformerContext,
-        apiInterface,
         productConfig,
-        namer,
         flatteningConfig,
         featureConfig,
-        method,
-        new DiscoGapicNamer(namer),
+        interfaceName,
         methodConfig,
-        typeTable);
+        surfaceTransformerContext,
+        typeTable,
+        method,
+        discoNamer);
   }
 
-  /** The Discovery Method for which this object is a transformation context. */
-  public abstract Method getMethod();
-
-  public abstract DiscoGapicNamer getDiscoGapicNamer();
+  public abstract String interfaceName();
 
   @Override
   public abstract DiscoGapicMethodConfig getMethodConfig();
@@ -64,14 +63,9 @@ public abstract class DiscoGapicMethodContext implements MethodContext {
     return getFlatteningConfig() != null;
   }
 
-  public Interface getTargetInterface() {
-    return GapicInterfaceConfig.getTargetInterface(
-        getInterface(), getMethodConfig().getRerouteToGrpcInterface());
-  }
-
   @Override
   public InterfaceConfig getInterfaceConfig() {
-    return getProductConfig().getInterfaceConfig(getInterface());
+    return getProductConfig().getInterfaceConfig(interfaceName());
   }
 
   @Override
@@ -82,27 +76,60 @@ public abstract class DiscoGapicMethodContext implements MethodContext {
   @Override
   public DiscoGapicMethodContext cloneWithEmptyTypeTable() {
     return create(
-        getSurfaceTransformerContext(),
-        getInterface(),
+        getSurfaceInterfaceContext(),
+        interfaceName(),
         getProductConfig(),
-        (SchemaTypeTable) getTypeTable().cloneEmpty(),
-        getNamer(),
-        getMethod(),
+        getTypeTable().cloneEmpty(),
+        getDiscoGapicNamer(),
+        getMethodModel(),
         getMethodConfig(),
         getFlatteningConfig(),
         getFeatureConfig());
   }
 
   @Override
+  public abstract DiscoGapicInterfaceContext getSurfaceInterfaceContext();
+
+  @Override
   public abstract SchemaTypeTable getTypeTable();
 
   @Override
-  public String getAndSaveRequestTypeName() {
-    return getTypeTable().getAndSaveNicknameFor(getMethod().request());
+  public abstract DiscoveryMethodModel getMethodModel();
+
+  @Override
+  public ApiSource getApiSource() {
+    return DISCOVERY;
   }
 
   @Override
-  public String getAndSaveResponseTypeName() {
-    return getTypeTable().getAndSaveNicknameFor(getMethod().response());
+  public String getInterfaceSimpleName() {
+    return getDiscoGapicNamer().getSimpleInterfaceName(interfaceName());
+  }
+
+  @Override
+  public SurfaceNamer getNamer() {
+    return getDiscoGapicNamer().getLanguageNamer();
+  }
+
+  public abstract DiscoGapicNamer getDiscoGapicNamer();
+
+  @Override
+  public String getTargetInterfaceFullName() {
+    return "TargetInterfaceFullName() not yet implemented.";
+  }
+
+  @Override
+  public String getGrpcContainerTypeName() {
+    return "";
+  }
+
+  @Override
+  public String getInterfaceFileName() {
+    return getTargetInterfaceFullName();
+  }
+
+  @Override
+  public String getTargetInterfaceSimpleName() {
+    return getInterfaceSimpleName();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/DiscoGapicMethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/DiscoGapicMethodContext.java
@@ -18,10 +18,12 @@ import static com.google.api.codegen.config.ApiSource.DISCOVERY;
 
 import com.google.api.codegen.config.ApiSource;
 import com.google.api.codegen.config.DiscoGapicMethodConfig;
+import com.google.api.codegen.config.DiscoInterfaceModel;
 import com.google.api.codegen.config.DiscoveryMethodModel;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.auto.value.AutoValue;
@@ -45,7 +47,7 @@ public abstract class DiscoGapicMethodContext implements MethodContext {
         productConfig,
         flatteningConfig,
         featureConfig,
-        interfaceName,
+        new DiscoInterfaceModel(interfaceName),
         methodConfig,
         surfaceTransformerContext,
         typeTable,
@@ -53,7 +55,12 @@ public abstract class DiscoGapicMethodContext implements MethodContext {
         discoNamer);
   }
 
-  public abstract String interfaceName();
+  public String interfaceName() {
+    return getInterfaceModel().getFullName();
+  }
+
+  @Override
+  public abstract InterfaceModel getInterfaceModel();
 
   @Override
   public abstract DiscoGapicMethodConfig getMethodConfig();
@@ -102,11 +109,6 @@ public abstract class DiscoGapicMethodContext implements MethodContext {
   }
 
   @Override
-  public String getInterfaceSimpleName() {
-    return getDiscoGapicNamer().getSimpleInterfaceName(interfaceName());
-  }
-
-  @Override
   public SurfaceNamer getNamer() {
     return getDiscoGapicNamer().getLanguageNamer();
   }
@@ -114,22 +116,12 @@ public abstract class DiscoGapicMethodContext implements MethodContext {
   public abstract DiscoGapicNamer getDiscoGapicNamer();
 
   @Override
-  public String getTargetInterfaceFullName() {
-    return "TargetInterfaceFullName() not yet implemented.";
-  }
-
-  @Override
   public String getGrpcContainerTypeName() {
     return "";
   }
 
   @Override
-  public String getInterfaceFileName() {
-    return getTargetInterfaceFullName();
-  }
-
-  @Override
-  public String getTargetInterfaceSimpleName() {
-    return getInterfaceSimpleName();
+  public DiscoInterfaceModel getTargetInterface() {
+    return new DiscoInterfaceModel(getInterfaceModel().getFullName());
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -16,7 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -175,7 +175,7 @@ public class DynamicLangApiMethodTransformer {
     if (methodConfig == null || !methodConfig.isPageStreaming()) {
       return fieldConfigs;
     }
-    final FieldType requestTokenField = methodConfig.getPageStreaming().getRequestTokenField();
+    final FieldModel requestTokenField = methodConfig.getPageStreaming().getRequestTokenField();
     return Iterables.filter(
         fieldConfigs,
         new Predicate<FieldConfig>() {
@@ -191,11 +191,11 @@ public class DynamicLangApiMethodTransformer {
     SurfaceNamer namer = context.getNamer();
     FeatureConfig featureConfig = context.getFeatureConfig();
     ModelTypeTable typeTable = context.getTypeTable();
-    FieldType field = fieldConfig.getField();
+    FieldModel field = fieldConfig.getField();
 
-    Iterable<FieldType> requiredFields = context.getMethodConfig().getRequiredFields();
+    Iterable<FieldModel> requiredFields = context.getMethodConfig().getRequiredFields();
     boolean isRequired = false;
-    for (FieldType f : requiredFields) {
+    for (FieldModel f : requiredFields) {
       if (f.getSimpleName().equals(field.getSimpleName())) {
         isRequired = true;
       }

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -146,10 +146,10 @@ public class DynamicLangApiMethodTransformer {
 
     docBuilder.mainDocLines(surfaceNamer.getDocLines(method, methodConfig));
     docBuilder.paramDocs(apiMethodParamTransformer.generateParamDocs(context));
-    docBuilder.returnTypeName(surfaceNamer.getDynamicLangReturnTypeName(method, methodConfig));
+    docBuilder.returnTypeName(surfaceNamer.getDynamicLangReturnTypeName(context));
     docBuilder.returnsDocLines(
         surfaceNamer.getReturnDocLines(
-            context.getSurfaceInterfaceContext(), methodConfig, Synchronicity.Sync));
+            context.getSurfaceInterfaceContext(), context, Synchronicity.Sync));
     if (methodConfig.isPageStreaming()) {
       docBuilder.pageStreamingResourceTypeName(
           surfaceNamer.getTypeNameDoc(

--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -126,7 +126,7 @@ public class DynamicLangApiMethodTransformer {
 
     apiMethod.packageName(namer.getPackageName());
     apiMethod.packageHasMultipleServices(packageHasMultipleServices);
-    apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterface()));
+    apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()));
     apiMethod.apiVersion(namer.getApiWrapperModuleVersion());
     apiMethod.longRunningView(
         context.getMethodConfig().isLongRunningOperation()

--- a/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
@@ -28,7 +28,7 @@ public class FileHeaderTransformer {
     this.importSectionTransformer = importSectionTransformer;
   }
 
-  public FileHeaderView generateFileHeader(InterfaceContext context) {
+  public FileHeaderView generateFileHeader(TransformationContext context) {
     return generateFileHeader(
         context.getProductConfig(),
         importSectionTransformer.generateImportSection(context),

--- a/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
@@ -23,6 +23,7 @@ import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
@@ -54,7 +55,7 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
       SurfaceNamer namer,
       FeatureConfig featureConfig) {
     return new AutoValue_GapicInterfaceContext(
-        apiInterface,
+        new ProtoInterfaceModel(apiInterface),
         productConfig,
         typeTable,
         namer,
@@ -85,7 +86,11 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
     return getInterface().getModel();
   }
 
-  public abstract Interface getInterface();
+  public Interface getInterface() {
+    return getInterfaceModel().getInterface();
+  }
+
+  public abstract ProtoInterfaceModel getInterfaceModel();
 
   @Override
   public abstract GapicProductConfig getProductConfig();
@@ -119,11 +124,6 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
   @Override
   public GapicInterfaceConfig getInterfaceConfig() {
     return getProductConfig().getInterfaceConfig(getInterface());
-  }
-
-  @Override
-  public String getInterfaceSimpleName() {
-    return getInterface().getSimpleName();
   }
 
   public GapicInterfaceContext withNewTypeTable(String packageName) {
@@ -241,6 +241,7 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
    * Returns a list of methods with samples, similar to getSupportedMethods, but also filter out
    * private methods.
    */
+  @Override
   public List<MethodModel> getPublicMethods() {
     List<MethodModel> methods = new ArrayList<>(getInterfaceConfig().getMethodConfigs().size());
     for (MethodModel method : getInterfaceConfigMethods()) {
@@ -303,16 +304,6 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
       }
     }
     return methods;
-  }
-
-  @Override
-  public String getInterfaceFileName() {
-    return getInterface().getFile().getFullName();
-  }
-
-  @Override
-  public String getInterfaceFullName() {
-    return getInterface().getFullName();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/GapicInterfaceContext.java
@@ -21,6 +21,7 @@ import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoInterfaceModel;
@@ -54,13 +55,25 @@ public abstract class GapicInterfaceContext implements InterfaceContext {
       ModelTypeTable typeTable,
       SurfaceNamer namer,
       FeatureConfig featureConfig) {
+    return create(
+        new ProtoInterfaceModel(apiInterface), productConfig, typeTable, namer, featureConfig);
+  }
+
+  public static GapicInterfaceContext create(
+      InterfaceModel apiInterface,
+      GapicProductConfig productConfig,
+      ModelTypeTable typeTable,
+      SurfaceNamer namer,
+      FeatureConfig featureConfig) {
+    Preconditions.checkArgument(apiInterface.getApiSource().equals(ApiSource.PROTO));
+    ProtoInterfaceModel protoInterface = (ProtoInterfaceModel) apiInterface;
     return new AutoValue_GapicInterfaceContext(
-        new ProtoInterfaceModel(apiInterface),
+        protoInterface,
         productConfig,
         typeTable,
         namer,
         featureConfig,
-        createGrpcRerouteMap(apiInterface.getModel(), productConfig));
+        createGrpcRerouteMap(protoInterface.getInterface().getModel(), productConfig));
   }
 
   private static Map<Interface, Interface> createGrpcRerouteMap(

--- a/src/main/java/com/google/api/codegen/transformer/GapicMethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/GapicMethodContext.java
@@ -21,6 +21,7 @@ import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.tools.framework.model.Interface;
@@ -49,12 +50,16 @@ public abstract class GapicMethodContext implements MethodContext {
         methodConfig,
         surfaceTransformerContext,
         typeTable,
-        apiInterface);
+        new ProtoInterfaceModel(apiInterface));
   }
 
   /** The Method for which this object is a transformation context. */
   public Method getMethod() {
     return getMethodModel().getProtoMethod();
+  }
+
+  public Interface getInterface() {
+    return getInterfaceModel().getInterface();
   }
 
   @Override
@@ -74,26 +79,24 @@ public abstract class GapicMethodContext implements MethodContext {
   @Override
   public abstract ModelTypeTable getTypeTable();
 
-  public abstract Interface getInterface();
-
   @Override
-  public String getInterfaceSimpleName() {
-    return getInterface().getSimpleName();
-  }
+  public abstract ProtoInterfaceModel getInterfaceModel();
 
   @Override
   public boolean isFlattenedMethodContext() {
     return getFlatteningConfig() != null;
   }
 
-  public Interface getTargetInterface() {
-    return GapicInterfaceConfig.getTargetInterface(
-        getInterface(), getMethodConfig().getRerouteToGrpcInterface());
+  @Override
+  public ProtoInterfaceModel getTargetInterface() {
+    return new ProtoInterfaceModel(
+        GapicInterfaceConfig.getTargetInterface(
+            getInterface(), getMethodConfig().getRerouteToGrpcInterface()));
   }
 
   @Override
   public GapicInterfaceConfig getInterfaceConfig() {
-    return getProductConfig().getInterfaceConfig(getInterface());
+    return getProductConfig().getInterfaceConfig(getInterfaceModel().getInterface());
   }
 
   @Override
@@ -105,7 +108,7 @@ public abstract class GapicMethodContext implements MethodContext {
   public GapicMethodContext cloneWithEmptyTypeTable() {
     return create(
         getSurfaceInterfaceContext(),
-        getInterface(),
+        getInterfaceModel().getInterface(),
         getProductConfig(),
         getTypeTable().cloneEmpty(),
         getNamer(),
@@ -116,22 +119,7 @@ public abstract class GapicMethodContext implements MethodContext {
   }
 
   @Override
-  public String getTargetInterfaceFullName() {
-    return getTargetInterface().getFullName();
-  }
-
-  @Override
   public String getGrpcContainerTypeName() {
     return getNamer().getGrpcContainerTypeName(getTargetInterface());
-  }
-
-  @Override
-  public String getInterfaceFileName() {
-    return getTargetInterface().getFile().getSimpleName();
-  }
-
-  @Override
-  public String getTargetInterfaceSimpleName() {
-    return getTargetInterface().getSimpleName();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.viewmodel.GrpcElementDocView;
 import com.google.api.codegen.viewmodel.GrpcEnumDocView;
 import com.google.api.codegen.viewmodel.GrpcEnumValueDocView;
@@ -63,9 +63,9 @@ public class GrpcElementDocTransformer {
   }
 
   private List<ParamDocView> generateMessagePropertyDocs(
-      ModelTypeTable typeTable, SurfaceNamer namer, Iterable<FieldType> fields) {
+      ModelTypeTable typeTable, SurfaceNamer namer, Iterable<FieldModel> fields) {
     ImmutableList.Builder<ParamDocView> propertyDocs = ImmutableList.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       SimpleParamDocView.Builder doc = SimpleParamDocView.newBuilder();
       doc.paramName(namer.getFieldKey(field));
       doc.typeName(namer.getMessagePropertyTypeName(typeTable, field));

--- a/src/main/java/com/google/api/codegen/transformer/GrpcStubTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcStubTransformer.java
@@ -14,9 +14,9 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.viewmodel.GrpcStubView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -27,8 +27,8 @@ public class GrpcStubTransformer {
   public List<GrpcStubView> generateGrpcStubs(GapicInterfaceContext context) {
     List<GrpcStubView> stubs = new ArrayList<>();
     Map<String, Interface> interfaces = new TreeMap<>();
-    Map<String, List<Method>> methods = new TreeMap<>();
-    for (Method method : context.getSupportedMethods()) {
+    Map<String, List<MethodModel>> methods = new TreeMap<>();
+    for (MethodModel method : context.getSupportedMethods()) {
       Interface targetInterface = context.asRequestMethodContext(method).getTargetInterface();
       interfaces.put(targetInterface.getFullName(), targetInterface);
       if (methods.containsKey(targetInterface.getFullName())) {
@@ -46,8 +46,8 @@ public class GrpcStubTransformer {
     return stubs;
   }
 
-  public GrpcStubView generateGrpcStub(
-      GapicInterfaceContext context, Interface targetInterface, List<Method> methods) {
+  GrpcStubView generateGrpcStub(
+      GapicInterfaceContext context, Interface targetInterface, List<MethodModel> methods) {
     SurfaceNamer namer = context.getNamer();
     GrpcStubView.Builder stub = GrpcStubView.newBuilder();
 
@@ -61,7 +61,7 @@ public class GrpcStubTransformer {
     stub.grpcClientImportName(namer.getGrpcClientImportName(targetInterface));
 
     List<String> methodNames = new ArrayList<>();
-    for (Method method : methods) {
+    for (MethodModel method : methods) {
       methodNames.add(
           namer.getApiMethodName(method, context.getMethodConfig(method).getVisibility()));
     }

--- a/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
@@ -39,8 +39,7 @@ public class IamResourceTransformer {
               .exampleName(
                   context
                       .getNamer()
-                      .getIamResourceGetterFunctionExampleName(
-                          context.getInterfaceModel().getSimpleName(), field))
+                      .getIamResourceGetterFunctionExampleName(context.getInterfaceModel(), field))
               .fieldName(context.getNamer().publicFieldName(Name.from(field.getSimpleName())))
               .resourceTypeName(resourceTypeName)
               .resourceConstructorName(context.getNamer().getTypeConstructor(resourceTypeName))

--- a/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
@@ -39,7 +39,8 @@ public class IamResourceTransformer {
               .exampleName(
                   context
                       .getNamer()
-                      .getIamResourceGetterFunctionExampleName(context.getInterface(), field))
+                      .getIamResourceGetterFunctionExampleName(
+                          context.getInterface().getSimpleName(), field))
               .fieldName(context.getNamer().publicFieldName(Name.from(field.getSimpleName())))
               .resourceTypeName(resourceTypeName)
               .resourceConstructorName(context.getNamer().getTypeConstructor(resourceTypeName))

--- a/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
@@ -14,23 +14,23 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.IamResourceView;
-import com.google.api.tools.framework.model.Field;
-import com.google.api.tools.framework.model.MessageType;
-import com.google.api.tools.framework.model.TypeRef;
 import java.util.ArrayList;
 import java.util.List;
 
 public class IamResourceTransformer {
-  public List<IamResourceView> generateIamResources(GapicInterfaceContext context) {
+  public List<IamResourceView> generateIamResources(InterfaceContext context) {
     List<IamResourceView> resources = new ArrayList<>();
-    for (Field field :
-        (context.getProductConfig().getInterfaceConfig(context.getInterface())).getIamResources()) {
+    for (FieldModel field :
+        (context.getProductConfig().getInterfaceConfig(context.getInterfaceModel()))
+            .getIamResources()) {
       String resourceTypeName =
           context
-              .getModelTypeTable()
-              .getAndSaveNicknameFor(TypeRef.of((MessageType) field.getParent()));
+              .getImportTypeTable()
+              .getAndSaveNicknameFor(
+                  field.getParentTypeName(context.getImportTypeTable()).getFullName());
       resources.add(
           IamResourceView.builder()
               .resourceGetterFunctionName(
@@ -40,7 +40,7 @@ public class IamResourceTransformer {
                   context
                       .getNamer()
                       .getIamResourceGetterFunctionExampleName(
-                          context.getInterface().getSimpleName(), field))
+                          context.getInterfaceModel().getSimpleName(), field))
               .fieldName(context.getNamer().publicFieldName(Name.from(field.getSimpleName())))
               .resourceTypeName(resourceTypeName)
               .resourceConstructorName(context.getNamer().getTypeConstructor(resourceTypeName))

--- a/src/main/java/com/google/api/codegen/transformer/ImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ImportSectionTransformer.java
@@ -20,9 +20,9 @@ import com.google.api.codegen.viewmodel.ImportSectionView;
 /** Generates import sections. */
 public interface ImportSectionTransformer {
   /** Generates an ImportSectionView for a file header. */
-  ImportSectionView generateImportSection(InterfaceContext context);
+  ImportSectionView generateImportSection(TransformationContext context);
 
   /** Generates an ImportSectionView for the InitCodeTransformer. */
   ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes);
+      MethodContext context, Iterable<InitCodeNode> specItemNodes);
 }

--- a/src/main/java/com/google/api/codegen/transformer/ImportTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/ImportTypeTable.java
@@ -34,6 +34,9 @@ public interface ImportTypeTable extends TypeFormatter {
   /** Creates a new ModelTypeTable of the same concrete type, but with an empty import set. */
   ImportTypeTable cloneEmpty();
 
+  /** Creates a new ModelTypeTable of the same concrete type, but with an empty import set. */
+  ImportTypeTable cloneEmpty(String packageName);
+
   /** Compute the nickname for the given fullName and save it in the import set. */
   void saveNicknameFor(String fullName);
 

--- a/src/main/java/com/google/api/codegen/transformer/ImportTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/ImportTypeTable.java
@@ -15,21 +15,21 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.util.TypeTable;
 import java.util.Map;
 
 /**
  * A ModelTypeTable manages the imports for a set of fully-qualified type names, and provides helper
- * methods for importing instances of FieldType.
+ * methods for importing instances of FieldModel.
  */
 public interface ImportTypeTable extends TypeFormatter {
   /** Returns the underlying TypeTable. */
   TypeTable getTypeTable();
 
   /** Returns the enum value string. */
-  String getEnumValue(FieldType type, String value);
+  String getEnumValue(FieldModel type, String value);
 
   /** Creates a new ModelTypeTable of the same concrete type, but with an empty import set. */
   ImportTypeTable cloneEmpty();
@@ -59,7 +59,7 @@ public interface ImportTypeTable extends TypeFormatter {
    * Computes the nickname for the given type, adds the full name to the import set, and returns the
    * nickname.
    */
-  String getAndSaveNicknameFor(FieldType type);
+  String getAndSaveNicknameFor(FieldModel type);
 
   /*
    * Computes the nickname for the given FieldConfig, and ResourceName. Adds the full name to
@@ -81,7 +81,7 @@ public interface ImportTypeTable extends TypeFormatter {
    * contained type; if the type is not a repeated type, then the element type is the boxed form of
    * the type.
    */
-  String getAndSaveNicknameForElementType(FieldType type);
+  String getAndSaveNicknameForElementType(FieldModel type);
 
   String getAndSaveNicknameForContainer(String containerFullName, String... elementFullNames);
 
@@ -89,9 +89,9 @@ public interface ImportTypeTable extends TypeFormatter {
    * If the given type is not implicitly imported, the add it to the import set, then return the
    * zero value for that type.
    */
-  String getSnippetZeroValueAndSaveNicknameFor(FieldType type);
+  String getSnippetZeroValueAndSaveNicknameFor(FieldModel type);
 
-  String getImplZeroValueAndSaveNicknameFor(FieldType type);
+  String getImplZeroValueAndSaveNicknameFor(FieldModel type);
 
   /** Returns the imports accumulated so far. */
   Map<String, TypeAlias> getImports();

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -473,7 +473,7 @@ public class InitCodeTransformer {
             context
                 .getNamer()
                 .getFormatFunctionName(
-                    context.getInterfaceSimpleName(),
+                    context.getInterfaceModel().getSimpleName(),
                     initValueConfig.getSingleResourceNameConfig()));
 
         List<String> varList =

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -30,6 +30,8 @@ import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
 import com.google.api.codegen.viewmodel.FieldSettingView;
 import com.google.api.codegen.viewmodel.FormattedInitValueView;
+import com.google.api.codegen.viewmodel.ImportFileView;
+import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.InitCodeLineView;
 import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.InitValueView;
@@ -49,6 +51,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -71,6 +74,21 @@ public class InitCodeTransformer {
    * Generates initialization code from the given GapicMethodContext and InitCodeContext objects.
    */
   public InitCodeView generateInitCode(
+      MethodContext methodContext, InitCodeContext initCodeContext) {
+    switch (methodContext.getApiSource()) {
+      case DISCOVERY:
+        return generateInitCode((DiscoGapicMethodContext) methodContext, initCodeContext);
+      case PROTO:
+        return generateInitCode((GapicMethodContext) methodContext, initCodeContext);
+      default:
+        throw new IllegalArgumentException("Unhandled ApiSource type.");
+    }
+  }
+
+  /**
+   * Generates initialization code from the given GapicMethodContext and InitCodeContext objects.
+   */
+  public InitCodeView generateInitCode(
       GapicMethodContext methodContext, InitCodeContext initCodeContext) {
     InitCodeNode rootNode = InitCodeNode.createTree(initCodeContext);
     if (initCodeContext.outputType() == InitCodeOutputType.FieldList) {
@@ -78,6 +96,29 @@ public class InitCodeTransformer {
     } else {
       return buildInitCodeViewRequestObject(methodContext, rootNode);
     }
+  }
+
+  /**
+   * Generates initialization code from the given GapicMethodContext and InitCodeContext objects.
+   */
+  public InitCodeView generateInitCode(
+      DiscoGapicMethodContext methodContext, InitCodeContext initCodeContext) {
+    // TODO(andrealin): Implementation.
+    return InitCodeView.newBuilder()
+        .apiFileName("apiFileName")
+        .fieldSettings(new LinkedList<FieldSettingView>())
+        .importSection(
+            ImportSectionView.newBuilder()
+                .appImports(new LinkedList<ImportFileView>())
+                .externalImports(new LinkedList<ImportFileView>())
+                .serviceImports(new LinkedList<ImportFileView>())
+                .standardImports(new LinkedList<ImportFileView>())
+                .build())
+        .lines(new LinkedList<InitCodeLineView>())
+        .topLevelLines(new LinkedList<InitCodeLineView>())
+        .versionIndexFileImportName("versionIndexFileImportName")
+        .topLevelIndexFileImportName("topLevelIndexFileImportName")
+        .build();
   }
 
   public InitCodeContext createRequestInitCodeContext(
@@ -100,7 +141,7 @@ public class InitCodeTransformer {
   }
 
   /** Generates assert views for the test of the tested method and its fields. */
-  public List<ClientTestAssertView> generateRequestAssertViews(
+  List<ClientTestAssertView> generateRequestAssertViews(
       GapicMethodContext methodContext, InitCodeContext initContext) {
     InitCodeNode rootNode =
         InitCodeNode.createTree(
@@ -164,8 +205,7 @@ public class InitCodeTransformer {
    * A utility method which creates the InitValueConfig map that contains the collection config
    * data.
    */
-  public static ImmutableMap<String, InitValueConfig> createCollectionMap(
-      GapicMethodContext context) {
+  public static ImmutableMap<String, InitValueConfig> createCollectionMap(MethodContext context) {
     ImmutableMap.Builder<String, InitValueConfig> mapBuilder = ImmutableMap.builder();
     Map<String, String> fieldNamePatterns = context.getMethodConfig().getFieldNamePatterns();
     for (Map.Entry<String, String> fieldNamePattern : fieldNamePatterns.entrySet()) {
@@ -433,7 +473,8 @@ public class InitCodeTransformer {
             context
                 .getNamer()
                 .getFormatFunctionName(
-                    context.getInterface(), initValueConfig.getSingleResourceNameConfig()));
+                    context.getInterfaceSimpleName(),
+                    initValueConfig.getSingleResourceNameConfig()));
 
         List<String> varList =
             Lists.newArrayList(

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -473,8 +473,7 @@ public class InitCodeTransformer {
             context
                 .getNamer()
                 .getFormatFunctionName(
-                    context.getInterfaceModel().getSimpleName(),
-                    initValueConfig.getSingleResourceNameConfig()));
+                    context.getInterfaceModel(), initValueConfig.getSingleResourceNameConfig()));
 
         List<String> varList =
             Lists.newArrayList(

--- a/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
@@ -55,8 +55,10 @@ public interface InterfaceContext extends TransformationContext {
 
   MethodContext asFlattenedMethodContext(MethodModel method, FlatteningConfig flatteningConfig);
 
+  /* @return the methods in the interface. */
   List<MethodModel> getInterfaceMethods();
 
+  /* @return the methods in the interface that have method configs. */
   List<MethodModel> getInterfaceConfigMethods();
 
   Iterable<MethodModel> getLongRunningMethods();

--- a/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
@@ -14,22 +14,61 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProductConfig;
-import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * The context for transforming an API interface, in an input-agnostic way, into a view model to use
  * for client library generation.
  */
-public interface InterfaceContext {
+public interface InterfaceContext extends TransformationContext {
 
+  InterfaceConfig getInterfaceConfig();
+
+  FeatureConfig getFeatureConfig();
+
+  Iterable<MethodModel> getSupportedMethods();
+
+  Iterable<MethodModel> getPageStreamingMethods();
+
+  Iterable<MethodModel> getBatchingMethods();
+
+  MethodConfig getMethodConfig(MethodModel method);
+
+  MethodContext asRequestMethodContext(MethodModel method);
+
+  MethodContext asDynamicMethodContext(MethodModel method);
+
+  String getInterfaceFileName();
+
+  String getInterfaceFullName();
+
+  String getInterfaceDescription();
+
+  String getInterfaceSimpleName();
+
+  InterfaceContext withNewTypeTable();
+
+  MethodContext asFlattenedMethodContext(MethodModel method, FlatteningConfig flatteningConfig);
+
+  List<MethodModel> getInterfaceMethods();
+
+  List<MethodModel> getInterfaceConfigMethods();
+
+  Iterable<MethodModel> getLongRunningMethods();
+
+  String serviceTitle();
+
+  @Override
   ProductConfig getProductConfig();
 
+  @Override
   SurfaceNamer getNamer();
 
+  @Override
   ImportTypeTable getImportTypeTable();
-
-  @Nullable
-  InterfaceConfig getInterfaceConfig();
 }

--- a/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/InterfaceContext.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProductConfig;
@@ -29,9 +30,13 @@ public interface InterfaceContext extends TransformationContext {
 
   InterfaceConfig getInterfaceConfig();
 
+  InterfaceModel getInterfaceModel();
+
   FeatureConfig getFeatureConfig();
 
   Iterable<MethodModel> getSupportedMethods();
+
+  Iterable<MethodModel> getPublicMethods();
 
   Iterable<MethodModel> getPageStreamingMethods();
 
@@ -43,13 +48,7 @@ public interface InterfaceContext extends TransformationContext {
 
   MethodContext asDynamicMethodContext(MethodModel method);
 
-  String getInterfaceFileName();
-
-  String getInterfaceFullName();
-
   String getInterfaceDescription();
-
-  String getInterfaceSimpleName();
 
   InterfaceContext withNewTypeTable();
 

--- a/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
@@ -19,35 +19,23 @@ import com.google.api.codegen.config.LongRunningConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.viewmodel.LongRunningOperationDetailView;
-import com.google.api.tools.framework.model.Method;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
 
 public class LongRunningTransformer {
-
-  public List<LongRunningOperationDetailView> generateDetailViews(GapicInterfaceContext context) {
-    ImmutableList.Builder<LongRunningOperationDetailView> views = ImmutableList.builder();
-    for (Method method : context.getLongRunningMethods()) {
-      views.add(generateDetailView(context.asDynamicMethodContext(method)));
-    }
-    return views.build();
-  }
-
-  public LongRunningOperationDetailView generateDetailView(GapicMethodContext context) {
+  LongRunningOperationDetailView generateDetailView(MethodContext context) {
     MethodConfig methodConfig = context.getMethodConfig();
     LongRunningConfig lroConfig = methodConfig.getLongRunningConfig();
     SurfaceNamer namer = context.getNamer();
 
     String clientReturnTypeName =
         namer.getAndSaveOperationResponseTypeName(
-            context.getMethod(), context.getTypeTable(), methodConfig);
+            context.getMethodModel(), context.getTypeTable(), methodConfig);
     String operationPayloadTypeName =
         namer.getLongRunningOperationTypeName(context.getTypeTable(), lroConfig.getReturnType());
     String metadataTypeName =
         namer.getLongRunningOperationTypeName(context.getTypeTable(), lroConfig.getMetadataType());
 
     return LongRunningOperationDetailView.newBuilder()
-        .methodName(namer.getApiMethodName(context.getMethod(), VisibilityConfig.PUBLIC))
+        .methodName(namer.getApiMethodName(context.getMethodModel(), VisibilityConfig.PUBLIC))
         .constructorName(namer.getTypeConstructor(clientReturnTypeName))
         .clientReturnTypeName(clientReturnTypeName)
         .operationPayloadTypeName(operationPayloadTypeName)

--- a/src/main/java/com/google/api/codegen/transformer/MethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/MethodContext.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.config.ApiSource;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
@@ -31,7 +32,11 @@ public interface MethodContext {
 
   ApiSource getApiSource();
 
-  String getInterfaceSimpleName();
+  InterfaceModel getTargetInterface();
+
+  InterfaceModel getInterfaceModel();
+
+  InterfaceConfig getInterfaceConfig();
 
   GapicProductConfig getProductConfig();
 
@@ -48,17 +53,9 @@ public interface MethodContext {
 
   boolean isFlattenedMethodContext();
 
-  InterfaceConfig getInterfaceConfig();
-
   SingleResourceNameConfig getSingleResourceNameConfig(String entityName);
 
   MethodContext cloneWithEmptyTypeTable();
-
-  String getTargetInterfaceFullName();
-
-  String getTargetInterfaceSimpleName();
-
-  String getInterfaceFileName();
 
   String getGrpcContainerTypeName();
 }

--- a/src/main/java/com/google/api/codegen/transformer/MethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/MethodContext.java
@@ -14,21 +14,24 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.ApiSource;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
-import com.google.api.tools.framework.model.Interface;
 import javax.annotation.Nullable;
 
 /** The context for transforming a method to a view model object. */
 public interface MethodContext {
+  InterfaceContext getSurfaceInterfaceContext();
 
-  InterfaceContext getSurfaceTransformerContext();
+  MethodModel getMethodModel();
 
-  @Nullable
-  Interface getInterface();
+  ApiSource getApiSource();
+
+  String getInterfaceSimpleName();
 
   GapicProductConfig getProductConfig();
 
@@ -51,9 +54,11 @@ public interface MethodContext {
 
   MethodContext cloneWithEmptyTypeTable();
 
-  /* Get the request type name and save it in the type table. */
-  String getAndSaveRequestTypeName();
+  String getTargetInterfaceFullName();
 
-  /* Get the response type name and save it in the type table. */
-  String getAndSaveResponseTypeName();
+  String getTargetInterfaceSimpleName();
+
+  String getInterfaceFileName();
+
+  String getGrpcContainerTypeName();
 }

--- a/src/main/java/com/google/api/codegen/transformer/MethodContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/MethodContext.java
@@ -57,5 +57,6 @@ public interface MethodContext {
 
   MethodContext cloneWithEmptyTypeTable();
 
+  // TODO(andrealin): Move this out when HTTP is implemented in gax.
   String getGrpcContainerTypeName();
 }

--- a/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
@@ -18,11 +18,11 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.viewmodel.testing.MockGrpcMethodView;
 import com.google.api.codegen.viewmodel.testing.MockServiceUsageView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Strings;
 import java.util.ArrayList;
@@ -60,15 +60,15 @@ public class MockServiceTransformer {
     return interfaces;
   }
 
-  public List<MockGrpcMethodView> createMockGrpcMethodViews(GapicInterfaceContext context) {
-    List<Method> methods = context.getInterface().getMethods();
+  public List<MockGrpcMethodView> createMockGrpcMethodViews(InterfaceContext context) {
+    List<MethodModel> methods = context.getInterfaceMethods();
     ArrayList<MockGrpcMethodView> mocks = new ArrayList<>(methods.size());
-    for (Method method : methods) {
-      GapicMethodContext methodContext = context.asRequestMethodContext(method);
+    for (MethodModel method : methods) {
+      MethodContext methodContext = context.asRequestMethodContext(method);
       String requestTypeName =
-          methodContext.getTypeTable().getAndSaveNicknameFor(method.getInputType());
+          method.getAndSaveRequestTypeName(methodContext.getTypeTable(), methodContext.getNamer());
       String responseTypeName =
-          methodContext.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
+          method.getAndSaveResponseTypeName(methodContext.getTypeTable(), methodContext.getNamer());
       MethodConfig methodConfig = methodContext.getMethodConfig();
       mocks.add(
           MockGrpcMethodView.newBuilder()
@@ -89,9 +89,9 @@ public class MockServiceTransformer {
     for (Interface apiInterface : getGrpcInterfacesToMock(model, productConfig)) {
       MockServiceUsageView mockService =
           MockServiceUsageView.newBuilder()
-              .className(namer.getMockServiceClassName(apiInterface))
-              .varName(namer.getMockServiceVarName(apiInterface))
-              .implName(namer.getMockGrpcServiceImplName(apiInterface))
+              .className(namer.getMockServiceClassName(apiInterface.getSimpleName()))
+              .varName(namer.getMockServiceVarName(apiInterface.getSimpleName()))
+              .implName(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
               .registerFunctionName(namer.getServerRegisterFunctionName(apiInterface))
               .build();
       mockServices.add(mockService);

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeFormatterImpl.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeFormatterImpl.java
@@ -15,6 +15,8 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.TypeRef;
 
@@ -39,6 +41,13 @@ public class ModelTypeFormatterImpl implements ModelTypeFormatter {
   @Override
   public String getFullNameFor(ProtoElement element) {
     return typeNameConverter.getTypeName(element).getFullName();
+  }
+
+  @Override
+  public String getFullNameFor(InterfaceModel interfaceModel) {
+    return typeNameConverter
+        .getTypeName(((ProtoInterfaceModel) interfaceModel).getInterface())
+        .getFullName();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeFormatterImpl.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeFormatterImpl.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.TypeRef;
 
@@ -57,22 +57,22 @@ public class ModelTypeFormatterImpl implements ModelTypeFormatter {
   }
 
   @Override
-  public String getFullNameFor(FieldType type) {
+  public String getFullNameFor(FieldModel type) {
     return getFullNameFor(type.getProtoTypeRef());
   }
 
   @Override
-  public String getFullNameForElementType(FieldType type) {
+  public String getFullNameForElementType(FieldModel type) {
     return getFullNameForElementType(type.getProtoTypeRef());
   }
 
   @Override
-  public String getNicknameFor(FieldType type) {
+  public String getNicknameFor(FieldModel type) {
     return getNicknameFor(type.getProtoTypeRef());
   }
 
   @Override
-  public String renderPrimitiveValue(FieldType type, String key) {
+  public String renderPrimitiveValue(FieldModel type, String key) {
     return renderPrimitiveValue(type.getProtoTypeRef(), key);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeNameConverter.java
@@ -16,6 +16,8 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypedValue;
 import com.google.api.tools.framework.model.EnumValue;
@@ -26,6 +28,12 @@ import com.google.api.tools.framework.model.TypeRef;
 public abstract class ModelTypeNameConverter implements TypeNameConverter {
   /** Provides a TypeName for the given TypeRef. */
   public abstract TypeName getTypeName(TypeRef type);
+
+  /** Provides a TypeName for the given TypeRef. */
+  @Override
+  public TypeName getTypeName(InterfaceModel interfaceModel) {
+    return getTypeName(((ProtoInterfaceModel) interfaceModel).getInterface());
+  }
 
   /** Provides a TypedValue for the given enum TypeRef. */
   public abstract TypedValue getEnumValue(TypeRef type, EnumValue value);

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeNameConverter.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypedValue;
 import com.google.api.tools.framework.model.EnumValue;
@@ -71,21 +71,21 @@ public abstract class ModelTypeNameConverter implements TypeNameConverter {
 
   // Overriden interface methods call the overloaded method on the underlying Field object.
 
-  /** Provides a TypeName for the given FieldType. */
+  /** Provides a TypeName for the given FieldModel. */
   @Override
-  public TypeName getTypeName(FieldType type) {
+  public TypeName getTypeName(FieldModel type) {
     return getTypeName(type.getProtoTypeRef());
   }
 
-  /** Provides a TypedValue for the given enum FieldType. */
+  /** Provides a TypedValue for the given enum FieldModel. */
   @Override
-  public TypedValue getEnumValue(FieldType type, EnumValue value) {
+  public TypedValue getEnumValue(FieldModel type, EnumValue value) {
     return getEnumValue(type.getProtoTypeRef(), value);
   }
 
-  /** Provides a TypeName for the element type of the given FieldType. */
+  /** Provides a TypeName for the element type of the given FieldModel. */
   @Override
-  public TypeName getTypeNameForElementType(FieldType type) {
+  public TypeName getTypeNameForElementType(FieldModel type) {
     return getTypeNameForElementType(type.getProtoTypeRef());
   }
 
@@ -94,23 +94,23 @@ public abstract class ModelTypeNameConverter implements TypeNameConverter {
    * type; suitable for use within code snippets.
    */
   @Override
-  public TypedValue getSnippetZeroValue(FieldType type) {
+  public TypedValue getSnippetZeroValue(FieldModel type) {
     return getSnippetZeroValue(type.getProtoTypeRef());
   }
 
   /**
    * Provides a TypedValue containing the zero value of the given type, for use internally within
    * the vkit layer; plus the TypeName of the type. This will often return the same value as {@link
-   * #getSnippetZeroValue(FieldType)}.
+   * #getSnippetZeroValue(FieldModel)}.
    */
   @Override
-  public TypedValue getImplZeroValue(FieldType type) {
+  public TypedValue getImplZeroValue(FieldModel type) {
     return getImplZeroValue(type.getProtoTypeRef());
   }
 
   /** Renders the given value if it is a primitive type. */
   @Override
-  public String renderPrimitiveValue(FieldType type, String value) {
+  public String renderPrimitiveValue(FieldModel type, String value) {
     return renderPrimitiveValue(type.getProtoTypeRef(), value);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
@@ -16,6 +16,8 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypeTable;
@@ -42,6 +44,11 @@ public class ModelTypeTable implements ImportTypeTable, ModelTypeFormatter {
   @Override
   public String getImplicitPackageFullNameFor(String shortName) {
     return typeFormatter.getImplicitPackageFullNameFor(shortName);
+  }
+
+  @Override
+  public String getFullNameFor(InterfaceModel type) {
+    return getFullNameFor(((ProtoInterfaceModel) type).getInterface());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypeTable;
@@ -83,7 +83,7 @@ public class ModelTypeTable implements ImportTypeTable, ModelTypeFormatter {
 
   /** Returns the enum value string */
   @Override
-  public String getEnumValue(FieldType type, String value) {
+  public String getEnumValue(FieldModel type, String value) {
     return getEnumValue(type.getProtoTypeRef(), value);
   }
 
@@ -142,7 +142,7 @@ public class ModelTypeTable implements ImportTypeTable, ModelTypeFormatter {
    * nickname.
    */
   @Override
-  public String getAndSaveNicknameFor(FieldType type) {
+  public String getAndSaveNicknameFor(FieldModel type) {
     return typeTable.getAndSaveNicknameFor(typeNameConverter.getTypeName(type));
   }
 
@@ -186,7 +186,7 @@ public class ModelTypeTable implements ImportTypeTable, ModelTypeFormatter {
    * the type.
    */
   @Override
-  public String getAndSaveNicknameForElementType(FieldType type) {
+  public String getAndSaveNicknameForElementType(FieldModel type) {
     return typeTable.getAndSaveNicknameFor(typeNameConverter.getTypeNameForElementType(type));
   }
 
@@ -210,36 +210,36 @@ public class ModelTypeTable implements ImportTypeTable, ModelTypeFormatter {
    * zero value for that type.
    */
   @Override
-  public String getSnippetZeroValueAndSaveNicknameFor(FieldType type) {
+  public String getSnippetZeroValueAndSaveNicknameFor(FieldModel type) {
     return typeNameConverter.getSnippetZeroValue(type).getValueAndSaveTypeNicknameIn(typeTable);
   }
 
   @Override
-  public String getImplZeroValueAndSaveNicknameFor(FieldType type) {
+  public String getImplZeroValueAndSaveNicknameFor(FieldModel type) {
     return typeNameConverter.getImplZeroValue(type).getValueAndSaveTypeNicknameIn(typeTable);
   }
 
   /** Get the full name for the given type. */
   @Override
-  public String getFullNameFor(FieldType type) {
+  public String getFullNameFor(FieldModel type) {
     return getFullNameFor(type.getProtoTypeRef());
   }
 
   /** Get the full name for the element type of the given type. */
   @Override
-  public String getFullNameForElementType(FieldType type) {
+  public String getFullNameForElementType(FieldModel type) {
     return getFullNameForElementType(type.getProtoTypeRef());
   }
 
   /** Returns the nickname for the given type (without adding the full name to the import set). */
   @Override
-  public String getNicknameFor(FieldType type) {
+  public String getNicknameFor(FieldModel type) {
     return getNicknameFor(type.getProtoTypeRef());
   }
 
   /** Renders the primitive value of the given type. */
   @Override
-  public String renderPrimitiveValue(FieldType type, String key) {
+  public String renderPrimitiveValue(FieldModel type, String key) {
     return renderPrimitiveValue(type.getProtoTypeRef(), key);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
@@ -93,6 +93,7 @@ public class ModelTypeTable implements ImportTypeTable, ModelTypeFormatter {
     return new ModelTypeTable(typeTable.cloneEmpty(), typeNameConverter);
   }
 
+  @Override
   public ModelTypeTable cloneEmpty(String packageName) {
     return new ModelTypeTable(typeTable.cloneEmpty(packageName), typeNameConverter);
   }

--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PageStreamingConfig;
@@ -83,7 +83,7 @@ public class PageStreamingTransformer {
 
     PageStreamingDescriptorClassView.Builder desc = PageStreamingDescriptorClassView.newBuilder();
 
-    FieldType resourceField = pageStreaming.getResourcesField();
+    FieldModel resourceField = pageStreaming.getResourcesField();
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
 
     desc.name(namer.getPageStreamingDescriptorConstName(method));
@@ -129,7 +129,7 @@ public class PageStreamingTransformer {
     MethodModel method = context.getMethodModel();
     ImportTypeTable typeTable = context.getTypeTable();
     PageStreamingConfig pageStreaming = context.getMethodConfig().getPageStreaming();
-    FieldType resourceField = pageStreaming.getResourcesField();
+    FieldModel resourceField = pageStreaming.getResourcesField();
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
 
     PagedListResponseFactoryClassView.Builder factory =

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -54,7 +54,7 @@ import java.util.Map.Entry;
 public class PathTemplateTransformer {
   private static final String VAR_PLACE_HOLDER = "__GAPIC_VARIABLE__";
 
-  public List<PathTemplateView> generatePathTemplates(GapicInterfaceContext context) {
+  public List<PathTemplateView> generatePathTemplates(InterfaceContext context) {
     List<PathTemplateView> pathTemplates = new ArrayList<>();
     if (!context.getFeatureConfig().enableStringFormatFunctions()) {
       return pathTemplates;
@@ -64,7 +64,9 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateView.Builder pathTemplate = PathTemplateView.newBuilder();
       pathTemplate.name(
-          context.getNamer().getPathTemplateName(context.getInterface(), resourceNameConfig));
+          context
+              .getNamer()
+              .getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig));
       pathTemplate.pattern(resourceNameConfig.getNamePattern());
       pathTemplates.add(pathTemplate.build());
     }
@@ -77,8 +79,8 @@ public class PathTemplateTransformer {
         context, context.getProductConfig().getResourceNameConfigs().values());
   }
 
-  public List<ResourceNameView> generateResourceNames(
-      GapicInterfaceContext context, Iterable<ResourceNameConfig> configs) {
+  List<ResourceNameView> generateResourceNames(
+      InterfaceContext context, Iterable<ResourceNameConfig> configs) {
     List<ResourceNameView> resourceNames = new ArrayList<>();
     int index = 1;
     for (ResourceNameConfig config : configs) {
@@ -104,7 +106,7 @@ public class PathTemplateTransformer {
   }
 
   private ResourceNameSingleView generateResourceNameSingle(
-      GapicInterfaceContext context, int index, SingleResourceNameConfig config) {
+      InterfaceContext context, int index, SingleResourceNameConfig config) {
     SurfaceNamer namer = context.getNamer();
     ResourceNameSingleView.Builder builder =
         ResourceNameSingleView.newBuilder()
@@ -131,7 +133,7 @@ public class PathTemplateTransformer {
   }
 
   private ResourceNameOneofView generateResourceNameOneof(
-      GapicInterfaceContext context, int index, ResourceNameOneofConfig config) {
+      InterfaceContext context, int index, ResourceNameOneofConfig config) {
     SurfaceNamer namer = context.getNamer();
     ResourceNameOneofView.Builder builder =
         ResourceNameOneofView.newBuilder()
@@ -146,7 +148,7 @@ public class PathTemplateTransformer {
   }
 
   private ResourceNameFixedView generateResourceNameFixed(
-      GapicInterfaceContext context, int index, FixedResourceNameConfig config) {
+      InterfaceContext context, int index, FixedResourceNameConfig config) {
     SurfaceNamer namer = context.getNamer();
     ResourceNameFixedView.Builder builder =
         ResourceNameFixedView.newBuilder()
@@ -219,24 +221,26 @@ public class PathTemplateTransformer {
   }
 
   public List<FormatResourceFunctionView> generateFormatResourceFunctions(
-      GapicInterfaceContext context) {
+      InterfaceContext context) {
     List<FormatResourceFunctionView> functions = new ArrayList<>();
     if (!context.getFeatureConfig().enableStringFormatFunctions()) {
       return functions;
     }
 
     SurfaceNamer namer = context.getNamer();
-    Interface apiInterface = context.getInterface();
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
     for (SingleResourceNameConfig resourceNameConfig :
         interfaceConfig.getSingleResourceNameConfigs()) {
       FormatResourceFunctionView.Builder function =
           FormatResourceFunctionView.newBuilder()
               .entityName(resourceNameConfig.getEntityName())
-              .name(namer.getFormatFunctionName(apiInterface, resourceNameConfig))
-              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+              .name(
+                  namer.getFormatFunctionName(context.getInterfaceSimpleName(), resourceNameConfig))
+              .pathTemplateName(
+                  namer.getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig))
               .pathTemplateGetterName(
-                  namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+                  namer.getPathTemplateNameGetter(
+                      context.getInterfaceSimpleName(), resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
       List<ResourceIdParamView> resourceIdParams = new ArrayList<>();
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
@@ -256,15 +260,13 @@ public class PathTemplateTransformer {
     return functions;
   }
 
-  public List<ParseResourceFunctionView> generateParseResourceFunctions(
-      GapicInterfaceContext context) {
+  public List<ParseResourceFunctionView> generateParseResourceFunctions(InterfaceContext context) {
     List<ParseResourceFunctionView> functions = new ArrayList<>();
     if (!context.getFeatureConfig().enableStringFormatFunctions()) {
       return functions;
     }
 
     SurfaceNamer namer = context.getNamer();
-    Interface apiInterface = context.getInterface();
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
     for (SingleResourceNameConfig resourceNameConfig :
         interfaceConfig.getSingleResourceNameConfigs()) {
@@ -273,9 +275,11 @@ public class PathTemplateTransformer {
             ParseResourceFunctionView.newBuilder()
                 .entityName(resourceNameConfig.getEntityName())
                 .name(namer.getParseFunctionName(var, resourceNameConfig))
-                .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+                .pathTemplateName(
+                    namer.getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig))
                 .pathTemplateGetterName(
-                    namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+                    namer.getPathTemplateNameGetter(
+                        context.getInterfaceSimpleName(), resourceNameConfig))
                 .entityNameParamName(namer.getEntityNameParamName(resourceNameConfig))
                 .outputResourceId(var);
         functions.add(function.build());
@@ -296,9 +300,11 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateGetterFunctionView.Builder function =
           PathTemplateGetterFunctionView.newBuilder()
-              .name(namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+              .name(
+                  namer.getPathTemplateNameGetter(apiInterface.getSimpleName(), resourceNameConfig))
               .resourceName(namer.getPathTemplateResourcePhraseName(resourceNameConfig))
-              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+              .pathTemplateName(
+                  namer.getPathTemplateName(apiInterface.getSimpleName(), resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
 
       List<PathTemplateArgumentView> args = new ArrayList<>();

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -66,7 +66,8 @@ public class PathTemplateTransformer {
       pathTemplate.name(
           context
               .getNamer()
-              .getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig));
+              .getPathTemplateName(
+                  context.getInterfaceModel().getSimpleName(), resourceNameConfig));
       pathTemplate.pattern(resourceNameConfig.getNamePattern());
       pathTemplates.add(pathTemplate.build());
     }
@@ -235,12 +236,14 @@ public class PathTemplateTransformer {
           FormatResourceFunctionView.newBuilder()
               .entityName(resourceNameConfig.getEntityName())
               .name(
-                  namer.getFormatFunctionName(context.getInterfaceSimpleName(), resourceNameConfig))
+                  namer.getFormatFunctionName(
+                      context.getInterfaceModel().getSimpleName(), resourceNameConfig))
               .pathTemplateName(
-                  namer.getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig))
+                  namer.getPathTemplateName(
+                      context.getInterfaceModel().getSimpleName(), resourceNameConfig))
               .pathTemplateGetterName(
                   namer.getPathTemplateNameGetter(
-                      context.getInterfaceSimpleName(), resourceNameConfig))
+                      context.getInterfaceModel().getSimpleName(), resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
       List<ResourceIdParamView> resourceIdParams = new ArrayList<>();
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
@@ -276,10 +279,11 @@ public class PathTemplateTransformer {
                 .entityName(resourceNameConfig.getEntityName())
                 .name(namer.getParseFunctionName(var, resourceNameConfig))
                 .pathTemplateName(
-                    namer.getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig))
+                    namer.getPathTemplateName(
+                        context.getInterfaceModel().getSimpleName(), resourceNameConfig))
                 .pathTemplateGetterName(
                     namer.getPathTemplateNameGetter(
-                        context.getInterfaceSimpleName(), resourceNameConfig))
+                        context.getInterfaceModel().getSimpleName(), resourceNameConfig))
                 .entityNameParamName(namer.getEntityNameParamName(resourceNameConfig))
                 .outputResourceId(var);
         functions.add(function.build());

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.FixedResourceNameConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameMessageConfigs;
 import com.google.api.codegen.config.ResourceNameOneofConfig;
@@ -39,7 +40,6 @@ import com.google.api.codegen.viewmodel.ResourceNameView;
 import com.google.api.codegen.viewmodel.ResourceProtoFieldView;
 import com.google.api.codegen.viewmodel.ResourceProtoView;
 import com.google.api.gax.protobuf.PathTemplate;
-import com.google.api.tools.framework.model.Interface;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
@@ -64,10 +64,7 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateView.Builder pathTemplate = PathTemplateView.newBuilder();
       pathTemplate.name(
-          context
-              .getNamer()
-              .getPathTemplateName(
-                  context.getInterfaceModel().getSimpleName(), resourceNameConfig));
+          context.getNamer().getPathTemplateName(context.getInterfaceModel(), resourceNameConfig));
       pathTemplate.pattern(resourceNameConfig.getNamePattern());
       pathTemplates.add(pathTemplate.build());
     }
@@ -235,15 +232,11 @@ public class PathTemplateTransformer {
       FormatResourceFunctionView.Builder function =
           FormatResourceFunctionView.newBuilder()
               .entityName(resourceNameConfig.getEntityName())
-              .name(
-                  namer.getFormatFunctionName(
-                      context.getInterfaceModel().getSimpleName(), resourceNameConfig))
+              .name(namer.getFormatFunctionName(context.getInterfaceModel(), resourceNameConfig))
               .pathTemplateName(
-                  namer.getPathTemplateName(
-                      context.getInterfaceModel().getSimpleName(), resourceNameConfig))
+                  namer.getPathTemplateName(context.getInterfaceModel(), resourceNameConfig))
               .pathTemplateGetterName(
-                  namer.getPathTemplateNameGetter(
-                      context.getInterfaceModel().getSimpleName(), resourceNameConfig))
+                  namer.getPathTemplateNameGetter(context.getInterfaceModel(), resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
       List<ResourceIdParamView> resourceIdParams = new ArrayList<>();
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
@@ -279,11 +272,10 @@ public class PathTemplateTransformer {
                 .entityName(resourceNameConfig.getEntityName())
                 .name(namer.getParseFunctionName(var, resourceNameConfig))
                 .pathTemplateName(
-                    namer.getPathTemplateName(
-                        context.getInterfaceModel().getSimpleName(), resourceNameConfig))
+                    namer.getPathTemplateName(context.getInterfaceModel(), resourceNameConfig))
                 .pathTemplateGetterName(
                     namer.getPathTemplateNameGetter(
-                        context.getInterfaceModel().getSimpleName(), resourceNameConfig))
+                        context.getInterfaceModel(), resourceNameConfig))
                 .entityNameParamName(namer.getEntityNameParamName(resourceNameConfig))
                 .outputResourceId(var);
         functions.add(function.build());
@@ -298,17 +290,15 @@ public class PathTemplateTransformer {
     List<PathTemplateGetterFunctionView> functions = new ArrayList<>();
 
     SurfaceNamer namer = context.getNamer();
-    Interface apiInterface = context.getInterface();
+    InterfaceModel apiInterface = context.getInterfaceModel();
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
     for (SingleResourceNameConfig resourceNameConfig :
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateGetterFunctionView.Builder function =
           PathTemplateGetterFunctionView.newBuilder()
-              .name(
-                  namer.getPathTemplateNameGetter(apiInterface.getSimpleName(), resourceNameConfig))
+              .name(namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
               .resourceName(namer.getPathTemplateResourcePhraseName(resourceNameConfig))
-              .pathTemplateName(
-                  namer.getPathTemplateName(apiInterface.getSimpleName(), resourceNameConfig))
+              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
 
       List<PathTemplateArgumentView> args = new ArrayList<>();

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.FixedResourceNameConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.ResourceNameConfig;
@@ -166,18 +166,18 @@ public class PathTemplateTransformer {
     SurfaceNamer namer = context.getNamer();
     ResourceNameMessageConfigs resourceConfigs =
         context.getProductConfig().getResourceNameMessageConfigs();
-    ListMultimap<String, FieldType> fieldsByMessage =
+    ListMultimap<String, FieldModel> fieldsByMessage =
         resourceConfigs.getFieldsWithResourceNamesByMessage();
     Map<String, FieldConfig> fieldConfigMap =
         context.getProductConfig().getDefaultResourceNameFieldConfigMap();
     List<ResourceProtoView> protos = new ArrayList<>();
-    for (Entry<String, Collection<FieldType>> entry : fieldsByMessage.asMap().entrySet()) {
+    for (Entry<String, Collection<FieldModel>> entry : fieldsByMessage.asMap().entrySet()) {
       String msgName = entry.getKey();
-      Collection<FieldType> fields = new ArrayList<>(entry.getValue());
+      Collection<FieldModel> fields = new ArrayList<>(entry.getValue());
       ResourceProtoView.Builder protoBuilder = ResourceProtoView.newBuilder();
       protoBuilder.protoClassName(namer.getTypeNameConverter().getTypeName(msgName).getNickname());
       List<ResourceProtoFieldView> fieldViews = new ArrayList<>();
-      for (FieldType field : fields) {
+      for (FieldModel field : fields) {
         FieldConfig fieldConfig = fieldConfigMap.get(field.getFullName());
         String fieldTypeSimpleName = namer.getResourceTypeName(fieldConfig.getResourceNameConfig());
         String fieldTypeName =

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeFormatterImpl.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeFormatterImpl.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.discovery.Schema;
 
 /** Default implementation of SchemaTypeFormatter. */
@@ -53,6 +54,11 @@ public class SchemaTypeFormatterImpl implements SchemaTypeFormatter {
   @Override
   public String getFullNameFor(FieldModel type) {
     return getFullNameFor(type.getDiscoveryField());
+  }
+
+  @Override
+  public String getFullNameFor(InterfaceModel type) {
+    return type.getFullName();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeFormatterImpl.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeFormatterImpl.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.discovery.Schema;
 
 /** Default implementation of SchemaTypeFormatter. */
@@ -51,23 +51,23 @@ public class SchemaTypeFormatterImpl implements SchemaTypeFormatter {
   }
 
   @Override
-  public String getFullNameFor(FieldType type) {
+  public String getFullNameFor(FieldModel type) {
     return getFullNameFor(type.getDiscoveryField());
   }
 
   @Override
-  public String getFullNameForElementType(FieldType type) {
+  public String getFullNameForElementType(FieldModel type) {
     return getFullNameFor(type);
   }
 
   @Override
-  public String renderPrimitiveValue(FieldType type, String value) {
+  public String renderPrimitiveValue(FieldModel type, String value) {
     return renderPrimitiveValue(type.getDiscoveryField(), value);
   }
 
   /** Returns the nickname for the given type (without adding the full name to the import set). */
   @Override
-  public String getNicknameFor(FieldType type) {
+  public String getNicknameFor(FieldModel type) {
     return getNicknameFor(type.getDiscoveryField());
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
@@ -70,8 +70,13 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
 
   /** Creates a new SchemaTypeTable of the same concrete type, but with an empty import set. */
   @Override
-  public ImportTypeTable cloneEmpty() {
+  public SchemaTypeTable cloneEmpty() {
     return new SchemaTypeTable(typeTable.cloneEmpty(), typeNameConverter);
+  }
+
+  @Override
+  public SchemaTypeTable cloneEmpty(String packageName) {
+    return new SchemaTypeTable(typeTable.cloneEmpty(packageName), typeNameConverter);
   }
 
   /** Compute the nickname for the given fullName and save it in the import set. */

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.SchemaTypeNameConverter.BoxingBehavior;
 import com.google.api.codegen.util.TypeAlias;
@@ -127,6 +128,11 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
   @Override
   public String getFullNameFor(FieldModel type) {
     return getFullNameFor(type.getDiscoveryField());
+  }
+
+  @Override
+  public String getFullNameFor(InterfaceModel type) {
+    return type.getFullName();
   }
 
   /** Get the full name for the element type of the given type. */

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.transformer.SchemaTypeNameConverter.BoxingBehavior;
 import com.google.api.codegen.util.TypeAlias;
@@ -64,7 +64,7 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
   }
 
   @Override
-  public String getEnumValue(FieldType type, String value) {
+  public String getEnumValue(FieldModel type, String value) {
     return getNotImplementedString("SchemaTypeTable.getFullNameFor(TypeRef type)");
   }
 
@@ -125,25 +125,25 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
 
   /** Get the full name for the given type. */
   @Override
-  public String getFullNameFor(FieldType type) {
+  public String getFullNameFor(FieldModel type) {
     return getFullNameFor(type.getDiscoveryField());
   }
 
   /** Get the full name for the element type of the given type. */
   @Override
-  public String getFullNameForElementType(FieldType type) {
+  public String getFullNameForElementType(FieldModel type) {
     return getFullNameForElementType(type.getDiscoveryField());
   }
 
   /** Returns the nickname for the given type (without adding the full name to the import set). */
   @Override
-  public String getNicknameFor(FieldType type) {
+  public String getNicknameFor(FieldModel type) {
     return typeFormatter.getNicknameFor(type);
   }
 
   /** Renders the primitive value of the given type. */
   @Override
-  public String renderPrimitiveValue(FieldType type, String key) {
+  public String renderPrimitiveValue(FieldModel type, String key) {
     return renderPrimitiveValue(type.getDiscoveryField(), key);
   }
 
@@ -152,7 +152,7 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
    * nickname.
    */
   @Override
-  public String getAndSaveNicknameFor(FieldType type) {
+  public String getAndSaveNicknameFor(FieldModel type) {
     return typeTable.getAndSaveNicknameFor(typeNameConverter.getTypeName(type.getDiscoveryField()));
   }
 
@@ -171,7 +171,7 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
   }
 
   @Override
-  public String getAndSaveNicknameForElementType(FieldType type) {
+  public String getAndSaveNicknameForElementType(FieldModel type) {
     return getAndSaveNicknameFor(type.getDiscoveryField());
   }
 
@@ -183,14 +183,14 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
   }
 
   @Override
-  public String getSnippetZeroValueAndSaveNicknameFor(FieldType type) {
+  public String getSnippetZeroValueAndSaveNicknameFor(FieldModel type) {
     return typeNameConverter
         .getSnippetZeroValue(type.getDiscoveryField())
         .getValueAndSaveTypeNicknameIn(typeTable);
   }
 
   @Override
-  public String getImplZeroValueAndSaveNicknameFor(FieldType type) {
+  public String getImplZeroValueAndSaveNicknameFor(FieldModel type) {
     return typeNameConverter
         .getImplZeroValue(type.getDiscoveryField())
         .getValueAndSaveTypeNicknameIn(typeTable);

--- a/src/main/java/com/google/api/codegen/transformer/ServiceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ServiceTransformer.java
@@ -22,12 +22,12 @@ import com.google.common.collect.ImmutableList;
 public class ServiceTransformer {
 
   public ServiceDocView generateServiceDoc(
-      GapicInterfaceContext context, ApiMethodView exampleApiMethod) {
+      InterfaceContext context, ApiMethodView exampleApiMethod) {
     SurfaceNamer namer = context.getNamer();
     ServiceDocView.Builder serviceDoc = ServiceDocView.newBuilder();
 
     ImmutableList.Builder<String> docLines = ImmutableList.builder();
-    docLines.addAll(namer.getDocLines(context.getInterface()));
+    docLines.addAll(namer.getDocLines(context.getInterfaceDescription()));
     InterfaceConfig conf = context.getInterfaceConfig();
     if (!conf.getManualDoc().isEmpty()) {
       docLines.add("");
@@ -41,7 +41,7 @@ public class ServiceTransformer {
     serviceDoc.settingsVarName(namer.getApiSettingsVariableName(context.getInterfaceConfig()));
     serviceDoc.settingsClassName(namer.getApiSettingsClassName(context.getInterfaceConfig()));
     serviceDoc.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
-    serviceDoc.serviceTitle(context.getModel().getServiceConfig().getTitle());
+    serviceDoc.serviceTitle(context.serviceTitle());
     return serviceDoc.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/StandardImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardImportSectionTransformer.java
@@ -24,13 +24,13 @@ import java.util.Map;
 
 public class StandardImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(InterfaceContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context) {
     return generateImportSection(context.getImportTypeTable().getImports());
   }
 
   @Override
   public ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes) {
+      MethodContext context, Iterable<InitCodeNode> specItemNodes) {
     return generateImportSection(context.getTypeTable().getImports());
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -623,7 +623,7 @@ public class StaticLangApiMethodTransformer {
             .throwsDocLines(namer.getThrowsDocLines(context.getMethodConfig()))
             .returnsDocLines(
                 namer.getReturnDocLines(
-                    context.getSurfaceInterfaceContext(), context.getMethodConfig(), synchronicity))
+                    context.getSurfaceInterfaceContext(), context, synchronicity))
             .build());
 
     List<RequestObjectParamView> params = new ArrayList<>();
@@ -669,8 +669,7 @@ public class StaticLangApiMethodTransformer {
             .paramDocs(paramDocs)
             .throwsDocLines(namer.getThrowsDocLines(context.getMethodConfig()))
             .returnsDocLines(
-                namer.getReturnDocLines(
-                    context.getSurfaceInterfaceContext(), context.getMethodConfig(), sync))
+                namer.getReturnDocLines(context.getSurfaceInterfaceContext(), context, sync))
             .build());
     // TODO(andrealin): refactor InitCodeView/Transformer to be API source agsnostic.
     InitCodeView initCode = null;
@@ -740,7 +739,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.pathTemplateChecks(new ArrayList<PathTemplateCheckView>());
 
     String genericAwareResponseTypeFullName =
-        context.getNamer().getGenericAwareResponseTypeName(method);
+        context.getNamer().getGenericAwareResponseTypeName(context);
     String genericAwareResponseType =
         context.getTypeTable().getAndSaveNicknameFor(genericAwareResponseTypeFullName);
     methodViewBuilder.callableMethod(
@@ -752,10 +751,8 @@ public class StaticLangApiMethodTransformer {
 
   private void setStaticLangAsyncReturnTypeName(
       MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
-    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
-    String returnTypeFullName =
-        namer.getStaticLangAsyncReturnTypeName(method, context.getMethodConfig());
+    String returnTypeFullName = namer.getStaticLangAsyncReturnTypeName(context);
     String returnTypeNickname = context.getTypeTable().getAndSaveNicknameFor(returnTypeFullName);
     methodViewBuilder.responseTypeName(returnTypeNickname);
   }
@@ -764,8 +761,7 @@ public class StaticLangApiMethodTransformer {
       MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
     MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
-    String returnTypeFullName =
-        namer.getStaticLangReturnTypeName(method, context.getMethodConfig());
+    String returnTypeFullName = namer.getStaticLangReturnTypeName(context);
     String returnTypeNickname = context.getTypeTable().getAndSaveNicknameFor(returnTypeFullName);
     methodViewBuilder.responseTypeName(returnTypeNickname);
   }

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -70,7 +70,8 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(
+            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
 
@@ -107,7 +108,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), method));
+        namer.getApiMethodExampleName(context.getInterfaceModel().getSimpleName(), method));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
@@ -223,7 +224,8 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(
+            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
     methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     setStaticLangReturnTypeName(context, methodViewBuilder);
@@ -246,7 +248,8 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(
+            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(method),
@@ -314,7 +317,7 @@ public class StaticLangApiMethodTransformer {
         context
             .getNamer()
             .getGrpcStreamingApiMethodExampleName(
-                context.getInterfaceSimpleName(), context.getMethodModel()));
+                context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context, namer.getCallableMethodName(method), Synchronicity.Sync, methodViewBuilder);
     setStaticLangGrpcStreamingReturnTypeName(context, methodViewBuilder);
@@ -338,7 +341,8 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(
+            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(method),
@@ -366,7 +370,8 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(
+            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
     methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
@@ -494,7 +499,7 @@ public class StaticLangApiMethodTransformer {
 
     methodViewBuilder.apiClassName(namer.getApiWrapperClassName(interfaceConfig));
     methodViewBuilder.apiVariableName(namer.getApiWrapperVariableName(interfaceConfig));
-    methodViewBuilder.stubName(namer.getStubName(context.getTargetInterfaceSimpleName()));
+    methodViewBuilder.stubName(namer.getStubName(context.getTargetInterface().getSimpleName()));
     methodViewBuilder.settingsGetterName(namer.getSettingsFunctionName(method));
     methodViewBuilder.callableName(context.getNamer().getCallableName(method));
     methodViewBuilder.modifyMethodName(namer.getModifyMethodName(context));
@@ -807,7 +812,8 @@ public class StaticLangApiMethodTransformer {
         check.pathTemplateName(
             context
                 .getNamer()
-                .getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig));
+                .getPathTemplateName(
+                    context.getInterfaceModel().getSimpleName(), resourceNameConfig));
         check.paramName(context.getNamer().getVariableName(field));
         check.allowEmptyString(shouldAllowEmpty(context, field));
         check.validationMessageContext(

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -18,7 +18,7 @@ import static com.google.api.codegen.config.ApiSource.PROTO;
 
 import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -545,7 +545,7 @@ public class StaticLangApiMethodTransformer {
         method.getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer());
 
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
-    FieldType resourceField = resourceFieldConfig.getField();
+    FieldModel resourceField = resourceFieldConfig.getField();
 
     String resourceTypeName;
 
@@ -787,7 +787,7 @@ public class StaticLangApiMethodTransformer {
         // Don't generate a path template check if fieldConfig is not configured to use validation.
         continue;
       }
-      FieldType field = fieldConfig.getField();
+      FieldModel field = fieldConfig.getField();
       ImmutableMap<String, String> fieldNamePatterns =
           context.getMethodConfig().getFieldNamePatterns();
       String entityName = fieldNamePatterns.get(field.getSimpleName());
@@ -821,8 +821,8 @@ public class StaticLangApiMethodTransformer {
     return pathTemplateChecks;
   }
 
-  private boolean shouldAllowEmpty(MethodContext context, FieldType field) {
-    for (FieldType requiredField : context.getMethodConfig().getRequiredFields()) {
+  private boolean shouldAllowEmpty(MethodContext context, FieldModel field) {
+    for (FieldModel requiredField : context.getMethodConfig().getRequiredFields()) {
       if (requiredField.equals(field)) {
         return false;
       }
@@ -835,11 +835,11 @@ public class StaticLangApiMethodTransformer {
     SurfaceNamer namer = context.getNamer();
     FeatureConfig featureConfig = context.getFeatureConfig();
     ImportTypeTable typeTable = context.getTypeTable();
-    FieldType field = fieldConfig.getField();
+    FieldModel field = fieldConfig.getField();
 
-    Iterable<FieldType> requiredFields = context.getMethodConfig().getRequiredFields();
+    Iterable<FieldModel> requiredFields = context.getMethodConfig().getRequiredFields();
     boolean isRequired = false;
-    for (FieldType f : requiredFields) {
+    for (FieldModel f : requiredFields) {
       if (f.getSimpleName().equals(field.getSimpleName())) {
         isRequired = true;
       }
@@ -915,7 +915,7 @@ public class StaticLangApiMethodTransformer {
       return allDocs;
     }
     for (FieldConfig fieldConfig : fieldConfigs) {
-      FieldType field = fieldConfig.getField();
+      FieldModel field = fieldConfig.getField();
       SimpleParamDocView.Builder paramDoc = SimpleParamDocView.newBuilder();
       paramDoc.paramName(context.getNamer().getVariableName(field));
       paramDoc.typeName(context.getTypeTable().getAndSaveNicknameFor(field));

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -14,10 +14,14 @@
  */
 package com.google.api.codegen.transformer;
 
+import static com.google.api.codegen.config.ApiSource.PROTO;
+
 import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.metacode.InitCodeContext;
@@ -26,6 +30,7 @@ import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.ApiMethodDocView;
 import com.google.api.codegen.viewmodel.CallableMethodDetailView;
 import com.google.api.codegen.viewmodel.ClientMethodType;
+import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.ListMethodDetailView;
 import com.google.api.codegen.viewmodel.ParamDocView;
 import com.google.api.codegen.viewmodel.PathTemplateCheckView;
@@ -51,65 +56,62 @@ public class StaticLangApiMethodTransformer {
   private final InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
   private final LongRunningTransformer lroTransformer = new LongRunningTransformer();
 
-  public StaticLangApiMethodView generatePagedFlattenedMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generatePagedFlattenedMethod(MethodContext context) {
     return generatePagedFlattenedMethod(context, Collections.<ParamWithSimpleDoc>emptyList());
   }
 
   public StaticLangApiMethodView generatePagedFlattenedMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+        namer.getApiMethodName(
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.PagedFlattenedMethod).build();
   }
 
-  public StaticLangApiMethodView generatePagedFlattenedAsyncMethod(GapicMethodContext context) {
-    return generatePagedFlattenedAsyncMethod(context, Collections.<ParamWithSimpleDoc>emptyList());
-  }
-
   public StaticLangApiMethodView generatePagedFlattenedAsyncMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel methodModel = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getAsyncApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
-    methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getAsyncApiMethodName(methodModel, context.getMethodConfig().getVisibility()));
+    methodViewBuilder.exampleName(namer.getAsyncApiMethodExampleName(methodModel));
     setListMethodFields(context, Synchronicity.Async, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Async, methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.PagedFlattenedAsyncMethod).build();
   }
 
-  public StaticLangApiMethodView generatePagedRequestObjectMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generatePagedRequestObjectMethod(MethodContext context) {
     return generatePagedRequestObjectMethod(context, Collections.<ParamWithSimpleDoc>emptyList());
   }
 
   public StaticLangApiMethodView generatePagedRequestObjectMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+        namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), method));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
-        namer.getPagedCallableMethodName(context.getMethod()),
+        namer.getPagedCallableMethodName(method),
         Synchronicity.Sync,
         additionalParams,
         methodViewBuilder);
@@ -118,20 +120,20 @@ public class StaticLangApiMethodTransformer {
   }
 
   public StaticLangApiMethodView generatePagedRequestObjectAsyncMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
         namer.getAsyncApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
-    methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
+    methodViewBuilder.exampleName(namer.getAsyncApiMethodExampleName(method));
     setListMethodFields(context, Synchronicity.Async, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
-        namer.getPagedCallableMethodName(context.getMethod()),
+        namer.getPagedCallableMethodName(method),
         Synchronicity.Async,
         additionalParams,
         methodViewBuilder);
@@ -139,31 +141,30 @@ public class StaticLangApiMethodTransformer {
     return methodViewBuilder.type(ClientMethodType.AsyncPagedRequestObjectMethod).build();
   }
 
-  public StaticLangApiMethodView generatePagedCallableMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generatePagedCallableMethod(MethodContext context) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getPagedCallableMethodName(context.getMethod()));
-    methodViewBuilder.exampleName(
-        namer.getPagedCallableMethodExampleName(context.getInterface(), context.getMethod()));
+    methodViewBuilder.name(namer.getPagedCallableMethodName(method));
+    methodViewBuilder.exampleName(namer.getPagedCallableMethodExampleName(method));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
-    setCallableMethodFields(
-        context, namer.getPagedCallableName(context.getMethod()), methodViewBuilder);
+    setCallableMethodFields(context, namer.getPagedCallableName(method), methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.PagedCallableMethod).build();
   }
 
-  public StaticLangApiMethodView generateUnpagedListCallableMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateUnpagedListCallableMethod(MethodContext context) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getCallableMethodName(context.getMethod()));
-    methodViewBuilder.exampleName(
-        namer.getCallableMethodExampleName(context.getInterface(), context.getMethod()));
+    methodViewBuilder.name(namer.getCallableMethodName(method));
+    methodViewBuilder.exampleName(namer.getCallableMethodExampleName(method));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
-    setCallableMethodFields(context, namer.getCallableName(context.getMethod()), methodViewBuilder);
+    setCallableMethodFields(context, namer.getCallableName(method), methodViewBuilder);
 
     String getResourceListCallName =
         namer.getFieldGetFunctionName(
@@ -177,74 +178,78 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.unpagedListCallableMethod(unpagedListCallableDetails);
 
     methodViewBuilder.responseTypeName(
-        context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType()));
+        context
+            .getMethodModel()
+            .getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer()));
 
     return methodViewBuilder.type(ClientMethodType.UnpagedListCallableMethod).build();
   }
 
   public StaticLangApiMethodView generateFlattenedAsyncMethod(
-      GapicMethodContext context, ClientMethodType type) {
+      MethodContext context, ClientMethodType type) {
     return generateFlattenedAsyncMethod(context, Collections.<ParamWithSimpleDoc>emptyList(), type);
   }
 
   public StaticLangApiMethodView generateFlattenedAsyncMethod(
-      GapicMethodContext context,
-      List<ParamWithSimpleDoc> additionalParams,
-      ClientMethodType type) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams, ClientMethodType type) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
         namer.getAsyncApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
-    methodViewBuilder.exampleName(
-        namer.getCallableMethodExampleName(context.getInterface(), context.getMethod()));
-    methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
+    methodViewBuilder.exampleName(namer.getCallableMethodExampleName(method));
+    methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Async, methodViewBuilder);
     setStaticLangAsyncReturnTypeName(context, methodViewBuilder);
 
     return methodViewBuilder.type(type).build();
   }
 
-  public StaticLangApiMethodView generateFlattenedMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateFlattenedMethod(MethodContext context) {
     return generateFlattenedMethod(context, Collections.<ParamWithSimpleDoc>emptyList());
   }
 
   public StaticLangApiMethodView generateFlattenedMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+        namer.getApiMethodName(
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
-    methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+    methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     setStaticLangReturnTypeName(context, methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.FlattenedMethod).build();
   }
 
-  public StaticLangApiMethodView generateRequestObjectMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateRequestObjectMethod(MethodContext context) {
     return generateRequestObjectMethod(context, Collections.<ParamWithSimpleDoc>emptyList());
   }
 
   public StaticLangApiMethodView generateRequestObjectMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+        namer.getApiMethodName(
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context,
-        namer.getCallableMethodName(context.getMethod()),
+        namer.getCallableMethodName(method),
         Synchronicity.Sync,
         additionalParams,
         methodViewBuilder);
@@ -253,24 +258,24 @@ public class StaticLangApiMethodTransformer {
     return methodViewBuilder.type(ClientMethodType.RequestObjectMethod).build();
   }
 
-  public StaticLangApiMethodView generateRequestObjectAsyncMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateRequestObjectAsyncMethod(MethodContext context) {
     return generateRequestObjectAsyncMethod(context, Collections.<ParamWithSimpleDoc>emptyList());
   }
 
   public StaticLangApiMethodView generateRequestObjectAsyncMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
         namer.getAsyncApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
-    methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
+    methodViewBuilder.exampleName(namer.getAsyncApiMethodExampleName(method));
     setRequestObjectMethodFields(
         context,
-        namer.getCallableAsyncMethodName(context.getMethod()),
+        namer.getCallableAsyncMethodName(method),
         Synchronicity.Async,
         additionalParams,
         methodViewBuilder);
@@ -279,94 +284,100 @@ public class StaticLangApiMethodTransformer {
     return methodViewBuilder.type(ClientMethodType.AsyncRequestObjectMethod).build();
   }
 
-  public StaticLangApiMethodView generateCallableMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateCallableMethod(MethodContext context) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getCallableMethodName(context.getMethod()));
-    methodViewBuilder.exampleName(
-        context
-            .getNamer()
-            .getCallableMethodExampleName(context.getInterface(), context.getMethod()));
-    setCallableMethodFields(context, namer.getCallableName(context.getMethod()), methodViewBuilder);
+    methodViewBuilder.name(namer.getCallableMethodName(method));
+    methodViewBuilder.exampleName(context.getNamer().getCallableMethodExampleName(method));
+    setCallableMethodFields(context, namer.getCallableName(method), methodViewBuilder);
     methodViewBuilder.responseTypeName(
-        context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType()));
+        context
+            .getMethodModel()
+            .getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer()));
 
     return methodViewBuilder.type(ClientMethodType.CallableMethod).build();
   }
 
-  public StaticLangApiMethodView generateGrpcStreamingRequestObjectMethod(
-      GapicMethodContext context) {
+  public StaticLangApiMethodView generateGrpcStreamingRequestObjectMethod(MethodContext context) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
         namer.getGrpcStreamingApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
         context
             .getNamer()
-            .getGrpcStreamingApiMethodExampleName(context.getInterface(), context.getMethod()));
+            .getGrpcStreamingApiMethodExampleName(
+                context.getInterfaceSimpleName(), context.getMethodModel()));
     setRequestObjectMethodFields(
-        context,
-        namer.getCallableMethodName(context.getMethod()),
-        Synchronicity.Sync,
-        methodViewBuilder);
+        context, namer.getCallableMethodName(method), Synchronicity.Sync, methodViewBuilder);
     setStaticLangGrpcStreamingReturnTypeName(context, methodViewBuilder);
 
     return methodViewBuilder.type(ClientMethodType.RequestObjectMethod).build();
   }
 
-  public StaticLangApiMethodView generateOperationRequestObjectMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateOperationRequestObjectMethod(MethodContext context) {
     return generateOperationRequestObjectMethod(
         context, Collections.<ParamWithSimpleDoc>emptyList());
   }
 
   public StaticLangApiMethodView generateOperationRequestObjectMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+        namer.getApiMethodName(
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context,
-        namer.getCallableMethodName(context.getMethod()),
+        namer.getCallableMethodName(method),
         Synchronicity.Sync,
         additionalParams,
         methodViewBuilder);
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
-    TypeRef returnType = context.getMethodConfig().getLongRunningConfig().getReturnType();
-    methodViewBuilder.responseTypeName(context.getTypeTable().getAndSaveNicknameFor(returnType));
+    methodViewBuilder.responseTypeName(
+        context
+            .getMethodConfig()
+            .getLongRunningConfig()
+            .getLongRunningOperationReturnTypeName(context.getTypeTable()));
 
     return methodViewBuilder.type(ClientMethodType.OperationRequestObjectMethod).build();
   }
 
   public StaticLangApiMethodView generateOperationFlattenedMethod(
-      GapicMethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+      MethodContext context, List<ParamWithSimpleDoc> additionalParams) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
-        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+        namer.getApiMethodName(
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
-    methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceSimpleName(), context.getMethodModel()));
+    methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
     TypeRef returnType = context.getMethodConfig().getLongRunningConfig().getReturnType();
-    methodViewBuilder.responseTypeName(context.getTypeTable().getAndSaveNicknameFor(returnType));
+    methodViewBuilder.responseTypeName(
+        ((ModelTypeTable) context.getTypeTable()).getAndSaveNicknameFor(returnType));
 
     return methodViewBuilder.type(ClientMethodType.OperationFlattenedMethod).build();
   }
 
-  public StaticLangApiMethodView generateAsyncOperationFlattenedMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateAsyncOperationFlattenedMethod(MethodContext context) {
     return generateAsyncOperationFlattenedMethod(
         context,
         Collections.<ParamWithSimpleDoc>emptyList(),
@@ -375,103 +386,118 @@ public class StaticLangApiMethodTransformer {
   }
 
   public StaticLangApiMethodView generateAsyncOperationFlattenedMethod(
-      GapicMethodContext context,
+      MethodContext context,
       List<ParamWithSimpleDoc> additionalParams,
       ClientMethodType type,
       boolean requiresOperationMethod) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
         namer.getAsyncApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
-    methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
-    methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
+    methodViewBuilder.exampleName(namer.getAsyncApiMethodExampleName(method));
+    methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Async, methodViewBuilder);
     if (requiresOperationMethod) {
       methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
     }
-    TypeRef returnType = context.getMethodConfig().getLongRunningConfig().getReturnType();
-    methodViewBuilder.responseTypeName(context.getTypeTable().getAndSaveNicknameFor(returnType));
+    methodViewBuilder.responseTypeName(
+        context
+            .getMethodConfig()
+            .getLongRunningConfig()
+            .getLongRunningOperationReturnTypeName(context.getTypeTable()));
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
 
     return methodViewBuilder.type(type).build();
   }
 
-  public StaticLangApiMethodView generateAsyncOperationRequestObjectMethod(
-      GapicMethodContext context) {
+  public StaticLangApiMethodView generateAsyncOperationRequestObjectMethod(MethodContext context) {
     return generateAsyncOperationRequestObjectMethod(
         context, Collections.<ParamWithSimpleDoc>emptyList(), false);
   }
 
   public StaticLangApiMethodView generateAsyncOperationRequestObjectMethod(
-      GapicMethodContext context,
+      MethodContext context,
       List<ParamWithSimpleDoc> additionalParams,
       boolean requiresOperationMethod) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(
         namer.getAsyncApiMethodName(
-            context.getMethod(), context.getMethodConfig().getVisibility()));
-    methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+            context.getMethodModel(), context.getMethodConfig().getVisibility()));
+    methodViewBuilder.exampleName(namer.getAsyncApiMethodExampleName(method));
     setRequestObjectMethodFields(
         context,
-        namer.getOperationCallableMethodName(context.getMethod()),
+        namer.getOperationCallableMethodName(method),
         Synchronicity.Async,
         additionalParams,
         methodViewBuilder);
     if (requiresOperationMethod) {
+      // Only for protobuf-based APIs.
       methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
     }
-    TypeRef returnType = context.getMethodConfig().getLongRunningConfig().getReturnType();
-    methodViewBuilder.responseTypeName(context.getTypeTable().getAndSaveNicknameFor(returnType));
-    methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
-
+    if (context.getMethodConfig().isLongRunningOperation()) {
+      // Only for protobuf-based APIs.
+      methodViewBuilder.responseTypeName(
+          context
+              .getMethodConfig()
+              .getLongRunningConfig()
+              .getLongRunningOperationReturnTypeName(context.getTypeTable()));
+      methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
+    } else {
+      throw new IllegalArgumentException(
+          "Discovery-based APIs do not have LongRunning operations.");
+    }
     return methodViewBuilder.type(ClientMethodType.AsyncOperationRequestObjectMethod).build();
   }
 
-  public StaticLangApiMethodView generateOperationCallableMethod(GapicMethodContext context) {
+  public StaticLangApiMethodView generateOperationCallableMethod(MethodContext context) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getOperationCallableMethodName(context.getMethod()));
-    methodViewBuilder.exampleName(
-        context
-            .getNamer()
-            .getOperationCallableMethodExampleName(context.getInterface(), context.getMethod()));
-    setCallableMethodFields(
-        context, namer.getOperationCallableName(context.getMethod()), methodViewBuilder);
+    methodViewBuilder.name(namer.getOperationCallableMethodName(method));
+    methodViewBuilder.exampleName(context.getNamer().getOperationCallableMethodExampleName(method));
+    setCallableMethodFields(context, namer.getOperationCallableName(method), methodViewBuilder);
     TypeRef returnType = context.getMethodConfig().getLongRunningConfig().getReturnType();
-    methodViewBuilder.responseTypeName(context.getTypeTable().getAndSaveNicknameFor(returnType));
+    methodViewBuilder.responseTypeName(
+        context
+            .getMethodConfig()
+            .getLongRunningConfig()
+            .getLongRunningOperationReturnTypeName(context.getTypeTable()));
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
 
     return methodViewBuilder.type(ClientMethodType.OperationCallableMethod).build();
   }
 
   private void setCommonFields(
-      GapicMethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+      MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
 
     String requestTypeName =
-        context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getInputType());
+        context
+            .getMethodModel()
+            .getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer());
     methodViewBuilder.serviceRequestTypeName(requestTypeName);
     methodViewBuilder.serviceRequestTypeConstructor(namer.getTypeConstructor(requestTypeName));
 
     setServiceResponseTypeName(context, methodViewBuilder);
 
-    methodViewBuilder.apiClassName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    methodViewBuilder.apiVariableName(
-        namer.getApiWrapperVariableName(context.getInterfaceConfig()));
-    methodViewBuilder.stubName(namer.getStubName(context.getTargetInterface()));
-    methodViewBuilder.settingsGetterName(namer.getSettingsFunctionName(context.getMethod()));
-    methodViewBuilder.callableName(context.getNamer().getCallableName(context.getMethod()));
-    methodViewBuilder.modifyMethodName(namer.getModifyMethodName(context.getMethod()));
+    methodViewBuilder.apiClassName(namer.getApiWrapperClassName(interfaceConfig));
+    methodViewBuilder.apiVariableName(namer.getApiWrapperVariableName(interfaceConfig));
+    methodViewBuilder.stubName(namer.getStubName(context.getTargetInterfaceSimpleName()));
+    methodViewBuilder.settingsGetterName(namer.getSettingsFunctionName(method));
+    methodViewBuilder.callableName(context.getNamer().getCallableName(method));
+    methodViewBuilder.modifyMethodName(namer.getModifyMethodName(context));
     methodViewBuilder.grpcStreamingType(context.getMethodConfig().getGrpcStreamingType());
     methodViewBuilder.visibility(
         namer.getVisiblityKeyword(context.getMethodConfig().getVisibility()));
@@ -483,34 +509,40 @@ public class StaticLangApiMethodTransformer {
       methodViewBuilder.hasReturnValue(
           !messages.isEmptyType(context.getMethodConfig().getLongRunningConfig().getReturnType()));
     } else {
-      methodViewBuilder.hasReturnValue(!messages.isEmptyType(context.getMethod().getOutputType()));
+      methodViewBuilder.hasReturnValue(method.hasReturnValue());
     }
   }
 
   protected void setServiceResponseTypeName(
-      GapicMethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+      MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
     SurfaceNamer namer = context.getNamer();
     if (context.getMethodConfig().isGrpcStreaming()) {
+      // Only applicable for protobuf APIs.
       String returnTypeFullName =
-          namer.getGrpcStreamingApiReturnTypeName(context.getMethod(), context.getTypeTable());
+          namer.getGrpcStreamingApiReturnTypeName(context, context.getTypeTable());
       String returnTypeNickname = context.getTypeTable().getAndSaveNicknameFor(returnTypeFullName);
       methodViewBuilder.serviceResponseTypeName(returnTypeNickname);
     } else {
       String responseTypeName =
-          context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType());
+          context
+              .getMethodModel()
+              .getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer());
       methodViewBuilder.serviceResponseTypeName(responseTypeName);
     }
   }
 
   private void setListMethodFields(
-      GapicMethodContext context,
+      MethodContext context,
       Synchronicity synchronicity,
       StaticLangApiMethodView.Builder methodViewBuilder) {
-    ModelTypeTable typeTable = context.getTypeTable();
+    MethodModel method = context.getMethodModel();
+    ImportTypeTable typeTable = context.getTypeTable();
     SurfaceNamer namer = context.getNamer();
     PageStreamingConfig pageStreaming = context.getMethodConfig().getPageStreaming();
-    String requestTypeName = typeTable.getAndSaveNicknameFor(context.getMethod().getInputType());
-    String responseTypeName = typeTable.getAndSaveNicknameFor(context.getMethod().getOutputType());
+    String requestTypeName =
+        method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer());
+    String responseTypeName =
+        method.getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer());
 
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
     FieldType resourceField = resourceFieldConfig.getField();
@@ -545,39 +577,53 @@ public class StaticLangApiMethodTransformer {
     switch (synchronicity) {
       case Sync:
         methodViewBuilder.responseTypeName(
-            namer.getAndSavePagedResponseTypeName(
-                context.getMethod(), context.getTypeTable(), resourceFieldConfig));
+            namer.getAndSavePagedResponseTypeName(context, resourceFieldConfig));
         break;
       case Async:
         methodViewBuilder.responseTypeName(
-            namer.getAndSaveAsyncPagedResponseTypeName(
-                context.getMethod(), context.getTypeTable(), resourceFieldConfig));
+            namer.getAndSaveAsyncPagedResponseTypeName(context, resourceFieldConfig));
         break;
     }
   }
 
   private void setFlattenedMethodFields(
-      GapicMethodContext context,
+      MethodContext context,
       List<ParamWithSimpleDoc> additionalParams,
       Synchronicity synchronicity,
       StaticLangApiMethodView.Builder methodViewBuilder) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     Iterable<FieldConfig> fieldConfigs =
         context.getFlatteningConfig().getFlattenedFieldConfigs().values();
-    methodViewBuilder.initCode(
-        initCodeTransformer.generateInitCode(
-            context.cloneWithEmptyTypeTable(),
-            createInitCodeContext(context, fieldConfigs, InitCodeOutputType.FieldList)));
+
+    // TODO(andrealin): refactor InitCodeView/Transformer to be API source agsnostic.
+    InitCodeView initCode = null;
+    switch (context.getApiSource()) {
+      case DISCOVERY:
+        DiscoGapicMethodContext discoGapicMethodContext = (DiscoGapicMethodContext) context;
+        initCode = initCodeTransformer.generateInitCode(discoGapicMethodContext, null);
+        break;
+      case PROTO:
+        GapicMethodContext gapicMethodContext = (GapicMethodContext) context;
+        initCode =
+            initCodeTransformer.generateInitCode(
+                gapicMethodContext.cloneWithEmptyTypeTable(),
+                createInitCodeContext(
+                    gapicMethodContext, fieldConfigs, InitCodeOutputType.FieldList));
+        break;
+      default:
+        throw new IllegalArgumentException("Unhandled ApiSource type.");
+    }
+
+    methodViewBuilder.initCode(initCode);
     methodViewBuilder.doc(
         ApiMethodDocView.newBuilder()
-            .mainDocLines(namer.getDocLines(context.getMethod(), context.getMethodConfig()))
+            .mainDocLines(namer.getDocLines(method, context.getMethodConfig()))
             .paramDocs(getMethodParamDocs(context, fieldConfigs, additionalParams))
             .throwsDocLines(namer.getThrowsDocLines(context.getMethodConfig()))
             .returnsDocLines(
                 namer.getReturnDocLines(
-                    context.getSurfaceTransformerContext(),
-                    context.getMethodConfig(),
-                    synchronicity))
+                    context.getSurfaceInterfaceContext(), context.getMethodConfig(), synchronicity))
             .build());
 
     List<RequestObjectParamView> params = new ArrayList<>();
@@ -594,7 +640,7 @@ public class StaticLangApiMethodTransformer {
   }
 
   private void setRequestObjectMethodFields(
-      GapicMethodContext context,
+      MethodContext context,
       String callableMethodName,
       Synchronicity sync,
       StaticLangApiMethodView.Builder methodViewBuilder) {
@@ -607,31 +653,47 @@ public class StaticLangApiMethodTransformer {
   }
 
   private void setRequestObjectMethodFields(
-      GapicMethodContext context,
+      MethodContext context,
       String callableMethodName,
       Synchronicity sync,
       List<ParamWithSimpleDoc> additionalParams,
       StaticLangApiMethodView.Builder methodViewBuilder) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     List<ParamDocView> paramDocs = new ArrayList<>();
-    paramDocs.addAll(getRequestObjectParamDocs(context, context.getMethod().getInputType()));
+    paramDocs.addAll(getRequestObjectParamDocs(context));
     paramDocs.addAll(ParamWithSimpleDoc.asParamDocViews(additionalParams));
     methodViewBuilder.doc(
         ApiMethodDocView.newBuilder()
-            .mainDocLines(namer.getDocLines(context.getMethod(), context.getMethodConfig()))
+            .mainDocLines(namer.getDocLines(method, context.getMethodConfig()))
             .paramDocs(paramDocs)
             .throwsDocLines(namer.getThrowsDocLines(context.getMethodConfig()))
             .returnsDocLines(
                 namer.getReturnDocLines(
-                    context.getSurfaceTransformerContext(), context.getMethodConfig(), sync))
+                    context.getSurfaceInterfaceContext(), context.getMethodConfig(), sync))
             .build());
-    methodViewBuilder.initCode(
-        initCodeTransformer.generateInitCode(
-            context.cloneWithEmptyTypeTable(),
-            createInitCodeContext(
-                context,
-                context.getMethodConfig().getRequiredFieldConfigs(),
-                InitCodeOutputType.SingleObject)));
+    // TODO(andrealin): refactor InitCodeView/Transformer to be API source agsnostic.
+    InitCodeView initCode = null;
+    switch (context.getApiSource()) {
+      case DISCOVERY:
+        DiscoGapicMethodContext discoGapicMethodContext = (DiscoGapicMethodContext) context;
+        initCode = initCodeTransformer.generateInitCode(discoGapicMethodContext, null);
+        break;
+      case PROTO:
+        GapicMethodContext gapicMethodContext = (GapicMethodContext) context;
+        initCode =
+            initCodeTransformer.generateInitCode(
+                context.cloneWithEmptyTypeTable(),
+                createInitCodeContext(
+                    gapicMethodContext,
+                    context.getMethodConfig().getRequiredFieldConfigs(),
+                    InitCodeOutputType.SingleObject));
+        break;
+      default:
+        throw new IllegalArgumentException("Unhandled ApiSource type.");
+    }
+
+    methodViewBuilder.initCode(initCode);
 
     methodViewBuilder.methodParams(new ArrayList<RequestObjectParamView>());
     methodViewBuilder.requestObjectParams(new ArrayList<RequestObjectParamView>());
@@ -650,28 +712,35 @@ public class StaticLangApiMethodTransformer {
   }
 
   private void setCallableMethodFields(
-      GapicMethodContext context, String callableName, Builder methodViewBuilder) {
+      MethodContext context, String callableName, Builder methodViewBuilder) {
+    MethodModel method = context.getMethodModel();
     methodViewBuilder.doc(
         ApiMethodDocView.newBuilder()
-            .mainDocLines(
-                context.getNamer().getDocLines(context.getMethod(), context.getMethodConfig()))
+            .mainDocLines(context.getNamer().getDocLines(method, context.getMethodConfig()))
             .paramDocs(new ArrayList<ParamDocView>())
             .throwsDocLines(new ArrayList<String>())
             .build());
-    methodViewBuilder.initCode(
-        initCodeTransformer.generateInitCode(
-            context.cloneWithEmptyTypeTable(),
-            createInitCodeContext(
-                context,
-                context.getMethodConfig().getRequiredFieldConfigs(),
-                InitCodeOutputType.SingleObject)));
+    // TODO(andrealin): implement initCode for Discovery and remove the ApiSource check and casting.
+    if (context.getApiSource().equals(PROTO)) {
+      methodViewBuilder.initCode(
+          initCodeTransformer.generateInitCode(
+              (GapicMethodContext) context.cloneWithEmptyTypeTable(),
+              createInitCodeContext(
+                  (GapicMethodContext) context,
+                  context.getMethodConfig().getRequiredFieldConfigs(),
+                  InitCodeOutputType.SingleObject)));
+    } else {
+      methodViewBuilder.initCode(
+          initCodeTransformer.generateInitCode(
+              ((DiscoGapicMethodContext) context).cloneWithEmptyTypeTable(), null));
+    }
 
     methodViewBuilder.methodParams(new ArrayList<RequestObjectParamView>());
     methodViewBuilder.requestObjectParams(new ArrayList<RequestObjectParamView>());
     methodViewBuilder.pathTemplateChecks(new ArrayList<PathTemplateCheckView>());
 
     String genericAwareResponseTypeFullName =
-        context.getNamer().getGenericAwareResponseTypeName(context.getMethod().getOutputType());
+        context.getNamer().getGenericAwareResponseTypeName(method);
     String genericAwareResponseType =
         context.getTypeTable().getAndSaveNicknameFor(genericAwareResponseTypeFullName);
     methodViewBuilder.callableMethod(
@@ -682,35 +751,37 @@ public class StaticLangApiMethodTransformer {
   }
 
   private void setStaticLangAsyncReturnTypeName(
-      GapicMethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+      MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     String returnTypeFullName =
-        namer.getStaticLangAsyncReturnTypeName(context.getMethod(), context.getMethodConfig());
+        namer.getStaticLangAsyncReturnTypeName(method, context.getMethodConfig());
     String returnTypeNickname = context.getTypeTable().getAndSaveNicknameFor(returnTypeFullName);
     methodViewBuilder.responseTypeName(returnTypeNickname);
   }
 
   private void setStaticLangReturnTypeName(
-      GapicMethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+      MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+    MethodModel method = context.getMethodModel();
     SurfaceNamer namer = context.getNamer();
     String returnTypeFullName =
-        namer.getStaticLangReturnTypeName(context.getMethod(), context.getMethodConfig());
+        namer.getStaticLangReturnTypeName(method, context.getMethodConfig());
     String returnTypeNickname = context.getTypeTable().getAndSaveNicknameFor(returnTypeFullName);
     methodViewBuilder.responseTypeName(returnTypeNickname);
   }
 
   private void setStaticLangGrpcStreamingReturnTypeName(
-      GapicMethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+      MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
     SurfaceNamer namer = context.getNamer();
     // use the api return type name as the surface return type name
     String returnTypeFullName =
-        namer.getGrpcStreamingApiReturnTypeName(context.getMethod(), context.getTypeTable());
+        namer.getGrpcStreamingApiReturnTypeName(context, context.getTypeTable());
     String returnTypeNickname = context.getTypeTable().getAndSaveNicknameFor(returnTypeFullName);
     methodViewBuilder.responseTypeName(returnTypeNickname);
   }
 
   private List<PathTemplateCheckView> generatePathTemplateChecks(
-      GapicMethodContext context, Iterable<FieldConfig> fieldConfigs) {
+      MethodContext context, Iterable<FieldConfig> fieldConfigs) {
     List<PathTemplateCheckView> pathTemplateChecks = new ArrayList<>();
     if (!context.getFeatureConfig().enableStringFormatFunctions()) {
       return pathTemplateChecks;
@@ -728,7 +799,7 @@ public class StaticLangApiMethodTransformer {
         SingleResourceNameConfig resourceNameConfig =
             context.getSingleResourceNameConfig(entityName);
         if (resourceNameConfig == null) {
-          String methodName = context.getMethod().getSimpleName();
+          String methodName = context.getMethodModel().getSimpleName();
           throw new IllegalStateException(
               "No collection config with id '"
                   + entityName
@@ -738,20 +809,23 @@ public class StaticLangApiMethodTransformer {
         }
         PathTemplateCheckView.Builder check = PathTemplateCheckView.newBuilder();
         check.pathTemplateName(
-            context.getNamer().getPathTemplateName(context.getInterface(), resourceNameConfig));
+            context
+                .getNamer()
+                .getPathTemplateName(context.getInterfaceSimpleName(), resourceNameConfig));
         check.paramName(context.getNamer().getVariableName(field));
         check.allowEmptyString(shouldAllowEmpty(context, field));
         check.validationMessageContext(
             context
                 .getNamer()
-                .getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
+                .getApiMethodName(
+                    context.getMethodModel(), context.getMethodConfig().getVisibility()));
         pathTemplateChecks.add(check.build());
       }
     }
     return pathTemplateChecks;
   }
 
-  private boolean shouldAllowEmpty(GapicMethodContext context, FieldType field) {
+  private boolean shouldAllowEmpty(MethodContext context, FieldType field) {
     for (FieldType requiredField : context.getMethodConfig().getRequiredFields()) {
       if (requiredField.equals(field)) {
         return false;
@@ -761,10 +835,10 @@ public class StaticLangApiMethodTransformer {
   }
 
   private RequestObjectParamView generateRequestObjectParam(
-      GapicMethodContext context, FieldConfig fieldConfig) {
+      MethodContext context, FieldConfig fieldConfig) {
     SurfaceNamer namer = context.getNamer();
     FeatureConfig featureConfig = context.getFeatureConfig();
-    ModelTypeTable typeTable = context.getTypeTable();
+    ImportTypeTable typeTable = context.getTypeTable();
     FieldType field = fieldConfig.getField();
 
     Iterable<FieldType> requiredFields = context.getMethodConfig().getRequiredFields();
@@ -835,11 +909,12 @@ public class StaticLangApiMethodTransformer {
   }
 
   private List<ParamDocView> getMethodParamDocs(
-      GapicMethodContext context,
+      MethodContext context,
       Iterable<FieldConfig> fieldConfigs,
       List<ParamWithSimpleDoc> additionalParamDocs) {
+    MethodModel method = context.getMethodModel();
     List<ParamDocView> allDocs = new ArrayList<>();
-    if (context.getMethod().getRequestStreaming()) {
+    if (method.getRequestStreaming()) {
       allDocs.addAll(ParamWithSimpleDoc.asParamDocViews(additionalParamDocs));
       return allDocs;
     }
@@ -883,12 +958,12 @@ public class StaticLangApiMethodTransformer {
     return allDocs;
   }
 
-  public List<SimpleParamDocView> getRequestObjectParamDocs(
-      GapicMethodContext context, TypeRef typeRef) {
+  public List<SimpleParamDocView> getRequestObjectParamDocs(MethodContext context) {
+    MethodModel method = context.getMethodModel();
     SimpleParamDocView doc =
         SimpleParamDocView.newBuilder()
             .paramName("request")
-            .typeName(context.getTypeTable().getAndSaveNicknameFor(typeRef))
+            .typeName(method.getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer()))
             .lines(
                 Arrays.<String>asList(
                     "The request object containing all of the parameters for the API call."))

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -70,8 +70,7 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(
-            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(context.getInterfaceModel(), context.getMethodModel()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
 
@@ -108,7 +107,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel().getSimpleName(), method));
+        namer.getApiMethodExampleName(context.getInterfaceModel(), method));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
@@ -224,8 +223,7 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(
-            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(context.getInterfaceModel(), context.getMethodModel()));
     methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     setStaticLangReturnTypeName(context, methodViewBuilder);
@@ -248,8 +246,7 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(
-            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(context.getInterfaceModel(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(method),
@@ -317,7 +314,7 @@ public class StaticLangApiMethodTransformer {
         context
             .getNamer()
             .getGrpcStreamingApiMethodExampleName(
-                context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
+                context.getInterfaceModel(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context, namer.getCallableMethodName(method), Synchronicity.Sync, methodViewBuilder);
     setStaticLangGrpcStreamingReturnTypeName(context, methodViewBuilder);
@@ -341,8 +338,7 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(
-            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(context.getInterfaceModel(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(method),
@@ -370,8 +366,7 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(
-            context.getInterfaceModel().getSimpleName(), context.getMethodModel()));
+        namer.getApiMethodExampleName(context.getInterfaceModel(), context.getMethodModel()));
     methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
@@ -499,7 +494,7 @@ public class StaticLangApiMethodTransformer {
 
     methodViewBuilder.apiClassName(namer.getApiWrapperClassName(interfaceConfig));
     methodViewBuilder.apiVariableName(namer.getApiWrapperVariableName(interfaceConfig));
-    methodViewBuilder.stubName(namer.getStubName(context.getTargetInterface().getSimpleName()));
+    methodViewBuilder.stubName(namer.getStubName(context.getTargetInterface()));
     methodViewBuilder.settingsGetterName(namer.getSettingsFunctionName(method));
     methodViewBuilder.callableName(context.getNamer().getCallableName(method));
     methodViewBuilder.modifyMethodName(namer.getModifyMethodName(context));
@@ -812,8 +807,7 @@ public class StaticLangApiMethodTransformer {
         check.pathTemplateName(
             context
                 .getNamer()
-                .getPathTemplateName(
-                    context.getInterfaceModel().getSimpleName(), resourceNameConfig));
+                .getPathTemplateName(context.getInterfaceModel(), resourceNameConfig));
         check.paramName(context.getNamer().getVariableName(field));
         check.allowEmptyString(shouldAllowEmpty(context, field));
         check.validationMessageContext(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -16,7 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig;
 import com.google.api.codegen.config.InterfaceConfig;
@@ -234,7 +234,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to set the given proto field. */
   public String getFieldSetFunctionName(FeatureConfig featureConfig, FieldConfig fieldConfig) {
-    FieldType field = fieldConfig.getField();
+    FieldModel field = fieldConfig.getField();
     if (featureConfig.useResourceNameFormatOption(fieldConfig)) {
       return getResourceNameFieldSetFunctionName(fieldConfig.getMessageFieldConfig());
     } else {
@@ -243,7 +243,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to set the given proto field. */
-  public String getFieldSetFunctionName(FieldType field) {
+  public String getFieldSetFunctionName(FieldModel field) {
     if (field.isMap()) {
       return publicMethodName(Name.from("put", "all").join(field.asName()));
     } else if (field.isRepeated()) {
@@ -266,7 +266,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to add an element to a map or repeated field. */
-  public String getFieldAddFunctionName(FieldType field) {
+  public String getFieldAddFunctionName(FieldModel field) {
     if (field.isMap()) {
       return publicMethodName(Name.from("put", "all").join(field.getSimpleName()));
     } else if (field.isRepeated()) {
@@ -288,7 +288,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to set a field that is a resource name class. */
   public String getResourceNameFieldSetFunctionName(FieldConfig fieldConfig) {
-    FieldType type = fieldConfig.getField();
+    FieldModel type = fieldConfig.getField();
     Name identifier = Name.from(fieldConfig.getField().getSimpleName());
     Name resourceName = getResourceTypeNameObject(fieldConfig.getResourceNameConfig());
     if (type.isMap()) {
@@ -301,7 +301,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
     }
   }
 
-  public String getFullNameForElementType(FieldType type) {
+  public String getFullNameForElementType(FieldModel type) {
     switch (type.getApiSource()) {
       case PROTO:
         getModelTypeFormatter().getFullNameForElementType(type);
@@ -313,7 +313,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to get the given proto field. */
   public String getFieldGetFunctionName(FeatureConfig featureConfig, FieldConfig fieldConfig) {
-    FieldType field = fieldConfig.getField();
+    FieldModel field = fieldConfig.getField();
     if (featureConfig.useResourceNameFormatOption(fieldConfig)) {
       return getResourceNameFieldGetFunctionName(fieldConfig.getMessageFieldConfig());
     } else {
@@ -322,7 +322,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to get the given proto field. */
-  public String getFieldGetFunctionName(FieldType field) {
+  public String getFieldGetFunctionName(FieldModel field) {
     return getFieldGetFunctionName(field, field.asName());
   }
 
@@ -338,7 +338,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to get a field having the given type and name. */
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     if (type.isRepeated() && !type.isMap()) {
       return publicMethodName(Name.from("get").join(identifier).join("list"));
     } else if (type.isMap()) {
@@ -350,7 +350,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to get a field that is a resource name class. */
   public String getResourceNameFieldGetFunctionName(FieldConfig fieldConfig) {
-    FieldType type = fieldConfig.getField();
+    FieldModel type = fieldConfig.getField();
     Name identifier = Name.from(fieldConfig.getField().getSimpleName());
     Name resourceName = getResourceTypeNameObject(fieldConfig.getResourceNameConfig());
     if (type.isMap()) {
@@ -368,7 +368,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    *
    * @throws IllegalArgumentException if the field is not a repeated field.
    */
-  public String getFieldCountGetFunctionName(FieldType field) {
+  public String getFieldCountGetFunctionName(FieldModel field) {
     if (field.isRepeated()) {
       return publicMethodName(Name.from("get", field.getSimpleName(), "count"));
     } else {
@@ -382,7 +382,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    *
    * @throws IllegalArgumentException if the field is not a repeated field.
    */
-  public String getByIndexGetFunctionName(FieldType field) {
+  public String getByIndexGetFunctionName(FieldModel field) {
     if (field.isRepeated()) {
       return publicMethodName(Name.from("get", field.getSimpleName()));
     } else {
@@ -574,7 +574,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return getAsyncApiMethodName(method, visibility);
   }
 
-  public String getByteLengthFunctionName(FieldType typeRef) {
+  public String getByteLengthFunctionName(FieldModel typeRef) {
     return getNotImplementedString("SurfaceNamer.getByteLengthFunctionName");
   }
 
@@ -584,7 +584,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of a variable to hold a value for the given proto message field (such as a flattened
    * parameter).
    */
-  public String getVariableName(FieldType field) {
+  public String getVariableName(FieldModel field) {
     return localVarName(Name.from(field.getSimpleName()));
   }
 
@@ -657,7 +657,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the field. */
-  public String getFieldName(FieldType field) {
+  public String getFieldName(FieldModel field) {
     return publicFieldName(Name.from(field.getSimpleName()));
   }
 
@@ -838,7 +838,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The type name for the method param */
-  public String getParamTypeName(ImportTypeTable typeTable, FieldType type) {
+  public String getParamTypeName(ImportTypeTable typeTable, FieldModel type) {
     // TODO(andrealin): Remove the switch statement and getProtoTypeRef().
     switch (type.getApiSource()) {
       case PROTO:
@@ -854,7 +854,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The type name for the message property */
-  public String getMessagePropertyTypeName(ImportTypeTable typeTable, FieldType type) {
+  public String getMessagePropertyTypeName(ImportTypeTable typeTable, FieldModel type) {
     return getParamTypeName(typeTable, type);
   }
 
@@ -958,13 +958,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The inner type name of the paged response type for the given method and resources field. */
   public String getPagedResponseTypeInnerName(
-      MethodModel method, ImportTypeTable typeTable, FieldType resourcesField) {
+      MethodModel method, ImportTypeTable typeTable, FieldModel resourcesField) {
     return getNotImplementedString("SurfaceNamer.getAndSavePagedResponseTypeInnerName");
   }
 
   /** The inner type name of the page type for the given method and resources field. */
   public String getPageTypeInnerName(
-      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+      MethodModel method, ImportTypeTable typeTable, FieldModel resourceField) {
     return getNotImplementedString("SurfaceNamer.getPageTypeInnerName");
   }
 
@@ -972,7 +972,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The inner type name of the fixed size collection type for the given method and resources field.
    */
   public String getFixedSizeCollectionTypeInnerName(
-      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+      MethodModel method, ImportTypeTable typeTable, FieldModel resourceField) {
     return getNotImplementedString("SurfaceNamer.getPageTypeInnerName");
   }
 
@@ -1172,7 +1172,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The key to use in a dictionary for the given field. */
-  public String getFieldKey(FieldType field) {
+  public String getFieldKey(FieldModel field) {
     return keyName(Name.from(field.getSimpleName()));
   }
 
@@ -1247,14 +1247,14 @@ public class SurfaceNamer extends NameFormatterDelegator {
   ///////////////////////////////////////// Imports ///////////////////////////////////////////////
 
   /** Returns true if the request object param type for the given field should be imported. */
-  public boolean shouldImportRequestObjectParamType(FieldType field) {
+  public boolean shouldImportRequestObjectParamType(FieldModel field) {
     return true;
   }
 
   /**
    * Returns true if the request object param element type for the given field should be imported.
    */
-  public boolean shouldImportRequestObjectParamElementType(FieldType field) {
+  public boolean shouldImportRequestObjectParamElementType(FieldModel field) {
     return true;
   }
 
@@ -1300,7 +1300,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Provides the doc lines for the given field in the current language. */
-  public List<String> getDocLines(FieldType field) {
+  public List<String> getDocLines(FieldModel field) {
     return getDocLines(field.getScopedDocumentation());
   }
 
@@ -1335,7 +1335,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of a type with with qualifying articles and descriptions. */
-  public String getTypeNameDoc(ImportTypeTable typeTable, FieldType type) {
+  public String getTypeNameDoc(ImportTypeTable typeTable, FieldModel type) {
     switch (type.getApiSource()) {
       case PROTO:
         return getTypeNameDoc(typeTable, type.getProtoTypeRef());
@@ -1510,7 +1510,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Make the given type name able to accept nulls, if it is a primitive type */
-  public String makePrimitiveTypeNullable(String typeName, FieldType type) {
+  public String makePrimitiveTypeNullable(String typeName, FieldModel type) {
     return typeName;
   }
 
@@ -1520,7 +1520,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Is this type a primitive, according to target language. */
-  public boolean isPrimitive(FieldType type) {
+  public boolean isPrimitive(FieldModel type) {
     return type.isPrimitive();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -874,22 +874,22 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The return type name in a dynamic language for the given method. */
-  public String getDynamicLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+  public String getDynamicLangReturnTypeName(MethodContext methodContext) {
     return getNotImplementedString("SurfaceNamer.getDynamicReturnTypeName");
   }
 
   /** The return type name in a static language for the given method. */
-  public String getStaticLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+  public String getStaticLangReturnTypeName(MethodContext methodContext) {
     return getNotImplementedString("SurfaceNamer.getStaticLangReturnTypeName");
   }
 
   /** The return type name in a static language that is used by the caller */
-  public String getStaticLangCallerReturnTypeName(MethodModel method, MethodConfig methodConfig) {
-    return getStaticLangReturnTypeName(method, methodConfig);
+  public String getStaticLangCallerReturnTypeName(MethodContext methodContext) {
+    return getStaticLangReturnTypeName(methodContext);
   }
 
   /** The async return type name in a static language for the given method. */
-  public String getStaticLangAsyncReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+  public String getStaticLangAsyncReturnTypeName(MethodContext methodContext) {
     return getNotImplementedString("SurfaceNamer.getStaticLangAsyncReturnTypeName");
   }
 
@@ -911,9 +911,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The async return type name in a static language that is used by the caller */
-  public String getStaticLangCallerAsyncReturnTypeName(
-      MethodModel method, MethodConfig methodConfig) {
-    return getStaticLangAsyncReturnTypeName(method, methodConfig);
+  public String getStaticLangCallerAsyncReturnTypeName(MethodContext methodContext) {
+    return getStaticLangAsyncReturnTypeName(methodContext);
   }
 
   /** The name used in Grpc for the given API method. This needs to match what Grpc generates. */
@@ -944,7 +943,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The generic-aware response type name for the given type. For example, in Java, this will be the
    * type used for Future&lt;...&gt;.
    */
-  public String getGenericAwareResponseTypeName(MethodModel method) {
+  public String getGenericAwareResponseTypeName(MethodContext methodContext) {
     return getNotImplementedString("SurfaceNamer.getGenericAwareResponseType");
   }
 
@@ -1317,7 +1316,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The doc lines that describe the return value for an API method. */
   public List<String> getReturnDocLines(
-      TransformationContext context, MethodConfig methodConfig, Synchronicity synchronicity) {
+      TransformationContext context, MethodContext methodContext, Synchronicity synchronicity) {
     return Collections.singletonList(getNotImplementedString("SurfaceNamer.getReturnDocLines"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -17,9 +17,9 @@ package com.google.api.codegen.transformer;
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
-import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.OneofConfig;
@@ -156,12 +156,12 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Returns the service name exported by the package */
-  public String getPackageServiceName(Interface apiInterface) {
+  public String getPackageServiceName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getPackageServiceName");
   }
 
   /** Human-friendly name of this API interface */
-  public String getServicePhraseName(Interface apiInterface) {
+  public String getServicePhraseName(InterfaceModel apiInterface) {
     return Name.upperCamel(apiInterface.getSimpleName()).toPhrase();
   }
 
@@ -204,7 +204,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The qualified namespace of an API interface. */
-  public String getNamespace(Interface apiInterface) {
+  public String getNamespace(InterfaceModel apiInterface) {
     NamePath namePath =
         typeNameConverter.getNamePath(getModelTypeFormatter().getFullNameFor(apiInterface));
     return qualifiedName(namePath.withoutHead());
@@ -394,7 +394,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   ///////////////////////////////// Function & Callable names /////////////////////////////////////
 
   /** The function name to retrieve default client option */
-  public String getDefaultApiSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultApiSettingsFunctionName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getDefaultClientOptionFunctionName");
   }
 
@@ -549,17 +549,17 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to retrieve default call option */
-  public String getDefaultCallSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultCallSettingsFunctionName(InterfaceModel apiInterface) {
     return publicMethodName(Name.upperCamel(apiInterface.getSimpleName(), "Settings"));
   }
 
   /** The name of the IAM resource getter function. */
-  public String getIamResourceGetterFunctionName(Field field) {
+  public String getIamResourceGetterFunctionName(FieldModel field) {
     return getNotImplementedString("SurfaceNamer.getIamResourceGetterFunctionName");
   }
 
   /** The name of the function that will create a stub. */
-  public String getCreateStubFunctionName(Interface apiInterface) {
+  public String getCreateStubFunctionName(InterfaceModel apiInterface) {
     return privateMethodName(
         Name.upperCamel("Create", apiInterface.getSimpleName(), "Stub", "Function"));
   }
@@ -623,7 +623,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the variable that will hold the stub for an API interface. */
-  public String getStubName(Interface apiInterface) {
+  public String getStubName(InterfaceModel apiInterface) {
     return privateFieldName(Name.upperCamel(apiInterface.getSimpleName(), "Stub"));
   }
 
@@ -633,7 +633,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the array which will hold the methods for a given stub. */
-  public String getStubMethodsArrayName(Interface apiInterface) {
+  public String getStubMethodsArrayName(InterfaceModel apiInterface) {
     return privateMethodName(Name.upperCamel(apiInterface.getSimpleName(), "Stub", "Methods"));
   }
 
@@ -652,7 +652,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the variable to hold the grpc client of an API interface. */
-  public String getGrpcClientVariableName(Interface apiInterface) {
+  public String getGrpcClientVariableName(InterfaceModel apiInterface) {
     return localVarName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
   }
 
@@ -693,12 +693,12 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the implementation class that implements a particular proto interface. */
-  public String getApiWrapperClassImplName(Interface apiInterface) {
+  public String getApiWrapperClassImplName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getApiWrapperClassImplName");
   }
 
   /** The name of the class that implements snippets for a particular proto interface. */
-  public String getApiSnippetsClassName(Interface apiInterface) {
+  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ApiSnippets"));
   }
 
@@ -742,7 +742,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The type name of the Grpc service class This needs to match what Grpc generates for the
    * particular language.
    */
-  public String getGrpcServiceClassName(Interface apiInterface) {
+  public String getGrpcServiceClassName(InterfaceModel apiInterface) {
     NamePath namePath =
         typeNameConverter.getNamePath(getModelTypeFormatter().getFullNameFor(apiInterface));
     String grpcContainerName =
@@ -762,12 +762,12 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   public String getTopLevelAliasedApiClassName(
-      GapicInterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
+      InterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return getNotImplementedString("SurfaceNamer.getTopLevelAliasedApiClassName");
   }
 
   public String getVersionAliasedApiClassName(
-      GapicInterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
+      InterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return getNotImplementedString("SurfaceNamer.getVersionAliasedApiClassName");
   }
 
@@ -804,8 +804,16 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The type name of the Grpc server class. This needs to match what Grpc generates for the
    * particular language.
    */
-  public String getGrpcServerTypeName(Interface apiInterface) {
+  public String getGrpcServerTypeName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getGrpcServerTypeName");
+  }
+
+  /**
+   * The type name of the Grpc client class. This needs to match what Grpc generates for the
+   * particular language.
+   */
+  public String getGrpcClientTypeName(InterfaceModel apiInterface) {
+    return getNotImplementedString("SurfaceNamer.getGrpcClientTypeName");
   }
 
   /**
@@ -821,7 +829,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * the nickname.
    */
   public String getAndSaveNicknameForGrpcClientTypeName(
-      ImportTypeTable typeTable, Interface apiInterface) {
+      ImportTypeTable typeTable, InterfaceModel apiInterface) {
     return typeTable.getAndSaveNicknameFor(getGrpcClientTypeName(apiInterface));
   }
 
@@ -829,9 +837,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The type name of the Grpc container class. This needs to match what Grpc generates for the
    * particular language.
    */
-  public String getGrpcContainerTypeName(Interface apiInterface) {
+  public String getGrpcContainerTypeName(InterfaceModel apiInterface) {
     NamePath namePath =
-        typeNameConverter.getNamePath(getModelTypeFormatter().getFullNameFor(apiInterface));
+        typeNameConverter.getNamePath(getTypeFormatter().getFullNameFor(apiInterface));
     String publicClassName =
         publicClassName(Name.upperCamelKeepUpperAcronyms(namePath.getHead(), "Grpc"));
     return qualifiedName(namePath.withHead(publicClassName));
@@ -928,7 +936,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The type name of call options */
-  public String getCallSettingsTypeName(Interface apiInterface) {
+  public String getCallSettingsTypeName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Settings"));
   }
 
@@ -1019,7 +1027,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The fully qualified type name for the stub of an API interface. */
-  public String getFullyQualifiedStubType(Interface apiInterface) {
+  public String getFullyQualifiedStubType(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getFullyQualifiedStubType");
   }
 
@@ -1085,8 +1093,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The parameter name of the IAM resource. */
-  public String getIamResourceParamName(Field field) {
-    return localVarName(Name.upperCamel(field.getParent().getSimpleName()));
+  public String getIamResourceParamName(FieldModel field) {
+    return localVarName(Name.upperCamel(field.getParentSimpleName()));
   }
 
   /////////////////////////////////////// Path Template ////////////////////////////////////////
@@ -1182,7 +1190,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The path to the client config for the given interface. */
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getClientConfigPath");
   }
 
@@ -1235,7 +1243,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The string used to identify the method in the gRPC stub. Not all languages will use this. */
-  public String getGrpcStubCallString(Interface apiInterface, MethodModel method) {
+  public String getGrpcStubCallString(InterfaceModel apiInterface, MethodModel method) {
     return getNotImplementedString("SurfaceNamer.getGrpcStubCallString");
   }
 
@@ -1267,7 +1275,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the import for a specific grpcClient */
-  public String getGrpcClientImportName(Interface apiInterface) {
+  public String getGrpcClientImportName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getGrpcClientImportName");
   }
 
@@ -1476,12 +1484,12 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The example name of the IAM resource getter function. */
   public String getIamResourceGetterFunctionExampleName(
-      String apiInterfaceSimpleName, Field field) {
+      String apiInterfaceSimpleName, FieldModel field) {
     return getIamResourceGetterFunctionName(field);
   }
 
   /** The file name for the example of an API interface. */
-  public String getExampleFileName(Interface apiInterface) {
+  public String getExampleFileName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getExampleFileName");
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -171,8 +171,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of the constructor for the apiInterface client. The client is VKit generated, not
    * GRPC.
    */
-  public String getApiWrapperClassConstructorName(String apiInterfaceSimpleName) {
-    return publicClassName(Name.upperCamel(apiInterfaceSimpleName, "Client"));
+  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
+    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
   }
 
   /** Constructor name for the type with the given nickname. */
@@ -565,7 +565,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Function used to register the GRPC server. */
-  public String getServerRegisterFunctionName(Interface apiInterface) {
+  public String getServerRegisterFunctionName(InterfaceModel apiInterface) {
     return getNotImplementedString("SurfaceNamer.getServerRegisterFunctionName");
   }
 
@@ -625,11 +625,6 @@ public class SurfaceNamer extends NameFormatterDelegator {
   /** The name of the variable that will hold the stub for an API interface. */
   public String getStubName(InterfaceModel apiInterface) {
     return privateFieldName(Name.upperCamel(apiInterface.getSimpleName(), "Stub"));
-  }
-
-  /** The name of the variable that will hold the stub for an API interface. */
-  public String getStubName(String apiInterfaceSimpleName) {
-    return privateFieldName(Name.upperCamel(apiInterfaceSimpleName, "Stub"));
   }
 
   /** The name of the array which will hold the methods for a given stub. */
@@ -1104,13 +1099,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * class.
    */
   public String getPathTemplateName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   /** The name of a getter function to get a particular path template for the given collection. */
   public String getPathTemplateNameGetter(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
         Name.from("get", resourceNameConfig.getEntityName(), "name", "template"));
   }
@@ -1122,7 +1117,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to format the entity for the given collection. */
   public String getFormatFunctionName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from("format", resourceNameConfig.getEntityName(), "name"));
   }
 
@@ -1408,19 +1403,19 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The class name of the mock gRPC service for the given API interface. */
-  public String getMockServiceClassName(String apiInterfaceSimpleName) {
-    return publicClassName(Name.upperCamelKeepUpperAcronyms("Mock", apiInterfaceSimpleName));
+  public String getMockServiceClassName(InterfaceModel apiInterface) {
+    return publicClassName(Name.upperCamelKeepUpperAcronyms("Mock", apiInterface.getSimpleName()));
   }
 
   /** The class name of a variable to hold the mock gRPC service for the given API interface. */
-  public String getMockServiceVarName(String apiInterfaceSimpleName) {
-    return localVarName(Name.upperCamelKeepUpperAcronyms("Mock", apiInterfaceSimpleName));
+  public String getMockServiceVarName(InterfaceModel apiInterface) {
+    return localVarName(Name.upperCamelKeepUpperAcronyms("Mock", apiInterface.getSimpleName()));
   }
 
   /** The class name of the mock gRPC service implementation for the given API interface. */
-  public String getMockGrpcServiceImplName(String apiInterfaceSimpleName) {
+  public String getMockGrpcServiceImplName(InterfaceModel apiInterface) {
     return publicClassName(
-        Name.upperCamelKeepUpperAcronyms("Mock", apiInterfaceSimpleName, "Impl"));
+        Name.upperCamelKeepUpperAcronyms("Mock", apiInterface.getSimpleName(), "Impl"));
   }
 
   /** Inject random value generator code to the given string. */
@@ -1444,8 +1439,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of example of the constructor for the service client. The client is VKit generated,
    * not GRPC.
    */
-  public String getApiWrapperClassConstructorExampleName(String apiInterfaceSimpleName) {
-    return getApiWrapperClassConstructorName(apiInterfaceSimpleName);
+  public String getApiWrapperClassConstructorExampleName(InterfaceModel apiInterface) {
+    return getApiWrapperClassConstructorName(apiInterface);
   }
 
   /** The name of the example for the paged callable variant. */
@@ -1464,8 +1459,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the example for the method. */
-  public String getApiMethodExampleName(String apiInterfaceSimpleName, MethodModel method) {
-    return getApiMethodName(Name.anyCamel(apiInterfaceSimpleName), VisibilityConfig.PUBLIC);
+  public String getApiMethodExampleName(InterfaceModel apiInterface, MethodModel method) {
+    return getApiMethodName(Name.anyCamel(apiInterface.getSimpleName()), VisibilityConfig.PUBLIC);
   }
 
   /** The name of the example for the async variant of the given method. */
@@ -1478,13 +1473,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * method.
    */
   public String getGrpcStreamingApiMethodExampleName(
-      String apiInterfaceSimpleName, MethodModel method) {
+      InterfaceModel apiInterface, MethodModel method) {
     return getGrpcStreamingApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
   /** The example name of the IAM resource getter function. */
   public String getIamResourceGetterFunctionExampleName(
-      String apiInterfaceSimpleName, FieldModel field) {
+      InterfaceModel apiInterface, FieldModel field) {
     return getIamResourceGetterFunctionName(field);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1333,11 +1333,6 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of a type with with qualifying articles and descriptions. */
-  public String getTypeNameDoc(ImportTypeTable typeTable, Schema type) {
-    return getNotImplementedString("SurfaceNamer.getTypeNameDoc");
-  }
-
-  /** The name of a type with with qualifying articles and descriptions. */
   public String getTypeNameDoc(ImportTypeTable typeTable, FieldModel type) {
     switch (type.getApiSource()) {
       case PROTO:

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -147,7 +147,8 @@ public class TestCaseTransformer {
         .fullyQualifiedRequestTypeName(method.getInputTypeName(typeTable).getFullName())
         .fullyQualifiedResponseTypeName(fullyQualifiedResponseTypeName)
         .serviceConstructorName(
-            namer.getApiWrapperClassConstructorName(methodContext.getInterfaceSimpleName()))
+            namer.getApiWrapperClassConstructorName(
+                methodContext.getInterfaceModel().getSimpleName()))
         .fullyQualifiedServiceClassName(
             namer.getFullyQualifiedApiWrapperClassName(methodContext.getInterfaceConfig()))
         .fullyQualifiedAliasedServiceClassName(

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -252,7 +252,7 @@ public class TestCaseTransformer {
         .suggestedName(Name.from("expected_response"))
         .initFieldConfigStrings(context.getMethodConfig().getSampleCodeInitFields())
         .initValueConfigMap(ImmutableMap.<String, InitValueConfig>of())
-        .initFields((primitiveFields))
+        .initFields(primitiveFields)
         .fieldConfigMap(context.getProductConfig().getDefaultResourceNameFieldConfigMap())
         .valueGenerator(valueGenerator)
         .additionalInitCodeNodes(createMockResponseAdditionalSubTrees(context))

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -108,7 +108,7 @@ public class TestCaseTransformer {
       String resourceTypeName = null;
       String resourcesFieldGetterName = null;
       if (methodConfig.getGrpcStreaming().hasResourceField()) {
-        FieldType resourcesField = methodConfig.getGrpcStreaming().getResourcesField();
+        FieldModel resourcesField = methodConfig.getGrpcStreaming().getResourcesField();
         resourceTypeName =
             methodContext.getTypeTable().getAndSaveNicknameForElementType(resourcesField);
         resourcesFieldGetterName =
@@ -174,7 +174,7 @@ public class TestCaseTransformer {
     }
 
     FieldConfig resourcesFieldConfig = methodConfig.getPageStreaming().getResourcesFieldConfig();
-    FieldType resourcesField = resourcesFieldConfig.getField();
+    FieldModel resourcesField = resourcesFieldConfig.getField();
     String resourceTypeName =
         methodContext.getTypeTable().getAndSaveNicknameForElementType(resourcesField);
     String resourcesFieldGetterName = namer.getFieldGetFunctionName(resourcesField);
@@ -236,7 +236,7 @@ public class TestCaseTransformer {
 
   private InitCodeContext createResponseInitCodeContext(
       GapicMethodContext context, SymbolTable symbolTable) {
-    ArrayList<FieldType> primitiveFields = new ArrayList<>();
+    ArrayList<FieldModel> primitiveFields = new ArrayList<>();
     TypeRef outputType = context.getMethod().getOutputType();
     if (context.getMethodConfig().isLongRunningOperation()) {
       outputType = context.getMethodConfig().getLongRunningConfig().getReturnType();

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -68,7 +68,7 @@ public class TestCaseTransformer {
     String clientMethodName;
     String responseTypeName;
     String fullyQualifiedResponseTypeName =
-        methodContext.getMethodModel().getOutputTypeFullName(typeTable);
+        methodContext.getMethodModel().getOutputTypeName(typeTable).getFullName();
 
     if (methodConfig.isPageStreaming()) {
       clientMethodName = namer.getApiMethodName(method, methodConfig.getVisibility());
@@ -144,7 +144,7 @@ public class TestCaseTransformer {
         .grpcStreamingView(grpcStreamingView)
         .requestTypeName(method.getAndSaveRequestTypeName(typeTable, namer))
         .responseTypeName(responseTypeName)
-        .fullyQualifiedRequestTypeName(method.getInputTypeFullName(typeTable))
+        .fullyQualifiedRequestTypeName(method.getInputTypeName(typeTable).getFullName())
         .fullyQualifiedResponseTypeName(fullyQualifiedResponseTypeName)
         .serviceConstructorName(
             namer.getApiWrapperClassConstructorName(methodContext.getInterfaceSimpleName()))

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -136,8 +136,7 @@ public class TestCaseTransformer {
         .hasReturnValue(hasReturnValue)
         .initCode(initCode)
         .mockResponse(mockGrpcResponseView)
-        .mockServiceVarName(
-            namer.getMockServiceVarName(methodContext.getTargetInterface().getSimpleName()))
+        .mockServiceVarName(namer.getMockServiceVarName(methodContext.getTargetInterface()))
         .name(namer.getTestCaseName(testNameTable, method))
         .nameWithException(namer.getExceptionTestCaseName(testNameTable, method))
         .pageStreamingResponseViews(createPageStreamingResponseViews(methodContext))
@@ -147,16 +146,14 @@ public class TestCaseTransformer {
         .fullyQualifiedRequestTypeName(method.getInputTypeName(typeTable).getFullName())
         .fullyQualifiedResponseTypeName(fullyQualifiedResponseTypeName)
         .serviceConstructorName(
-            namer.getApiWrapperClassConstructorName(
-                methodContext.getInterfaceModel().getSimpleName()))
+            namer.getApiWrapperClassConstructorName(methodContext.getInterfaceModel()))
         .fullyQualifiedServiceClassName(
             namer.getFullyQualifiedApiWrapperClassName(methodContext.getInterfaceConfig()))
         .fullyQualifiedAliasedServiceClassName(
             namer.getTopLevelAliasedApiClassName(
                 (methodContext.getInterfaceConfig()), packageHasMultipleServices))
         .clientMethodName(clientMethodName)
-        .mockGrpcStubTypeName(
-            namer.getMockGrpcServiceImplName(methodContext.getTargetInterface().getSimpleName()))
+        .mockGrpcStubTypeName(namer.getMockGrpcServiceImplName(methodContext.getTargetInterface()))
         .createStubFunctionName(namer.getCreateStubFunctionName(methodContext.getTargetInterface()))
         .grpcStubCallString(namer.getGrpcStubCallString(methodContext.getTargetInterface(), method))
         .build();

--- a/src/main/java/com/google/api/codegen/transformer/TransformationContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/TransformationContext.java
@@ -1,4 +1,4 @@
-/* Copyright 2016 Google Inc
+/* Copyright 2017 Google Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,14 +12,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.api.codegen.gapic;
+package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.ProductConfig;
 
 /**
- * An implementation of CodePathMapper is a strategy object, encapsulating a strategy for
- * constructing a path to the GAPIC output.
+ * The context for transforming an API model, in an input-agnostic way, into a view model to use for
+ * client library generation.
  */
-public interface GapicCodePathMapper {
-  String getOutputPath(String elementFullName, ProductConfig config);
+public interface TransformationContext {
+
+  ProductConfig getProductConfig();
+
+  SurfaceNamer getNamer();
+
+  ImportTypeTable getImportTypeTable();
 }

--- a/src/main/java/com/google/api/codegen/transformer/TypeFormatter.java
+++ b/src/main/java/com/google/api/codegen/transformer/TypeFormatter.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 
 /**
  * A read-only interface for mapping TypeRef instances to a corresponding String representation for
@@ -27,14 +27,14 @@ public interface TypeFormatter {
   String getImplicitPackageFullNameFor(String shortName);
 
   /** Get the full name for the given type. */
-  String getFullNameFor(FieldType type);
+  String getFullNameFor(FieldModel type);
 
   /** Get the full name for the element type of the given type. */
-  String getFullNameForElementType(FieldType type);
+  String getFullNameForElementType(FieldModel type);
 
   /** Returns the nickname for the given type (without adding the full name to the import set). */
-  String getNicknameFor(FieldType type);
+  String getNicknameFor(FieldModel type);
 
   /** Renders the primitive value of the given type. */
-  String renderPrimitiveValue(FieldType type, String key);
+  String renderPrimitiveValue(FieldModel type, String key);
 }

--- a/src/main/java/com/google/api/codegen/transformer/TypeFormatter.java
+++ b/src/main/java/com/google/api/codegen/transformer/TypeFormatter.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
 
 /**
  * A read-only interface for mapping TypeRef instances to a corresponding String representation for
@@ -28,6 +29,9 @@ public interface TypeFormatter {
 
   /** Get the full name for the given type. */
   String getFullNameFor(FieldModel type);
+
+  /** Get the full name for the given type. */
+  String getFullNameFor(InterfaceModel type);
 
   /** Get the full name for the element type of the given type. */
   String getFullNameForElementType(FieldModel type);

--- a/src/main/java/com/google/api/codegen/transformer/TypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/TypeNameConverter.java
@@ -15,21 +15,21 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypedValue;
 import com.google.api.tools.framework.model.EnumValue;
 
-/** ModelTypeNameConverter maps FieldType instances to TypeName instances. */
+/** ModelTypeNameConverter maps FieldModel instances to TypeName instances. */
 public interface TypeNameConverter {
-  /** Provides a TypeName for the given FieldType. */
-  TypeName getTypeName(FieldType type);
+  /** Provides a TypeName for the given FieldModel. */
+  TypeName getTypeName(FieldModel type);
 
-  /** Provides a TypedValue for the given enum FieldType. */
-  TypedValue getEnumValue(FieldType type, EnumValue value);
+  /** Provides a TypedValue for the given enum FieldModel. */
+  TypedValue getEnumValue(FieldModel type, EnumValue value);
 
-  /** Provides a TypeName for the element type of the given FieldType. */
-  TypeName getTypeNameForElementType(FieldType type);
+  /** Provides a TypeName for the element type of the given FieldModel. */
+  TypeName getTypeNameForElementType(FieldModel type);
 
   /** Provides a TypeName for the given FieldConfig and resource short name. */
   TypeName getTypeNameForTypedResourceName(FieldConfig fieldConfig, String typedResourceShortName);
@@ -48,15 +48,15 @@ public interface TypeNameConverter {
    * Provides a TypedValue containing the zero value of the given type, plus the TypeName of the
    * type; suitable for use within code snippets.
    */
-  TypedValue getSnippetZeroValue(FieldType type);
+  TypedValue getSnippetZeroValue(FieldModel type);
 
   /**
    * Provides a TypedValue containing the zero value of the given type, for use internally within
    * the auto-generated layer; plus the TypeName of the type. This will often return the same value
-   * as {@link #getSnippetZeroValue(FieldType)}.
+   * as {@link #getSnippetZeroValue(FieldModel)}.
    */
-  TypedValue getImplZeroValue(FieldType type);
+  TypedValue getImplZeroValue(FieldModel type);
 
   /** Renders the given value if it is a primitive type. */
-  String renderPrimitiveValue(FieldType type, String value);
+  String renderPrimitiveValue(FieldModel type, String value);
 }

--- a/src/main/java/com/google/api/codegen/transformer/TypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/TypeNameConverter.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypedValue;
 import com.google.api.tools.framework.model.EnumValue;
@@ -24,6 +25,8 @@ import com.google.api.tools.framework.model.EnumValue;
 public interface TypeNameConverter {
   /** Provides a TypeName for the given FieldModel. */
   TypeName getTypeName(FieldModel type);
+
+  TypeName getTypeName(InterfaceModel interfaceModel);
 
   /** Provides a TypedValue for the given enum FieldModel. */
   TypedValue getEnumValue(FieldModel type, EnumValue value);

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpApiMethodTransformer.java
@@ -14,11 +14,10 @@
  */
 package com.google.api.codegen.transformer.csharp;
 
-import com.google.api.codegen.transformer.GapicMethodContext;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.StaticLangApiMethodTransformer;
 import com.google.api.codegen.viewmodel.SimpleParamDocView;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
-import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
@@ -26,21 +25,26 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
 
   @Override
   protected void setServiceResponseTypeName(
-      GapicMethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
+      MethodContext context, StaticLangApiMethodView.Builder methodViewBuilder) {
     String responseTypeName =
-        context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType());
+        context
+            .getMethodModel()
+            .getAndSaveResponseTypeName(context.getTypeTable(), context.getNamer());
     methodViewBuilder.serviceResponseTypeName(responseTypeName);
   }
 
   @Override
-  public List<SimpleParamDocView> getRequestObjectParamDocs(
-      GapicMethodContext context, TypeRef typeRef) {
+  public List<SimpleParamDocView> getRequestObjectParamDocs(MethodContext context) {
+    String requestTypeName =
+        context
+            .getMethodModel()
+            .getAndSaveRequestTypeName(context.getTypeTable(), context.getNamer());
     switch (context.getMethodConfig().getGrpcStreamingType()) {
       case NonStreaming:
         SimpleParamDocView nonStreamingDoc =
             SimpleParamDocView.newBuilder()
                 .paramName("request")
-                .typeName(context.getTypeTable().getAndSaveNicknameFor(typeRef))
+                .typeName(requestTypeName)
                 .lines(
                     ImmutableList.of(
                         "The request object containing all of the parameters for the API call."))
@@ -50,7 +54,7 @@ public class CSharpApiMethodTransformer extends StaticLangApiMethodTransformer {
         SimpleParamDocView serverStreamingDoc =
             SimpleParamDocView.newBuilder()
                 .paramName("request")
-                .typeName(context.getTypeTable().getAndSaveNicknameFor(typeRef))
+                .typeName(requestTypeName)
                 .lines(
                     ImmutableList.of(
                         "The request object containing all of the parameters for the API call."))

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpCommonTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpCommonTransformer.java
@@ -14,12 +14,13 @@
  */
 package com.google.api.codegen.transformer.csharp;
 
-import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
+import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
+import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.ParamWithSimpleDoc;
-import com.google.api.tools.framework.model.Method;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -42,15 +43,14 @@ public class CSharpCommonTransformer {
     typeTable.saveNicknameFor("System.Collections.Generic.IEnumerable");
   }
 
-  public List<Method> getSupportedMethods(GapicInterfaceContext context) {
-    List<Method> result = new ArrayList<>();
+  public List<MethodModel> getSupportedMethods(InterfaceContext context) {
+    List<MethodModel> result = new ArrayList<>();
     boolean mixinsDisabled = !context.getFeatureConfig().enableMixins();
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       if (mixinsDisabled && context.getMethodConfig(method).getRerouteToGrpcInterface() != null) {
         continue;
       }
-
-      GapicMethodConfig methodConfig = context.getMethodConfig(method);
+      MethodConfig methodConfig = context.getMethodConfig(method);
       if (methodConfig.getGrpcStreamingType() == GrpcStreamingType.ClientStreaming) {
         // Client-streaming not yet supported
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -175,9 +175,9 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     apiClass.doc(serviceTransformer.generateServiceDoc(context, null));
 
     apiClass.name(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    apiClass.implName(namer.getApiWrapperClassImplName(context.getInterface()));
-    apiClass.grpcServiceName(namer.getGrpcContainerTypeName(context.getInterface()));
-    apiClass.grpcTypeName(namer.getGrpcServiceClassName(context.getInterface()));
+    apiClass.implName(namer.getApiWrapperClassImplName(context.getInterfaceModel()));
+    apiClass.grpcServiceName(namer.getGrpcContainerTypeName(context.getInterfaceModel()));
+    apiClass.grpcTypeName(namer.getGrpcServiceClassName(context.getInterfaceModel()));
     apiClass.settingsClassName(
         context.getNamer().getApiSettingsClassName(context.getInterfaceConfig()));
     List<ApiCallableView> callables = new ArrayList<>();

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -20,6 +20,7 @@ import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.ApiCallableTransformer;
@@ -27,6 +28,7 @@ import com.google.api.codegen.transformer.BatchingTransformer;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
@@ -52,9 +54,7 @@ import com.google.api.codegen.viewmodel.StaticLangResourceNamesView;
 import com.google.api.codegen.viewmodel.StaticLangSettingsView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.ArrayList;
@@ -134,7 +134,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     StaticLangResourceNamesView.Builder view = StaticLangResourceNamesView.newBuilder();
     view.templateFileName(RESOURCENAMES_TEMPLATE_FILENAME);
     String outputPath =
-        pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
     view.outputPath(outputPath + File.separator + "ResourceNames.cs");
     view.resourceNames(pathTemplateTransformer.generateResourceNames(context));
     view.resourceProtos(pathTemplateTransformer.generateResourceProtos(context));
@@ -156,7 +156,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     fileView.settings(generateSettingsClass(context));
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
     String name = context.getNamer().getApiWrapperClassName(context.getInterfaceConfig());
     fileView.outputPath(outputPath + File.separator + name + ".cs");
 
@@ -258,7 +258,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
   public List<ApiCallSettingsView> generateCallSettings(GapicInterfaceContext context) {
     // This method can be removed once mixins are supported in C#
     List<ApiCallSettingsView> settingsMembers = new ArrayList<>();
-    for (Method method : csharpCommonTransformer.getSupportedMethods(context)) {
+    for (MethodModel method : csharpCommonTransformer.getSupportedMethods(context)) {
       List<ApiCallSettingsView> calls =
           apiCallableTransformer.generateApiCallableSettings(
               context.asRequestMethodContext(method));
@@ -270,7 +270,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
   private List<ReroutedGrpcView> generateReroutedGrpcView(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
     Set<ReroutedGrpcView> reroutedViews = new LinkedHashSet<>();
-    for (Method method : csharpCommonTransformer.getSupportedMethods(context)) {
+    for (MethodModel method : csharpCommonTransformer.getSupportedMethods(context)) {
       MethodConfig methodConfig = context.getMethodConfig(method);
       String reroute = methodConfig.getRerouteToGrpcInterface();
       if (reroute != null) {
@@ -288,21 +288,21 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
 
   private List<ModifyMethodView> generateModifyMethods(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    ModelTypeTable typeTable = context.getModelTypeTable();
     List<ModifyMethodView> modifyMethods = new ArrayList<>();
-    Set<TypeRef> modifyTypes = new HashSet<TypeRef>();
-    for (Method method : csharpCommonTransformer.getSupportedMethods(context)) {
-
-      MethodConfig methodContext = context.asRequestMethodContext(method).getMethodConfig();
-      TypeRef inputType = method.getInputType();
-      if (modifyTypes.contains(inputType)) {
+    Set<String> modifyTypeNames = new HashSet<>();
+    for (MethodModel method : csharpCommonTransformer.getSupportedMethods(context)) {
+      MethodContext methodContext = context.asRequestMethodContext(method);
+      String inputTypeFullName = methodContext.getMethodModel().getInputFullName();
+      if (modifyTypeNames.contains(inputTypeFullName)) {
         continue;
       }
-      modifyTypes.add(inputType);
+      modifyTypeNames.add(inputTypeFullName);
+      MethodConfig methodConfig = methodContext.getMethodConfig();
       ModifyMethodView.Builder builder = ModifyMethodView.builder();
-      builder.name(namer.getModifyMethodName(method));
-      builder.requestTypeName(typeTable.getAndSaveNicknameFor(inputType));
-      builder.grpcStreamingType(methodContext.getGrpcStreamingType());
+      builder.name(namer.getModifyMethodName(methodContext));
+      builder.requestTypeName(
+          method.getAndSaveRequestTypeName(context.getImportTypeTable(), context.getNamer()));
+      builder.grpcStreamingType(methodConfig.getGrpcStreamingType());
       modifyMethods.add(builder.build());
     }
     return modifyMethods;
@@ -316,17 +316,21 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
             .build();
 
     List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
-    for (Method method : csharpCommonTransformer.getSupportedMethods(context)) {
+    for (MethodModel method : csharpCommonTransformer.getSupportedMethods(context)) {
       MethodConfig methodConfig = context.getMethodConfig(method);
-      GapicMethodContext requestMethodContext = context.asRequestMethodContext(method);
+      MethodContext requestMethodContext = context.asRequestMethodContext(method);
       if (methodConfig.isGrpcStreaming()) {
+        // Only for protobuf-based APIs.
         apiMethods.add(
             apiMethodTransformer.generateGrpcStreamingRequestObjectMethod(requestMethodContext));
       } else if (methodConfig.isLongRunningOperation()) {
+        // Only for protobuf-based APIs.
+        GapicMethodContext gapicMethodContext = (GapicMethodContext) requestMethodContext;
         if (methodConfig.isFlattening()) {
           for (FlatteningConfig flatteningGroup : methodConfig.getFlatteningConfigs()) {
             GapicMethodContext methodContext =
-                context.asFlattenedMethodContext(method, flatteningGroup);
+                context.asFlattenedMethodContext(
+                    requestMethodContext.getMethodModel(), flatteningGroup);
             apiMethods.add(
                 apiMethodTransformer.generateAsyncOperationFlattenedMethod(
                     methodContext,
@@ -349,7 +353,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
                 requestMethodContext, csharpCommonTransformer.callSettingsParam(), true));
         apiMethods.add(
             apiMethodTransformer.generateOperationRequestObjectMethod(
-                requestMethodContext, csharpCommonTransformer.callSettingsParam()));
+                gapicMethodContext, csharpCommonTransformer.callSettingsParam()));
       } else if (methodConfig.isPageStreaming()) {
         if (methodConfig.isFlattening()) {
           for (FlatteningConfig flatteningGroup : methodConfig.getFlatteningConfigs()) {

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -98,7 +98,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
 
   private SnippetsFileView generateSnippets(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    String name = namer.getApiSnippetsClassName(context.getInterface());
+    String name = namer.getApiSnippetsClassName(context.getInterfaceModel());
     SnippetsFileView.Builder snippetsBuilder = SnippetsFileView.newBuilder();
 
     snippetsBuilder.templateFileName(SNIPPETS_TEMPLATE_FILENAME);

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -339,9 +339,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     String callerResponseTypeName =
         methodContext
             .getTypeTable()
-            .getAndSaveNicknameFor(
-                namer.getStaticLangCallerAsyncReturnTypeName(
-                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
+            .getAndSaveNicknameFor(namer.getStaticLangCallerAsyncReturnTypeName(methodContext));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + suffix)
@@ -358,9 +356,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     String callerResponseTypeName =
         methodContext
             .getTypeTable()
-            .getAndSaveNicknameFor(
-                namer.getStaticLangCallerReturnTypeName(
-                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
+            .getAndSaveNicknameFor(namer.getStaticLangCallerReturnTypeName(methodContext));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + suffix)
@@ -377,9 +373,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     String callerResponseTypeName =
         methodContext
             .getTypeTable()
-            .getAndSaveNicknameFor(
-                namer.getStaticLangCallerAsyncReturnTypeName(
-                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
+            .getAndSaveNicknameFor(namer.getStaticLangCallerAsyncReturnTypeName(methodContext));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + "_RequestObject")
@@ -396,9 +390,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     String callerResponseTypeName =
         methodContext
             .getTypeTable()
-            .getAndSaveNicknameFor(
-                namer.getStaticLangCallerAsyncReturnTypeName(
-                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
+            .getAndSaveNicknameFor(namer.getStaticLangCallerAsyncReturnTypeName(methodContext));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + "_RequestObject")

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -19,11 +19,13 @@ import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
-import com.google.api.codegen.transformer.GapicMethodContext;
+import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.ParamWithSimpleDoc;
@@ -37,7 +39,6 @@ import com.google.api.codegen.viewmodel.StaticLangApiMethodSnippetView;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -102,7 +103,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
 
     snippetsBuilder.templateFileName(SNIPPETS_TEMPLATE_FILENAME);
     String outputPath =
-        pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
     snippetsBuilder.outputPath(
         outputPath + File.separator + name.replace("Generated", "") + ".g.cs");
     snippetsBuilder.name(name);
@@ -114,12 +115,12 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     return snippetsBuilder.build();
   }
 
-  private List<StaticLangApiMethodSnippetView> generateMethods(GapicInterfaceContext context) {
+  private List<StaticLangApiMethodSnippetView> generateMethods(InterfaceContext context) {
     List<StaticLangApiMethodSnippetView> methods = new ArrayList<>();
 
-    for (Method method : csharpCommonTransformer.getSupportedMethods(context)) {
+    for (MethodModel method : csharpCommonTransformer.getSupportedMethods(context)) {
       MethodConfig methodConfig = context.getMethodConfig(method);
-      GapicMethodContext methodContext = context.asRequestMethodContext(method);
+      MethodContext methodContext = context.asRequestMethodContext(method);
       if (methodConfig.isGrpcStreaming()) {
         methods.add(generateGrpcStreamingRequestMethod(methodContext));
       } else if (methodConfig.isLongRunningOperation()) {
@@ -129,7 +130,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
           for (int i = 0; i < flatteningGroups.size(); i++) {
             FlatteningConfig flatteningGroup = flatteningGroups.get(i);
             String nameSuffix = requiresNameSuffix ? Integer.toString(i + 1) : "";
-            GapicMethodContext methodContextFlat =
+            MethodContext methodContextFlat =
                 context.asFlattenedMethodContext(method, flatteningGroup);
             methods.add(generateOperationFlattenedAsyncMethod(methodContextFlat, nameSuffix));
             methods.add(generateOperationFlattenedMethod(methodContextFlat, nameSuffix));
@@ -144,7 +145,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
           for (int i = 0; i < flatteningGroups.size(); i++) {
             FlatteningConfig flatteningGroup = flatteningGroups.get(i);
             String nameSuffix = requiresNameSuffix ? Integer.toString(i + 1) : "";
-            GapicMethodContext methodContextFlat =
+            MethodContext methodContextFlat =
                 context.asFlattenedMethodContext(method, flatteningGroup);
             methods.add(generatePagedFlattenedAsyncMethod(methodContextFlat, nameSuffix));
             methods.add(generatePagedFlattenedMethod(methodContextFlat, nameSuffix));
@@ -159,7 +160,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
           for (int i = 0; i < flatteningGroups.size(); i++) {
             FlatteningConfig flatteningGroup = flatteningGroups.get(i);
             String nameSuffix = requiresNameSuffix ? Integer.toString(i + 1) : "";
-            GapicMethodContext methodContextFlat =
+            MethodContext methodContextFlat =
                 context.asFlattenedMethodContext(method, flatteningGroup);
             methods.add(generateFlattenedAsyncMethod(methodContextFlat, nameSuffix));
             methods.add(generateFlattenedMethod(methodContextFlat, nameSuffix));
@@ -174,7 +175,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateGrpcStreamingRequestMethod(
-      GapicMethodContext methodContext) {
+      MethodContext methodContext) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateGrpcStreamingRequestObjectMethod(methodContext);
@@ -189,7 +190,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateOperationFlattenedAsyncMethod(
-      GapicMethodContext methodContext, String suffix) {
+      MethodContext methodContext, String suffix) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateAsyncOperationFlattenedMethod(
@@ -208,7 +209,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateOperationFlattenedMethod(
-      GapicMethodContext methodContext, String suffix) {
+      MethodContext methodContext, String suffix) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateOperationFlattenedMethod(
@@ -224,7 +225,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateOperationRequestAsyncMethod(
-      GapicMethodContext methodContext) {
+      MethodContext methodContext) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateAsyncOperationRequestObjectMethod(
@@ -240,7 +241,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateOperationRequestMethod(
-      GapicMethodContext methodContext) {
+      MethodContext methodContext) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateOperationRequestObjectMethod(methodContext);
@@ -255,7 +256,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generatePagedFlattenedAsyncMethod(
-      GapicMethodContext methodContext, String suffix) {
+      MethodContext methodContext, String suffix) {
     StaticLangApiMethodView method =
         apiMethodTransformer.generatePagedFlattenedAsyncMethod(
             methodContext, csharpCommonTransformer.pagedMethodAdditionalParams());
@@ -263,8 +264,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     PageStreamingConfig pageStreaming = methodContext.getMethodConfig().getPageStreaming();
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
     String callerResponseTypeName =
-        namer.getAndSaveCallerAsyncPagedResponseTypeName(
-            methodContext.getMethod(), methodContext.getTypeTable(), resourceFieldConfig);
+        namer.getAndSaveCallerAsyncPagedResponseTypeName(methodContext, resourceFieldConfig);
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + suffix)
@@ -275,7 +275,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generatePagedFlattenedMethod(
-      GapicMethodContext methodContext, String suffix) {
+      MethodContext methodContext, String suffix) {
     StaticLangApiMethodView method =
         apiMethodTransformer.generatePagedFlattenedMethod(
             methodContext, csharpCommonTransformer.pagedMethodAdditionalParams());
@@ -283,8 +283,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     PageStreamingConfig pageStreaming = methodContext.getMethodConfig().getPageStreaming();
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
     String callerResponseTypeName =
-        namer.getAndSaveCallerPagedResponseTypeName(
-            methodContext.getMethod(), methodContext.getTypeTable(), resourceFieldConfig);
+        namer.getAndSaveCallerPagedResponseTypeName(methodContext, resourceFieldConfig);
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + suffix)
@@ -295,7 +294,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generatePagedRequestAsyncMethod(
-      GapicMethodContext methodContext) {
+      MethodContext methodContext) {
     StaticLangApiMethodView method =
         apiMethodTransformer.generatePagedRequestObjectAsyncMethod(
             methodContext, csharpCommonTransformer.pagedMethodAdditionalParams());
@@ -303,8 +302,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     PageStreamingConfig pageStreaming = methodContext.getMethodConfig().getPageStreaming();
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
     String callerResponseTypeName =
-        namer.getAndSaveCallerAsyncPagedResponseTypeName(
-            methodContext.getMethod(), methodContext.getTypeTable(), resourceFieldConfig);
+        namer.getAndSaveCallerAsyncPagedResponseTypeName(methodContext, resourceFieldConfig);
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + "_RequestObject")
@@ -314,8 +312,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
         .build();
   }
 
-  private StaticLangApiMethodSnippetView generatePagedRequestMethod(
-      GapicMethodContext methodContext) {
+  private StaticLangApiMethodSnippetView generatePagedRequestMethod(MethodContext methodContext) {
     StaticLangApiMethodView method =
         apiMethodTransformer.generatePagedRequestObjectMethod(
             methodContext, csharpCommonTransformer.pagedMethodAdditionalParams());
@@ -323,8 +320,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     PageStreamingConfig pageStreaming = methodContext.getMethodConfig().getPageStreaming();
     FieldConfig resourceFieldConfig = pageStreaming.getResourcesFieldConfig();
     String callerResponseTypeName =
-        namer.getAndSaveCallerPagedResponseTypeName(
-            methodContext.getMethod(), methodContext.getTypeTable(), resourceFieldConfig);
+        namer.getAndSaveCallerPagedResponseTypeName(methodContext, resourceFieldConfig);
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + "_RequestObject")
@@ -335,7 +331,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateFlattenedAsyncMethod(
-      GapicMethodContext methodContext, String suffix) {
+      MethodContext methodContext, String suffix) {
     StaticLangApiMethodView method =
         apiMethodTransformer.generateFlattenedAsyncMethod(
             methodContext, ClientMethodType.FlattenedAsyncCallSettingsMethod);
@@ -345,7 +341,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
             .getTypeTable()
             .getAndSaveNicknameFor(
                 namer.getStaticLangCallerAsyncReturnTypeName(
-                    methodContext.getMethod(), methodContext.getMethodConfig()));
+                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + suffix)
@@ -356,7 +352,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangApiMethodSnippetView generateFlattenedMethod(
-      GapicMethodContext methodContext, String suffix) {
+      MethodContext methodContext, String suffix) {
     StaticLangApiMethodView method = apiMethodTransformer.generateFlattenedMethod(methodContext);
     SurfaceNamer namer = methodContext.getNamer();
     String callerResponseTypeName =
@@ -364,7 +360,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
             .getTypeTable()
             .getAndSaveNicknameFor(
                 namer.getStaticLangCallerReturnTypeName(
-                    methodContext.getMethod(), methodContext.getMethodConfig()));
+                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + suffix)
@@ -374,7 +370,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
         .build();
   }
 
-  private StaticLangApiMethodSnippetView generateRequestMethod(GapicMethodContext methodContext) {
+  private StaticLangApiMethodSnippetView generateRequestMethod(MethodContext methodContext) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateRequestObjectMethod(methodContext);
@@ -383,7 +379,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
             .getTypeTable()
             .getAndSaveNicknameFor(
                 namer.getStaticLangCallerAsyncReturnTypeName(
-                    methodContext.getMethod(), methodContext.getMethodConfig()));
+                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + "_RequestObject")
@@ -393,8 +389,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
         .build();
   }
 
-  private StaticLangApiMethodSnippetView generateRequestAsyncMethod(
-      GapicMethodContext methodContext) {
+  private StaticLangApiMethodSnippetView generateRequestAsyncMethod(MethodContext methodContext) {
     SurfaceNamer namer = methodContext.getNamer();
     StaticLangApiMethodView method =
         apiMethodTransformer.generateRequestObjectAsyncMethod(methodContext);
@@ -403,7 +398,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
             .getTypeTable()
             .getAndSaveNicknameFor(
                 namer.getStaticLangCallerAsyncReturnTypeName(
-                    methodContext.getMethod(), methodContext.getMethodConfig()));
+                    methodContext.getMethodModel(), methodContext.getMethodConfig()));
     return StaticLangApiMethodSnippetView.newBuilder()
         .method(method)
         .snippetMethodName(method.name() + "_RequestObject")

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.transformer.csharp;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ResourceNameConfig;
@@ -35,7 +36,6 @@ import com.google.api.codegen.util.TypedValue;
 import com.google.api.codegen.util.csharp.CSharpCommentReformatter;
 import com.google.api.codegen.util.csharp.CSharpNameFormatter;
 import com.google.api.codegen.util.csharp.CSharpTypeTable;
-import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -181,7 +181,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSnippetsClassName(Interface apiInterface) {
+  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
     return publicClassName(
         Name.upperCamel("Generated", apiInterface.getSimpleName(), "ClientSnippets"));
   }
@@ -352,7 +352,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcContainerTypeName(Interface apiInterface) {
+  public String getGrpcContainerTypeName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName()));
   }
 
@@ -374,14 +374,14 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcServiceClassName(Interface apiInterface) {
+  public String getGrpcServiceClassName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName()))
         + "."
         + publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
   }
 
   @Override
-  public String getApiWrapperClassImplName(Interface apiInterface) {
+  public String getApiWrapperClassImplName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientImpl"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -204,7 +204,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "template"));
   }
 
@@ -282,7 +282,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return getResourceTypeName(resourceNameConfig);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer.csharp;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -210,7 +210,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getResourceNameFieldGetFunctionName(FieldConfig fieldConfig) {
-    FieldType type = fieldConfig.getField();
+    FieldModel type = fieldConfig.getField();
     String fieldName = fieldConfig.getField().getSimpleName();
     Name identifier = Name.from(fieldName);
     Name resourceName;
@@ -253,12 +253,12 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType field) {
+  public String getFieldGetFunctionName(FieldModel field) {
     return privateMethodName(Name.from(field.getSimpleName()));
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     return privateMethodName(Name.from(type.getSimpleName()));
   }
 
@@ -467,7 +467,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
       TransformationContext context, MethodContext methodContext, Synchronicity synchronicity) {
     MethodConfig methodConfig = methodContext.getMethodConfig();
     if (methodConfig.isPageStreaming()) {
-      FieldType resourceType = methodConfig.getPageStreaming().getResourcesField();
+      FieldModel resourceType = methodConfig.getPageStreaming().getResourcesField();
       String resourceTypeName =
           context.getImportTypeTable().getAndSaveNicknameForElementType(resourceType);
       switch (synchronicity) {
@@ -508,7 +508,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String makePrimitiveTypeNullable(String typeName, FieldType type) {
+  public String makePrimitiveTypeNullable(String typeName, FieldModel type) {
     return isPrimitive(type) ? typeName + "?" : typeName;
   }
 
@@ -539,14 +539,14 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public boolean isPrimitive(FieldType type) {
+  public boolean isPrimitive(FieldModel type) {
     return isPrimitive(type.getProtoTypeRef());
   }
 
   @Override
   public String getOptionalFieldDefaultValue(FieldConfig fieldConfig, MethodContext context) {
     // Need to provide defaults for primitives, enums, strings, and repeated (including maps)
-    FieldType type = fieldConfig.getField();
+    FieldModel type = fieldConfig.getField();
     if (context.getFeatureConfig().useResourceNameFormatOption(fieldConfig)) {
       if (type.isRepeated()) {
         TypeName elementTypeName =

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer.go;
 
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.metacode.InitCodeContext;
@@ -101,7 +102,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
     List<MockServiceImplView> impls = new ArrayList<>();
     List<ClientTestClassView> testClasses = new ArrayList<>();
 
-    for (Interface apiInterface :
+    for (InterfaceModel apiInterface :
         mockServiceTransformer.getGrpcInterfacesToMock(model, productConfig)) {
       GapicInterfaceContext context =
           GapicInterfaceContext.create(
@@ -109,7 +110,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
       impls.add(
           MockServiceImplView.newBuilder()
               .grpcClassName(namer.getGrpcServerTypeName(context.getInterfaceModel()))
-              .name(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
+              .name(namer.getMockGrpcServiceImplName(apiInterface))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
@@ -108,7 +108,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
               apiInterface, productConfig, typeTable, namer, featureConfig);
       impls.add(
           MockServiceImplView.newBuilder()
-              .grpcClassName(namer.getGrpcServerTypeName(apiInterface))
+              .grpcClassName(namer.getGrpcServerTypeName(context.getInterfaceModel()))
               .name(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
@@ -16,6 +16,8 @@ package com.google.api.codegen.transformer.go;
 
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.transformer.DefaultFeatureConfig;
@@ -45,7 +47,6 @@ import com.google.api.codegen.viewmodel.testing.MockServiceUsageView;
 import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
 import com.google.api.codegen.viewmodel.testing.TestCaseView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import java.io.File;
 import java.util.ArrayList;
@@ -108,7 +109,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
       impls.add(
           MockServiceImplView.newBuilder()
               .grpcClassName(namer.getGrpcServerTypeName(apiInterface))
-              .name(namer.getMockGrpcServiceImplName(apiInterface))
+              .name(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }
@@ -150,7 +151,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
   private List<TestCaseView> createTestCaseViews(GapicInterfaceContext context) {
     ArrayList<TestCaseView> testCaseViews = new ArrayList<>();
     SymbolTable testNameTable = new SymbolTable();
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       GapicMethodContext methodContext = context.asRequestMethodContext(method);
       ClientMethodType clientMethodType = ClientMethodType.RequestObjectMethod;
       if (methodContext.getMethodConfig().isPageStreaming()) {
@@ -175,7 +176,8 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
   private SmokeTestClassView createSmokeTestClassView(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
 
-    Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+    MethodModel method =
+        new ProtoMethodModel(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
     GapicMethodContext methodContext = context.asRequestMethodContext(method);
 
     SmokeTestClassView.Builder testClass = SmokeTestClassView.newBuilder();
@@ -200,7 +202,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
     // The shared code above add imports both for input and output.
     // Since we use short decls, we don't need to import anything for output.
     context.getModelTypeTable().getImports().clear();
-    context.getModelTypeTable().getAndSaveNicknameFor(method.getInputType());
+    method.getAndSaveRequestTypeName(methodContext.getTypeTable(), methodContext.getNamer());
 
     FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
     testClass.fileHeader(fileHeader);

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -138,8 +138,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.templateFileName(API_TEMPLATE_FILENAME);
     view.serviceDoc(serviceTransformer.generateServiceDoc(context, null));
     view.clientTypeName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    view.clientConstructorName(
-        namer.getApiWrapperClassConstructorName(apiInterface.getSimpleName()));
+    view.clientConstructorName(namer.getApiWrapperClassConstructorName(apiInterface));
     view.defaultClientOptionFunctionName(namer.getDefaultApiSettingsFunctionName(apiInterface));
     view.defaultCallOptionFunctionName(namer.getDefaultCallSettingsFunctionName(apiInterface));
     view.callOptionsTypeName(namer.getCallSettingsTypeName(apiInterface));
@@ -215,10 +214,8 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.outputPath(outputPath + File.separator + fileName);
 
     view.clientTypeName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    view.clientConstructorName(
-        namer.getApiWrapperClassConstructorName(apiInterface.getSimpleName()));
-    view.clientConstructorExampleName(
-        namer.getApiWrapperClassConstructorExampleName(apiInterface.getSimpleName()));
+    view.clientConstructorName(namer.getApiWrapperClassConstructorName(apiInterface));
+    view.clientConstructorExampleName(namer.getApiWrapperClassConstructorExampleName(apiInterface));
     view.apiMethods(generateApiMethods(context, context.getPublicMethods()));
     view.iamResources(iamResourceTransformer.generateIamResources(context));
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoImportSectionTransformer.java
@@ -15,9 +15,9 @@
 package com.google.api.codegen.transformer.go;
 
 import com.google.api.codegen.metacode.InitCodeNode;
-import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
-import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
@@ -27,13 +27,13 @@ import java.util.Map;
 
 public class GoImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(InterfaceContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context) {
     return generateImportSection(context.getImportTypeTable().getImports());
   }
 
   @Override
   public ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes) {
+      MethodContext context, Iterable<InitCodeNode> specItemNodes) {
     return generateImportSection(context.getTypeTable().getImports());
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -67,9 +67,9 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(
-        getReducedServiceName(apiInterfaceSimpleName)
+        getReducedServiceName(apiInterface.getSimpleName())
             .join(resourceNameConfig.getEntityName())
             .join("path")
             .join("template"));
@@ -77,15 +77,15 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateNameGetter(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
-    return getFormatFunctionName(apiInterfaceSimpleName, resourceNameConfig);
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+    return getFormatFunctionName(apiInterface, resourceNameConfig);
   }
 
   @Override
   public String getFormatFunctionName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
-        clientNamePrefix(apiInterfaceSimpleName)
+        clientNamePrefix(apiInterface.getSimpleName())
             .join(resourceNameConfig.getEntityName())
             .join("path"));
   }
@@ -181,7 +181,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getServerRegisterFunctionName(Interface apiInterface) {
+  public String getServerRegisterFunctionName(InterfaceModel apiInterface) {
     return converter.getTypeName(apiInterface).getNickname().replace(".", ".Register") + "Server";
   }
 
@@ -220,31 +220,29 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(String apiInterfaceSimpleName) {
+  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
     return publicMethodName(
-        Name.from("new").join(clientNamePrefix(apiInterfaceSimpleName)).join("client"));
+        Name.from("new").join(clientNamePrefix(apiInterface.getSimpleName())).join("client"));
   }
 
   @Override
-  public String getApiWrapperClassConstructorExampleName(String apiInterfaceSimpleName) {
+  public String getApiWrapperClassConstructorExampleName(InterfaceModel apiInterface) {
     return publicMethodName(
         Name.from("example")
             .join("new")
-            .join(clientNamePrefix(apiInterfaceSimpleName))
+            .join(clientNamePrefix(apiInterface.getSimpleName()))
             .join("client"));
   }
 
   @Override
-  public String getApiMethodExampleName(String apiInterfaceSimpleName, MethodModel method) {
-    return exampleFunction(
-        apiInterfaceSimpleName, getApiMethodName(method, VisibilityConfig.PUBLIC));
+  public String getApiMethodExampleName(InterfaceModel apiInterface, MethodModel method) {
+    return exampleFunction(apiInterface, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
   public String getGrpcStreamingApiMethodExampleName(
-      String apiInterfaceSimpleName, MethodModel method) {
-    return exampleFunction(
-        apiInterfaceSimpleName, getApiMethodName(method, VisibilityConfig.PUBLIC));
+      InterfaceModel apiInterface, MethodModel method) {
+    return exampleFunction(apiInterface, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
@@ -302,7 +300,8 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getServiceFileName(InterfaceConfig interfaceConfig) {
-    return classFileNameBase(getReducedServiceName(interfaceConfig.getRawName()).join("client"));
+    return classFileNameBase(
+        getReducedServiceName(interfaceConfig.getInterfaceModel().getSimpleName()).join("client"));
   }
 
   @Override
@@ -317,11 +316,6 @@ public class GoSurfaceNamer extends SurfaceNamer {
   @Override
   public String getStubName(InterfaceModel apiInterface) {
     return privateFieldName(clientNamePrefix(apiInterface.getSimpleName()).join("client"));
-  }
-
-  @Override
-  public String getStubName(String apiInterfaceSimpleName) {
-    return privateFieldName(clientNamePrefix(apiInterfaceSimpleName).join("client"));
   }
 
   @Override
@@ -358,8 +352,8 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getIamResourceGetterFunctionExampleName(
-      String apiInterfaceSimpleName, FieldModel field) {
-    return exampleFunction(apiInterfaceSimpleName, getIamResourceGetterFunctionName(field));
+      InterfaceModel apiInterface, FieldModel field) {
+    return exampleFunction(apiInterface, getIamResourceGetterFunctionName(field));
   }
 
   @Override
@@ -367,25 +361,28 @@ public class GoSurfaceNamer extends SurfaceNamer {
     return publicFieldName(Name.upperCamel(method.getSimpleName()));
   }
 
-  private String exampleFunction(String apiInterfaceSimpleName, String functionName) {
+  private String exampleFunction(InterfaceModel apiInterface, String functionName) {
     // We use "unsafe" string concatenation here.
     // Godoc expects the name to be in format "ExampleMyType_MyMethod";
     // it is the only place we have mixed camel and underscore names.
     return publicMethodName(
-            Name.from("example").join(clientNamePrefix(apiInterfaceSimpleName)).join("client"))
+            Name.from("example")
+                .join(clientNamePrefix(apiInterface.getSimpleName()))
+                .join("client"))
         + "_"
         + functionName;
   }
 
   @Override
-  public String getMockGrpcServiceImplName(String apiInterfaceSimpleName) {
+  public String getMockGrpcServiceImplName(InterfaceModel apiInterface) {
     return privateClassName(
-        Name.from("mock").join(getReducedServiceName(apiInterfaceSimpleName)).join("server"));
+        Name.from("mock").join(getReducedServiceName(apiInterface.getSimpleName()).join("server")));
   }
 
   @Override
-  public String getMockServiceVarName(String apiInterfaceSimpleName) {
-    return localVarName(Name.from("mock").join(getReducedServiceName(apiInterfaceSimpleName)));
+  public String getMockServiceVarName(InterfaceModel apiInterface) {
+    return localVarName(
+        Name.from("mock").join(getReducedServiceName(apiInterface.getSimpleName())));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer.go;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -399,7 +399,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     return publicMethodName(identifier);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -17,9 +17,11 @@ package com.google.api.codegen.transformer.go;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.OneofConfig;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
@@ -33,7 +35,6 @@ import com.google.api.codegen.util.PassThroughCommentReformatter;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.go.GoNameFormatter;
 import com.google.api.codegen.util.go.GoTypeTable;
-import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.annotations.VisibleForTesting;
@@ -165,12 +166,17 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcServerTypeName(Interface apiInterface) {
+  public String getGrpcServerTypeName(InterfaceModel apiInterface) {
     return converter.getTypeName(apiInterface).getNickname() + "Server";
   }
 
   @Override
   public String getGrpcClientTypeName(Interface apiInterface) {
+    return getGrpcClientTypeName(new ProtoInterfaceModel(apiInterface));
+  }
+
+  @Override
+  public String getGrpcClientTypeName(InterfaceModel apiInterface) {
     return converter.getTypeName(apiInterface).getNickname() + "Client";
   }
 
@@ -180,13 +186,13 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getCallSettingsTypeName(Interface apiInterface) {
+  public String getCallSettingsTypeName(InterfaceModel apiInterface) {
     return publicClassName(
         clientNamePrefix(apiInterface.getSimpleName()).join("call").join("options"));
   }
 
   @Override
-  public String getDefaultApiSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultApiSettingsFunctionName(InterfaceModel apiInterface) {
     return privateMethodName(
         Name.from("default")
             .join(clientNamePrefix(apiInterface.getSimpleName()))
@@ -195,7 +201,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getDefaultCallSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultCallSettingsFunctionName(InterfaceModel apiInterface) {
     return privateMethodName(
         Name.from("default")
             .join(clientNamePrefix(apiInterface.getSimpleName()))
@@ -290,7 +296,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcContainerTypeName(Interface apiInterface) {
+  public String getGrpcContainerTypeName(InterfaceModel apiInterface) {
     return "";
   }
 
@@ -300,7 +306,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getExampleFileName(Interface apiInterface) {
+  public String getExampleFileName(InterfaceModel apiInterface) {
     return classFileNameBase(
         getReducedServiceName(apiInterface.getSimpleName())
             .join("client")
@@ -309,7 +315,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getStubName(Interface apiInterface) {
+  public String getStubName(InterfaceModel apiInterface) {
     return privateFieldName(clientNamePrefix(apiInterface.getSimpleName()).join("client"));
   }
 
@@ -319,7 +325,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getCreateStubFunctionName(Interface apiInterface) {
+  public String getCreateStubFunctionName(InterfaceModel apiInterface) {
     return getGrpcClientTypeName(apiInterface).replace(".", ".New");
   }
 
@@ -344,15 +350,15 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getIamResourceGetterFunctionName(Field field) {
-    return Name.upperCamel(field.getParent().getSimpleName())
+  public String getIamResourceGetterFunctionName(FieldModel field) {
+    return Name.upperCamel(field.getParentSimpleName())
         .join(Name.upperCamelKeepUpperAcronyms("IAM"))
         .toUpperCamel();
   }
 
   @Override
   public String getIamResourceGetterFunctionExampleName(
-      String apiInterfaceSimpleName, Field field) {
+      String apiInterfaceSimpleName, FieldModel field) {
     return exampleFunction(apiInterfaceSimpleName, getIamResourceGetterFunctionName(field));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -90,8 +90,11 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getStaticLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
-    return method.getOutputTypeName(converter).getFullName();
+  public String getStaticLangReturnTypeName(MethodContext methodContext) {
+    return methodContext
+        .getMethodModel()
+        .getOutputTypeName(methodContext.getTypeTable())
+        .getFullName();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
@@ -16,6 +16,8 @@ package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.InterfaceModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.*;
 import com.google.api.codegen.viewmodel.FileHeaderView;
@@ -56,15 +58,17 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
 
   GapicInterfaceContext getSampleContext(Model model, GapicProductConfig productConfig) {
     for (Interface apiInterface : new InterfaceView().getElementIterable(model)) {
-      GapicInterfaceContext context = testTransformer.createContext(apiInterface, productConfig);
+      GapicInterfaceContext context =
+          testTransformer.createContext(new ProtoInterfaceModel(apiInterface), productConfig);
       if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
         // We use the first encountered smoke test config as the sample application
-        return testTransformer.createContext(apiInterface, productConfig);
+        return testTransformer.createContext(context.getInterfaceModel(), productConfig);
       }
     }
 
     // Use the first interface as the default one if no smoke test config is found
-    Interface defaultInterface = new InterfaceView().getElementIterable(model).iterator().next();
+    InterfaceModel defaultInterface =
+        new ProtoInterfaceModel(new InterfaceView().getElementIterable(model).iterator().next());
     return testTransformer.createContext(defaultInterface, productConfig);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
@@ -54,7 +54,7 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
     return Lists.newArrayList(SAMPLE_TEMPLATE_FILE);
   }
 
-  public GapicInterfaceContext getSampleContext(Model model, GapicProductConfig productConfig) {
+  GapicInterfaceContext getSampleContext(Model model, GapicProductConfig productConfig) {
     for (Interface apiInterface : new InterfaceView().getElementIterable(model)) {
       GapicInterfaceContext context = testTransformer.createContext(apiInterface, productConfig);
       if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
@@ -71,7 +71,7 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
   private ViewModel createSampleClassView(GapicInterfaceContext context) {
     if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
       String outputPath =
-          pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+          pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
       SurfaceNamer namer = context.getNamer();
       String name = namer.getSampleAppClassName();
 
@@ -91,9 +91,8 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
     testTransformer.addSmokeTestImports(context);
 
     SurfaceNamer namer = context.getNamer();
-    SmokeTestClassView.Builder testClass = SmokeTestClassView.newBuilder();
     String outputPath =
-        pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
     String name = namer.getSampleAppClassName();
     FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
@@ -71,7 +71,8 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
   private ViewModel createSampleClassView(GapicInterfaceContext context) {
     if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
       String outputPath =
-          pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+          pathMapper.getOutputPath(
+              context.getInterfaceModel().getFullName(), context.getProductConfig());
       SurfaceNamer namer = context.getNamer();
       String name = namer.getSampleAppClassName();
 
@@ -92,7 +93,8 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
 
     SurfaceNamer namer = context.getNamer();
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String name = namer.getSampleAppClassName();
     FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -113,7 +113,8 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
   private SmokeTestClassView createSmokeTestClassView(GapicInterfaceContext context) {
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     SurfaceNamer namer = context.getNamer();
     String name = namer.getSmokeTestClassName(context.getInterfaceConfig());
 
@@ -263,14 +264,15 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
     SurfaceNamer namer = context.getNamer();
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
-    String name = namer.getMockServiceClassName(context.getInterfaceSimpleName());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
+    String name = namer.getMockServiceClassName(context.getInterfaceModel().getSimpleName());
 
     MockServiceView.Builder mockService = MockServiceView.newBuilder();
 
     mockService.name(name);
     mockService.serviceImplClassName(
-        namer.getMockGrpcServiceImplName(context.getInterfaceSimpleName()));
+        namer.getMockGrpcServiceImplName(context.getInterfaceModel().getSimpleName()));
     mockService.outputPath(namer.getSourceFilePath(outputPath, name));
     mockService.templateFileName(MOCK_SERVICE_FILE);
 
@@ -281,18 +283,18 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     return mockService.build();
   }
 
-  private MockServiceImplFileView createMockServiceImplFileView(GapicInterfaceContext context) {
+  private MockServiceImplFileView createMockServiceImplFileView(InterfaceContext context) {
     addMockServiceImplImports(context);
 
-    Interface apiInterface = context.getInterface();
     SurfaceNamer namer = context.getNamer();
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
-    String name = namer.getMockGrpcServiceImplName(context.getInterfaceSimpleName());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
+    String name = namer.getMockGrpcServiceImplName(context.getInterfaceModel().getSimpleName());
     String grpcClassName =
         context
             .getImportTypeTable()
-            .getAndSaveNicknameFor(namer.getGrpcServiceClassName(apiInterface));
+            .getAndSaveNicknameFor(namer.getGrpcServiceClassName(context.getInterfaceModel()));
 
     MockServiceImplFileView.Builder mockServiceImplFile = MockServiceImplFileView.newBuilder();
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -32,6 +32,7 @@ import com.google.api.codegen.transformer.ApiCallableTransformer;
 import com.google.api.codegen.transformer.BatchingTransformer;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
+import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
@@ -171,7 +172,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
         new JavaModelTypeNameConverter(implicitPackageName));
   }
 
-  private StaticLangFileView<StaticLangApiView> generateApiFile(GapicInterfaceContext context) {
+  private StaticLangFileView<StaticLangApiView> generateApiFile(InterfaceContext context) {
     StaticLangFileView.Builder<StaticLangApiView> apiFile =
         StaticLangFileView.<StaticLangApiView>newBuilder();
 
@@ -180,7 +181,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     apiFile.classView(generateApiClass(context));
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiWrapperClassName(context.getInterfaceConfig());
     apiFile.outputPath(outputPath + File.separator + className + ".java");
 
@@ -190,9 +192,9 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     return apiFile.build();
   }
 
-  private StaticLangApiView generateApiClass(GapicInterfaceContext context) {
+  private StaticLangApiView generateApiClass(InterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    GapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
 
     addApiImports(context);
 
@@ -501,9 +503,9 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     return fileView.build();
   }
 
-  private StaticLangGrpcStubView generateGrpcStubClass(GapicInterfaceContext context) {
+  private StaticLangGrpcStubView generateGrpcStubClass(InterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    GapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
 
     addGrpcStubImports(context);
 
@@ -529,17 +531,17 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     return stubClass.build();
   }
 
-  private String getAndSaveNicknameForRootType(GapicInterfaceContext context, String nickname) {
+  private String getAndSaveNicknameForRootType(InterfaceContext context, String nickname) {
     SurfaceNamer namer = context.getNamer();
-    ModelTypeTable typeTable = context.getModelTypeTable();
+    ImportTypeTable typeTable = context.getImportTypeTable();
 
     String fullyQualifiedTypeName = namer.getRootPackageName() + "." + nickname;
     return typeTable.getAndSaveNicknameFor(fullyQualifiedTypeName);
   }
 
-  private String getAndSaveNicknameForStubType(GapicInterfaceContext context, String nickname) {
+  private String getAndSaveNicknameForStubType(InterfaceContext context, String nickname) {
     SurfaceNamer namer = context.getNamer();
-    ModelTypeTable typeTable = context.getModelTypeTable();
+    ImportTypeTable typeTable = context.getImportTypeTable();
 
     String fullyQualifiedTypeName = namer.getStubPackageName() + "." + nickname;
     return typeTable.getAndSaveNicknameFor(fullyQualifiedTypeName);
@@ -589,8 +591,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     return packageInfo.build();
   }
 
-  private void addApiImports(GapicInterfaceContext context) {
-    ModelTypeTable typeTable = context.getModelTypeTable();
+  private void addApiImports(InterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.core.BackgroundResource");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallable");
@@ -607,8 +609,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     }
   }
 
-  private void addSettingsImports(GapicInterfaceContext context) {
-    ModelTypeTable typeTable = context.getModelTypeTable();
+  private void addSettingsImports(InterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
     typeTable.saveNicknameFor("com.google.api.core.ApiFunction");
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.core.CredentialsProvider");
@@ -675,8 +677,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     }
   }
 
-  private void addGrpcStubImports(GapicInterfaceContext context) {
-    ModelTypeTable typeTable = context.getModelTypeTable();
+  private void addGrpcStubImports(InterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
 
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.core.BackgroundResource");
@@ -690,7 +692,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("java.util.concurrent.TimeUnit");
     typeTable.saveNicknameFor("javax.annotation.Generated");
 
-    GapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
     if (interfaceConfig.hasGrpcStreamingMethods()) {
       typeTable.saveNicknameFor("com.google.api.gax.rpc.StreamingCallable");
     }
@@ -700,22 +702,22 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     }
   }
 
-  private void addStubInterfaceImports(GapicInterfaceContext context) {
-    ModelTypeTable typeTable = context.getModelTypeTable();
+  private void addStubInterfaceImports(InterfaceContext context) {
+    ImportTypeTable typeTable = context.getImportTypeTable();
 
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.core.BackgroundResource");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.UnaryCallable");
     typeTable.saveNicknameFor("javax.annotation.Generated");
 
-    GapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
     if (interfaceConfig.hasLongRunningOperations()) {
       typeTable.saveNicknameFor("com.google.longrunning.Operation");
       typeTable.saveNicknameFor("com.google.longrunning.stub.OperationsStub");
     }
   }
 
-  private void addPagedResponseWrapperImports(ModelTypeTable typeTable) {
+  private void addPagedResponseWrapperImports(ImportTypeTable typeTable) {
     typeTable.saveNicknameFor("com.google.api.core.ApiFunction");
     typeTable.saveNicknameFor("com.google.api.core.ApiFuture");
     typeTable.saveNicknameFor("com.google.api.core.ApiFutures");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -18,7 +18,7 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicProductConfig;
@@ -284,7 +284,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
   private StaticLangPagedResponseView generatePagedResponseWrapper(
       MethodContext context, ModelTypeTable typeTable) {
     MethodModel method = context.getMethodModel();
-    FieldType resourceField = context.getMethodConfig().getPageStreaming().getResourcesField();
+    FieldModel resourceField = context.getMethodConfig().getPageStreaming().getResourcesField();
 
     StaticLangPagedResponseView.Builder pagedResponseWrapper =
         StaticLangPagedResponseView.newBuilder();

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -380,7 +380,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     settingsFile.templateFileName(SETTINGS_TEMPLATE_FILENAME);
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiSettingsClassName(context.getInterfaceConfig());
     settingsFile.outputPath(outputPath + File.separator + className + ".java");
 
@@ -444,7 +445,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     fileView.templateFileName(STUB_INTERFACE_TEMPLATE_FILENAME);
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiStubInterfaceName(context.getInterfaceConfig());
     fileView.outputPath(
         outputPath + File.separator + "stub" + File.separator + className + ".java");
@@ -487,7 +489,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     fileView.templateFileName(GRPC_STUB_TEMPLATE_FILENAME);
 
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String className = context.getNamer().getApiGrpcStubClassName(context.getInterfaceConfig());
     fileView.outputPath(
         outputPath + File.separator + "stub" + File.separator + className + ".java");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -106,11 +106,12 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getStaticLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+  public String getStaticLangReturnTypeName(MethodContext methodContext) {
+    MethodModel method = methodContext.getMethodModel();
     if (method.isOutputTypeEmpty()) {
       return "void";
     }
-    return method.getOutputTypeFullName(getTypeFormatter());
+    return method.getOutputTypeName(methodContext.getTypeTable()).getFullName();
   }
 
   @Override
@@ -130,11 +131,12 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGenericAwareResponseTypeName(MethodModel method) {
+  public String getGenericAwareResponseTypeName(MethodContext methodContext) {
+    MethodModel method = methodContext.getMethodModel();
     if (method.isOutputTypeEmpty()) {
       return "Void";
     } else {
-      return method.getOutputTypeFullName(getTypeFormatter());
+      return method.getOutputTypeName(methodContext.getTypeTable()).getFullName();
     }
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -15,16 +15,18 @@
 package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.ReleaseLevel;
-import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldType;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
+import com.google.api.codegen.transformer.SchemaTypeFormatterImpl;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.api.codegen.util.Name;
@@ -34,7 +36,6 @@ import com.google.api.codegen.util.java.JavaRenderingUtil;
 import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.api.codegen.viewmodel.ServiceMethodType;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -53,6 +54,17 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     super(
         new JavaNameFormatter(),
         new ModelTypeFormatterImpl(new JavaModelTypeNameConverter(packageName)),
+        new JavaTypeTable(packageName),
+        new JavaCommentReformatter(),
+        rootPackageName,
+        packageName);
+  }
+
+  /* Create a JavaSurfaceNamer for a Discovery-based API. */
+  public JavaSurfaceNamer(String packageName, String rootPackageName, JavaNameFormatter formatter) {
+    super(
+        formatter,
+        new SchemaTypeFormatterImpl(new JavaSchemaTypeNameConverter(packageName, formatter)),
         new JavaTypeTable(packageName),
         new JavaCommentReformatter(),
         rootPackageName,
@@ -94,37 +106,35 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getStaticLangReturnTypeName(Method method, MethodConfig methodConfig) {
-    if (ServiceMessages.s_isEmptyType(method.getOutputType())) {
+  public String getStaticLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+    if (method.isOutputTypeEmpty()) {
       return "void";
     }
-    return getModelTypeFormatter().getFullNameFor(method.getOutputType());
+    return method.getOutputTypeFullName(getTypeFormatter());
   }
 
   @Override
   public String getAndSaveOperationResponseTypeName(
-      Method method, ImportTypeTable typeTable, MethodConfig methodConfig) {
+      MethodModel method, ImportTypeTable typeTable, MethodConfig methodConfig) {
     String responseTypeName =
-        ((ModelTypeTable) typeTable)
-            .getFullNameFor(methodConfig.getLongRunningConfig().getReturnType());
+        methodConfig.getLongRunningConfig().getLongRunningOperationReturnTypeFullName(typeTable);
     String metadataTypeName =
-        ((ModelTypeTable) typeTable)
-            .getFullNameFor(methodConfig.getLongRunningConfig().getMetadataType());
+        methodConfig.getLongRunningConfig().getLongRunningOperationMetadataTypeFullName(typeTable);
     return typeTable.getAndSaveNicknameForContainer(
         "com.google.api.gax.grpc.OperationFuture", responseTypeName, metadataTypeName);
   }
 
   @Override
-  public String getLongRunningOperationTypeName(ModelTypeTable typeTable, TypeRef type) {
-    return typeTable.getAndSaveNicknameForElementType(type);
+  public String getLongRunningOperationTypeName(ImportTypeTable typeTable, TypeRef type) {
+    return ((ModelTypeTable) typeTable).getAndSaveNicknameForElementType(type);
   }
 
   @Override
-  public String getGenericAwareResponseTypeName(TypeRef outputType) {
-    if (ServiceMessages.s_isEmptyType(outputType)) {
+  public String getGenericAwareResponseTypeName(MethodModel method) {
+    if (method.isOutputTypeEmpty()) {
       return "Void";
     } else {
-      return getModelTypeFormatter().getFullNameFor(outputType);
+      return method.getOutputTypeFullName(getTypeFormatter());
     }
   }
 
@@ -148,32 +158,33 @@ public class JavaSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getAndSavePagedResponseTypeName(
-      Method method, ImportTypeTable typeTable, FieldConfig resourceFieldConfig) {
+      MethodContext methodContext, FieldConfig resourceFieldConfig) {
     // TODO(michaelbausor) make sure this uses the typeTable correctly
-
+    ImportTypeTable typeTable = methodContext.getTypeTable();
     String fullPackageWrapperName =
         typeTable.getImplicitPackageFullNameFor(getPagedResponseWrappersClassName());
     String pagedResponseShortName =
-        getPagedResponseTypeInnerName(method, typeTable, resourceFieldConfig.getField());
+        getPagedResponseTypeInnerName(
+            methodContext.getMethodModel(), typeTable, resourceFieldConfig.getField());
     return typeTable.getAndSaveNicknameForInnerType(fullPackageWrapperName, pagedResponseShortName);
   }
 
   @Override
   public String getPagedResponseTypeInnerName(
-      Method method, ImportTypeTable typeTable, FieldType resourceField) {
-    return publicClassName(Name.upperCamel(method.getSimpleName(), "PagedResponse"));
+      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+    return publicClassName(Name.anyCamel(method.getSimpleName(), "PagedResponse"));
   }
 
   @Override
   public String getPageTypeInnerName(
-      Method method, ImportTypeTable typeTable, FieldType resourceField) {
-    return publicClassName(Name.upperCamel(method.getSimpleName(), "Page"));
+      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+    return publicClassName(Name.anyCamel(method.getSimpleName(), "Page"));
   }
 
   @Override
   public String getFixedSizeCollectionTypeInnerName(
-      Method method, ImportTypeTable typeTable, FieldType resourceField) {
-    return publicClassName(Name.upperCamel(method.getSimpleName(), "FixedSizeCollection"));
+      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+    return publicClassName(Name.anyCamel(method.getSimpleName(), "FixedSizeCollection"));
   }
 
   @Override
@@ -256,7 +267,7 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getBatchingDescriptorConstName(Method method) {
+  public String getBatchingDescriptorConstName(MethodModel method) {
     return inittedConstantName(Name.upperCamel(method.getSimpleName()).join("batching_desc"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -16,7 +16,7 @@ package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -87,7 +87,7 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public boolean shouldImportRequestObjectParamElementType(FieldType field) {
+  public boolean shouldImportRequestObjectParamElementType(FieldModel field) {
     if (field.isMap()) {
       return false;
     } else {
@@ -173,19 +173,19 @@ public class JavaSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPagedResponseTypeInnerName(
-      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+      MethodModel method, ImportTypeTable typeTable, FieldModel resourceField) {
     return publicClassName(Name.anyCamel(method.getSimpleName(), "PagedResponse"));
   }
 
   @Override
   public String getPageTypeInnerName(
-      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+      MethodModel method, ImportTypeTable typeTable, FieldModel resourceField) {
     return publicClassName(Name.anyCamel(method.getSimpleName(), "Page"));
   }
 
   @Override
   public String getFixedSizeCollectionTypeInnerName(
-      MethodModel method, ImportTypeTable typeTable, FieldType resourceField) {
+      MethodModel method, ImportTypeTable typeTable, FieldModel resourceField) {
     return publicClassName(Name.anyCamel(method.getSimpleName(), "FixedSizeCollection"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ResourceNameType;
@@ -35,7 +36,6 @@ import com.google.api.codegen.util.java.JavaNameFormatter;
 import com.google.api.codegen.util.java.JavaRenderingUtil;
 import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.api.codegen.viewmodel.ServiceMethodType;
-import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -77,7 +77,7 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSnippetsClassName(Interface apiInterface) {
+  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientSnippets"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSApiMethodParamTransformer.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer.nodejs;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.transformer.ApiMethodParamTransformer;
 import com.google.api.codegen.transformer.GapicMethodContext;
@@ -48,7 +48,7 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
       return ImmutableList.of();
     }
     ImmutableList.Builder<DynamicLangDefaultableParamView> methodParams = ImmutableList.builder();
-    for (FieldType field : context.getMethodConfig().getRequiredFields()) {
+    for (FieldModel field : context.getMethodConfig().getRequiredFields()) {
       DynamicLangDefaultableParamView param =
           DynamicLangDefaultableParamView.newBuilder()
               .name(context.getNamer().getVariableName(field))
@@ -80,7 +80,7 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
     paramDoc.lines(ImmutableList.of("The request object that will be sent."));
 
     String typeName = "Object";
-    Iterable<FieldType> optionalParams = removePageTokenFromFields(methodConfig);
+    Iterable<FieldModel> optionalParams = removePageTokenFromFields(methodConfig);
     if (!methodConfig.getRequiredFieldConfigs().iterator().hasNext()
         && !optionalParams.iterator().hasNext()) {
       typeName += "=";
@@ -102,9 +102,9 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
     return paramDoc.build();
   }
 
-  private List<FieldType> removePageTokenFromFields(MethodConfig methodConfig) {
-    ImmutableList.Builder<FieldType> newFields = ImmutableList.builder();
-    for (FieldType field : methodConfig.getOptionalFields()) {
+  private List<FieldModel> removePageTokenFromFields(MethodConfig methodConfig) {
+    ImmutableList.Builder<FieldModel> newFields = ImmutableList.builder();
+    for (FieldModel field : methodConfig.getOptionalFields()) {
       if (methodConfig.isPageStreaming()
           && field.equals(methodConfig.getPageStreaming().getRequestTokenField())) {
         continue;
@@ -115,11 +115,11 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
   }
 
   private List<ParamDocView> generateMethodParamDocs(
-      GapicMethodContext context, Iterable<FieldType> fields, boolean isOptional) {
+      GapicMethodContext context, Iterable<FieldModel> fields, boolean isOptional) {
     SurfaceNamer namer = context.getNamer();
     MethodConfig methodConfig = context.getMethodConfig();
     ImmutableList.Builder<ParamDocView> docs = ImmutableList.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       if (isRequestTokenParam(methodConfig, field)) {
         continue;
       }
@@ -148,12 +148,12 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
     return docs.build();
   }
 
-  private boolean isRequestTokenParam(MethodConfig methodConfig, FieldType field) {
+  private boolean isRequestTokenParam(MethodConfig methodConfig, FieldModel field) {
     return methodConfig.isPageStreaming()
         && field.equals(methodConfig.getPageStreaming().getRequestTokenField());
   }
 
-  private boolean isPageSizeParam(MethodConfig methodConfig, FieldType field) {
+  private boolean isPageSizeParam(MethodConfig methodConfig, FieldModel field) {
     return methodConfig.isPageStreaming()
         && methodConfig.getPageStreaming().hasPageSizeField()
         && field.equals(methodConfig.getPageStreaming().getPageSizeField());

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSApiMethodParamTransformer.java
@@ -20,7 +20,6 @@ import com.google.api.codegen.transformer.ApiMethodParamTransformer;
 import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
-import com.google.api.codegen.util.js.JSCommentReformatter;
 import com.google.api.codegen.viewmodel.DynamicLangDefaultableParamView;
 import com.google.api.codegen.viewmodel.ParamDocView;
 import com.google.api.codegen.viewmodel.SimpleParamDocView;
@@ -28,7 +27,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransformer {
-  private static JSCommentReformatter commentReformatter = new JSCommentReformatter();
 
   @Override
   public List<DynamicLangDefaultableParamView> generateMethodParams(GapicMethodContext context) {
@@ -46,7 +44,7 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
 
   private List<DynamicLangDefaultableParamView> generateDefaultableParams(
       GapicMethodContext context) {
-    if (context.getMethod().getRequestStreaming()) {
+    if (context.getMethodModel().getRequestStreaming()) {
       return ImmutableList.of();
     }
     ImmutableList.Builder<DynamicLangDefaultableParamView> methodParams = ImmutableList.builder();
@@ -64,7 +62,7 @@ public class NodeJSApiMethodParamTransformer implements ApiMethodParamTransforme
   @Override
   public List<ParamDocView> generateParamDocs(GapicMethodContext context) {
     ImmutableList.Builder<ParamDocView> docs = ImmutableList.builder();
-    if (!context.getMethod().getRequestStreaming()) {
+    if (!context.getMethodModel().getRequestStreaming()) {
       docs.add(generateRequestObjectParamDoc(context));
       docs.addAll(
           generateMethodParamDocs(context, context.getMethodConfig().getRequiredFields(), false));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -20,6 +20,8 @@ import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.nodejs.NodeJSUtils;
@@ -53,7 +55,6 @@ import com.google.api.codegen.viewmodel.testing.MockServiceUsageView;
 import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
 import com.google.api.codegen.viewmodel.testing.TestCaseView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -113,7 +114,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
       impls.add(
           MockServiceImplView.newBuilder()
               .grpcClassName(namer.getGrpcServerTypeName(apiInterface))
-              .name(namer.getMockGrpcServiceImplName(apiInterface))
+              .name(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }
@@ -168,7 +169,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
   private List<TestCaseView> createTestCaseViews(GapicInterfaceContext context) {
     ArrayList<TestCaseView> testCaseViews = new ArrayList<>();
     SymbolTable testNameTable = new SymbolTable();
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       GapicMethodContext methodContext = context.asRequestMethodContext(method);
       if (methodContext.getMethodConfig().getGrpcStreamingType()
           == GrpcStreamingType.ClientStreaming) {
@@ -229,7 +230,8 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
     SurfaceNamer namer = context.getNamer();
     String name = namer.getSmokeTestClassName(context.getInterfaceConfig());
 
-    Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+    ProtoMethodModel method =
+        new ProtoMethodModel(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
     FlatteningConfig flatteningGroup =
         testCaseTransformer.getSmokeTestFlatteningGroup(
             context.getMethodConfig(method), context.getInterfaceConfig().getSmokeTestConfig());

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -113,7 +113,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
               apiInterface, productConfig, typeTable, namer, featureConfig);
       impls.add(
           MockServiceImplView.newBuilder()
-              .grpcClassName(namer.getGrpcServerTypeName(apiInterface))
+              .grpcClassName(namer.getGrpcServerTypeName(context.getInterfaceModel()))
               .name(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
@@ -135,7 +135,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
                       "NodeJSGapicSurfaceTestTransformer.generateTestView - name"))
               .testCases(createTestCaseViews(context))
               .apiHasLongRunningMethods(context.getInterfaceConfig().hasLongRunningOperations())
-              .packageServiceName(namer.getPackageServiceName(apiInterface))
+              .packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()))
               .missingDefaultServiceAddress(
                   !context.getInterfaceConfig().hasDefaultServiceAddress())
               .missingDefaultServiceScopes(!context.getInterfaceConfig().hasDefaultServiceScopes())

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProtoMethodModel;
@@ -106,7 +107,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
     List<MockServiceImplView> impls = new ArrayList<>();
     List<ClientTestClassView> testClasses = new ArrayList<>();
 
-    for (Interface apiInterface :
+    for (InterfaceModel apiInterface :
         mockServiceTransformer.getGrpcInterfacesToMock(model, productConfig)) {
       GapicInterfaceContext context =
           GapicInterfaceContext.create(
@@ -114,7 +115,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
       impls.add(
           MockServiceImplView.newBuilder()
               .grpcClassName(namer.getGrpcServerTypeName(context.getInterfaceModel()))
-              .name(namer.getMockGrpcServiceImplName(apiInterface.getSimpleName()))
+              .name(namer.getMockGrpcServiceImplName(apiInterface))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -169,8 +169,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()));
 
     xapiClass.validDescriptorsNames(generateValidDescriptorsNames(context));
-    xapiClass.constructorName(
-        namer.getApiWrapperClassConstructorName(context.getInterfaceModel().getSimpleName()));
+    xapiClass.constructorName(namer.getApiWrapperClassConstructorName(context.getInterfaceModel()));
     xapiClass.isGcloud(NodeJSUtils.isGcloud(context.getProductConfig()));
 
     return xapiClass.build();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -153,10 +153,10 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
-            context.getModelTypeTable(), context.getInterface()));
+            context.getModelTypeTable(), context.getInterfaceModel()));
 
     xapiClass.apiMethods(methods);
 
@@ -166,11 +166,11 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
         packageConfig.generatedPackageVersionBound(TargetLanguage.NODEJS).lower());
 
     xapiClass.packageHasMultipleServices(hasMultipleServices);
-    xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterface()));
+    xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()));
 
     xapiClass.validDescriptorsNames(generateValidDescriptorsNames(context));
     xapiClass.constructorName(
-        namer.getApiWrapperClassConstructorName(context.getInterface().getSimpleName()));
+        namer.getApiWrapperClassConstructorName(context.getInterfaceModel().getSimpleName()));
     xapiClass.isGcloud(NodeJSUtils.isGcloud(context.getProductConfig()));
 
     return xapiClass.build();
@@ -278,12 +278,12 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
           VersionIndexRequireView.newBuilder()
               .clientName(
                   namer.getApiWrapperVariableName(productConfig.getInterfaceConfig(apiInterface)))
-              .serviceName(namer.getPackageServiceName(apiInterface))
+              .serviceName(namer.getPackageServiceName(context.getInterfaceModel()))
               .localName(localName)
               .doc(
                   serviceTransformer.generateServiceDoc(
                       context, generateApiMethods(context, packageHasMultipleServices).get(0)))
-              .fileName(namer.getClientFileName(apiInterface))
+              .fileName(namer.getClientFileName(context.getInterfaceModel()))
               .build();
       requireViews.add(require);
     }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -14,17 +14,18 @@
  */
 package com.google.api.codegen.transformer.nodejs;
 
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
+import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.StandardImportSectionTransformer;
 import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.ImportTypeView;
-import com.google.api.tools.framework.model.Interface;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.List;
@@ -43,9 +44,9 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
     return new StandardImportSectionTransformer().generateImportSection(context, specItemNodes);
   }
 
-  private List<ImportFileView> generateExternalImports(GapicInterfaceContext context) {
+  private List<ImportFileView> generateExternalImports(InterfaceContext context) {
     ImmutableList.Builder<ImportFileView> imports = ImmutableList.builder();
-    Interface apiInterface = context.getInterface();
+    InterfaceModel apiInterface = context.getInterfaceModel();
     String configModule = context.getNamer().getClientConfigPath(apiInterface);
     imports.add(createImport("configData", "./" + configModule));
     imports.add(createImport("extend", "extend"));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -16,11 +16,11 @@ package com.google.api.codegen.transformer.nodejs;
 
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
-import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
-import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.StandardImportSectionTransformer;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.ImportTypeView;
@@ -31,7 +31,7 @@ import java.util.List;
 
 public class NodeJSImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(InterfaceContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context) {
     ImportSectionView.Builder importSection = ImportSectionView.newBuilder();
     importSection.externalImports(generateExternalImports((GapicInterfaceContext) context));
     return importSection.build();
@@ -39,7 +39,7 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
 
   @Override
   public ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes) {
+      MethodContext context, Iterable<InitCodeNode> specItemNodes) {
     return new StandardImportSectionTransformer().generateImportSection(context, specItemNodes);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -18,7 +18,9 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.config.VersionBound;
 import com.google.api.codegen.nodejs.NodeJSUtils;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
@@ -41,7 +43,6 @@ import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.metadata.PackageDependencyView;
 import com.google.api.codegen.viewmodel.metadata.ReadmeMetadataView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -142,7 +143,8 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
     for (Interface apiInterface : interfaces) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
       if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
-        Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+        MethodModel method =
+            new ProtoMethodModel(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
         FlatteningConfig flatteningGroup =
             testCaseTransformer.getSmokeTestFlatteningGroup(
                 context.getMethodConfig(method), context.getInterfaceConfig().getSmokeTestConfig());

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -14,23 +14,23 @@
  */
 package com.google.api.codegen.transformer.nodejs;
 
-import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldType;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.InterfaceContext;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.transformer.Synchronicity;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.NamePath;
@@ -103,8 +103,8 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(Interface apiInterface) {
-    return publicFieldName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
+  public String getApiWrapperClassConstructorName(String apiInterfaceSimpleName) {
+    return publicFieldName(Name.upperCamel(apiInterfaceSimpleName, "Client"));
   }
 
   @Override
@@ -118,7 +118,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
@@ -130,7 +130,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 
@@ -154,12 +154,12 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getDynamicLangReturnTypeName(Method method, MethodConfig methodConfig) {
-    if (new ServiceMessages().isEmptyType(method.getOutputType())) {
+  public String getDynamicLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+    if (method.isOutputTypeEmpty()) {
       return "";
     }
 
-    return getModelTypeFormatter().getFullNameFor(method.getOutputType());
+    return method.getOutputTypeFullName(getModelTypeFormatter());
   }
 
   @Override
@@ -184,19 +184,19 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldGetFunctionName(TypeRef type, Name identifier) {
+  public String getFieldGetFunctionName(FieldType type, Name identifier) {
     return identifier.toLowerCamel();
   }
 
   @Override
-  public String getAsyncApiMethodName(Method method, VisibilityConfig visibility) {
+  public String getAsyncApiMethodName(MethodModel method, VisibilityConfig visibility) {
     return getApiMethodName(Name.upperCamel(method.getSimpleName()), visibility);
   }
 
   /** Return JSDoc callback comment and return type comment for the given method. */
   @Override
   public List<String> getReturnDocLines(
-      InterfaceContext context, MethodConfig methodConfig, Synchronicity synchronicity) {
+      TransformationContext context, MethodConfig methodConfig, Synchronicity synchronicity) {
     GapicMethodConfig gapicMethodConfig = (GapicMethodConfig) methodConfig;
     Method method = ((GapicMethodConfig) methodConfig).getMethod();
     if (method.getRequestStreaming() && method.getResponseStreaming()) {

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -103,8 +103,8 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(String apiInterfaceSimpleName) {
-    return publicFieldName(Name.upperCamel(apiInterfaceSimpleName, "Client"));
+  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
+    return publicFieldName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
   }
 
   @Override
@@ -118,7 +118,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
@@ -130,7 +130,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
@@ -38,7 +39,6 @@ import com.google.api.codegen.util.js.JSCommentReformatter;
 import com.google.api.codegen.util.js.JSNameFormatter;
 import com.google.api.codegen.util.js.JSTypeTable;
 import com.google.api.tools.framework.model.EnumType;
-import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.ProtoFile;
@@ -98,7 +98,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getPackageServiceName(Interface apiInterface) {
+  public String getPackageServiceName(InterfaceModel apiInterface) {
     return getReducedServiceName(apiInterface.getSimpleName()).toLowerCamel();
   }
 
@@ -135,11 +135,11 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceModel apiInterface) {
     return Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore();
   }
 
-  public String getClientFileName(Interface apiInterface) {
+  public String getClientFileName(InterfaceModel apiInterface) {
     return Name.upperCamel(apiInterface.getSimpleName()).join("client").toLowerUnderscore();
   }
 
@@ -164,13 +164,13 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFullyQualifiedStubType(Interface apiInterface) {
+  public String getFullyQualifiedStubType(InterfaceModel apiInterface) {
     return getModelTypeFormatter().getFullNameFor(apiInterface);
   }
 
   @Override
-  public String getGrpcClientImportName(Interface apiInterface) {
-    return "grpc-" + NamePath.dotted(apiInterface.getFile().getFullName()).toDashed();
+  public String getGrpcClientImportName(InterfaceModel apiInterface) {
+    return "grpc-" + NamePath.dotted(apiInterface.getFileFullName()).toDashed();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer.nodejs;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.InterfaceConfig;
@@ -144,7 +144,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public boolean shouldImportRequestObjectParamType(FieldType field) {
+  public boolean shouldImportRequestObjectParamType(FieldModel field) {
     return field.isMap();
   }
 
@@ -175,17 +175,17 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFieldGetFunctionName(FeatureConfig featureConfig, FieldConfig fieldConfig) {
-    FieldType field = fieldConfig.getField();
+    FieldModel field = fieldConfig.getField();
     return Name.from(field.getSimpleName()).toLowerCamel();
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType field) {
+  public String getFieldGetFunctionName(FieldModel field) {
     return Name.from(field.getSimpleName()).toLowerCamel();
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     return identifier.toLowerCamel();
   }
 
@@ -341,7 +341,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
     String returnTypeDoc = "";
     if (methodConfig.isPageStreaming()) {
       returnTypeDoc = "Array of ";
-      FieldType resourcesType = methodConfig.getPageStreaming().getResourcesField();
+      FieldModel resourcesType = methodConfig.getPageStreaming().getResourcesField();
       if (resourcesType.isMessage()) {
         returnTypeDoc +=
             commentReformatter.getLinkedElementName(
@@ -388,7 +388,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public List<String> getDocLines(FieldType field) {
+  public List<String> getDocLines(FieldModel field) {
     ImmutableList.Builder<String> lines = ImmutableList.builder();
     List<String> fieldDocLines = getDocLines(field.getScopedDocumentation());
     String extraFieldDescription = getExtraFieldDescription(field);
@@ -404,7 +404,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
     return lines.build();
   }
 
-  private String getExtraFieldDescription(FieldType field) {
+  private String getExtraFieldDescription(FieldModel field) {
     boolean fieldIsMessage = field.isMessage() && !field.isMap();
     boolean fieldIsEnum = field.isEnum();
     if (fieldIsMessage) {
@@ -456,7 +456,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getByteLengthFunctionName(FieldType typeRef) {
+  public String getByteLengthFunctionName(FieldModel typeRef) {
     if (typeRef.isMessage()) {
       return "gax.createByteLengthFunction(grpcClients." + typeRef.getTypeFullName() + ")";
     } else if (typeRef.isString() || typeRef.isBytes()) {

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
@@ -56,7 +56,7 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
 
   private List<DynamicLangDefaultableParamView> generateDefaultableParams(
       GapicMethodContext context) {
-    if (context.getMethod().getRequestStreaming()) {
+    if (context.getMethodModel().getRequestStreaming()) {
       return ImmutableList.<DynamicLangDefaultableParamView>of();
     }
     ImmutableList.Builder<DynamicLangDefaultableParamView> methodParams = ImmutableList.builder();
@@ -73,7 +73,7 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
 
   private List<ParamDocView> getMethodParamDocs(
       GapicMethodContext context, Iterable<FieldType> fields) {
-    if (context.getMethod().getRequestStreaming()) {
+    if (context.getMethodModel().getRequestStreaming()) {
       return ImmutableList.of();
     }
     MethodConfig methodConfig = context.getMethodConfig();

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer.php;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.transformer.ApiMethodParamTransformer;
 import com.google.api.codegen.transformer.GapicMethodContext;
@@ -60,7 +60,7 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
       return ImmutableList.<DynamicLangDefaultableParamView>of();
     }
     ImmutableList.Builder<DynamicLangDefaultableParamView> methodParams = ImmutableList.builder();
-    for (FieldType field : context.getMethodConfig().getRequiredFields()) {
+    for (FieldModel field : context.getMethodConfig().getRequiredFields()) {
       DynamicLangDefaultableParamView param =
           DynamicLangDefaultableParamView.newBuilder()
               .name(context.getNamer().getVariableName(field))
@@ -72,13 +72,13 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
   }
 
   private List<ParamDocView> getMethodParamDocs(
-      GapicMethodContext context, Iterable<FieldType> fields) {
+      GapicMethodContext context, Iterable<FieldModel> fields) {
     if (context.getMethodModel().getRequestStreaming()) {
       return ImmutableList.of();
     }
     MethodConfig methodConfig = context.getMethodConfig();
     ImmutableList.Builder<ParamDocView> paramDocs = ImmutableList.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       SimpleParamDocView.Builder paramDoc = SimpleParamDocView.newBuilder();
       paramDoc.paramName(context.getNamer().getVariableName(field));
       paramDoc.typeName(context.getTypeTable().getAndSaveNicknameFor(field));
@@ -124,7 +124,7 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
   }
 
   private ParamDocView getOptionalArrayParamDoc(
-      GapicMethodContext context, Iterable<FieldType> fields) {
+      GapicMethodContext context, Iterable<FieldModel> fields) {
     MapParamDocView.Builder paramDoc = MapParamDocView.newBuilder();
 
     Name optionalArgsName = Name.from("optional", "args");

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
@@ -192,7 +192,8 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
       addUnitTestImports(typeTable);
 
-      String outputPath = pathMapper.getOutputPath(context.getInterfaceFullName(), productConfig);
+      String outputPath =
+          pathMapper.getOutputPath(context.getInterfaceModel().getFullName(), productConfig);
       ImportSectionView importSection =
           importSectionTransformer.generateImportSection(typeTable.getImports());
       testViews.add(

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
@@ -100,10 +101,10 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
       SurfaceNamer testPackageNamer) {
     List<MockServiceImplFileView> mockFiles = new ArrayList<>();
 
-    for (Interface grpcInterface :
+    for (InterfaceModel grpcInterface :
         mockServiceTransformer.getGrpcInterfacesToMock(model, productConfig)) {
       ModelTypeTable typeTable = createTypeTable(surfacePackageNamer.getTestPackageName());
-      String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface.getSimpleName());
+      String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface);
       String grpcClassName =
           typeTable.getAndSaveNicknameFor(surfacePackageNamer.getGrpcClientTypeName(grpcInterface));
       MockServiceImplView mockImpl =
@@ -146,12 +147,12 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
               apiInterface, productConfig, typeTable, surfacePackageNamer, featureConfig);
       List<MockServiceUsageView> mockServiceList = new ArrayList<>();
 
-      for (Interface grpcInterface :
+      for (InterfaceModel grpcInterface :
           mockServiceTransformer
               .getGrpcInterfacesForService(model, productConfig, apiInterface)
               .values()) {
-        String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface.getSimpleName());
-        String varName = surfacePackageNamer.getMockServiceVarName(grpcInterface.getSimpleName());
+        String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface);
+        String varName = surfacePackageNamer.getMockServiceVarName(grpcInterface);
         String grpcClassName =
             typeTable.getAndSaveNicknameFor(
                 surfacePackageNamer.getGrpcClientTypeName(grpcInterface));

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTestTransformer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.php.PhpGapicCodePathMapper;
@@ -47,7 +48,6 @@ import com.google.api.codegen.viewmodel.testing.MockServiceImplView;
 import com.google.api.codegen.viewmodel.testing.MockServiceUsageView;
 import com.google.api.codegen.viewmodel.testing.TestCaseView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -103,7 +103,7 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
     for (Interface grpcInterface :
         mockServiceTransformer.getGrpcInterfacesToMock(model, productConfig)) {
       ModelTypeTable typeTable = createTypeTable(surfacePackageNamer.getTestPackageName());
-      String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface);
+      String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface.getSimpleName());
       String grpcClassName =
           typeTable.getAndSaveNicknameFor(surfacePackageNamer.getGrpcClientTypeName(grpcInterface));
       MockServiceImplView mockImpl =
@@ -112,7 +112,7 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
               .grpcClassName(grpcClassName)
               .grpcMethods(new ArrayList<MockGrpcMethodView>())
               .build();
-      String outputPath = pathMapper.getOutputPath(grpcInterface, productConfig);
+      String outputPath = pathMapper.getOutputPath(grpcInterface.getFullName(), productConfig);
 
       addUnitTestImports(typeTable);
 
@@ -150,8 +150,8 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
           mockServiceTransformer
               .getGrpcInterfacesForService(model, productConfig, apiInterface)
               .values()) {
-        String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface);
-        String varName = surfacePackageNamer.getMockServiceVarName(grpcInterface);
+        String name = surfacePackageNamer.getMockGrpcServiceImplName(grpcInterface.getSimpleName());
+        String varName = surfacePackageNamer.getMockServiceVarName(grpcInterface.getSimpleName());
         String grpcClassName =
             typeTable.getAndSaveNicknameFor(
                 surfacePackageNamer.getGrpcClientTypeName(grpcInterface));
@@ -192,7 +192,7 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
       addUnitTestImports(typeTable);
 
-      String outputPath = pathMapper.getOutputPath(context.getInterface(), productConfig);
+      String outputPath = pathMapper.getOutputPath(context.getInterfaceFullName(), productConfig);
       ImportSectionView importSection =
           importSectionTransformer.generateImportSection(typeTable.getImports());
       testViews.add(
@@ -212,7 +212,7 @@ public class PhpGapicSurfaceTestTransformer implements ModelToViewTransformer {
   private List<TestCaseView> createTestCaseViews(GapicInterfaceContext context) {
     ArrayList<TestCaseView> testCaseViews = new ArrayList<>();
     SymbolTable testNameTable = new SymbolTable();
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       GapicMethodContext methodContext = context.asRequestMethodContext(method);
 
       if (methodContext.getMethodConfig().getGrpcStreamingType()

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -99,7 +99,8 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
 
   public List<ViewModel> transform(GapicInterfaceContext context) {
     String outputPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     SurfaceNamer namer = context.getNamer();
 
     List<ViewModel> surfaceData = new ArrayList<>();
@@ -138,11 +139,11 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.grpcStreamingDescriptors(createGrpcStreamingDescriptors(context));
 
     xapiClass.methodKeys(generateMethodKeys(context));
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
     xapiClass.interfaceKey(context.getInterface().getFullName());
     String grpcClientTypeName =
         namer.getAndSaveNicknameForGrpcClientTypeName(
-            context.getModelTypeTable(), context.getInterface());
+            context.getModelTypeTable(), context.getInterfaceModel());
     xapiClass.grpcClientTypeName(grpcClientTypeName);
 
     xapiClass.apiMethods(methods);

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -20,8 +20,8 @@ import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig;
 import com.google.api.codegen.config.LongRunningConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ProductServiceConfig;
-import com.google.api.codegen.config.ProtoField;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
@@ -42,7 +42,6 @@ import com.google.api.codegen.viewmodel.GrpcStreamingDetailView;
 import com.google.api.codegen.viewmodel.LongRunningOperationDetailView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.TypeRef;
 import java.util.ArrayList;
@@ -100,7 +99,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
 
   public List<ViewModel> transform(GapicInterfaceContext context) {
     String outputPath =
-        pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
     SurfaceNamer namer = context.getNamer();
 
     List<ViewModel> surfaceData = new ArrayList<>();
@@ -169,7 +168,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
       GapicInterfaceContext context) {
     List<LongRunningOperationDetailView> result = new ArrayList<>();
 
-    for (Method method : context.getLongRunningMethods()) {
+    for (MethodModel method : context.getLongRunningMethods()) {
       GapicMethodContext methodContext = context.asDynamicMethodContext(method);
       LongRunningConfig lroConfig = methodContext.getMethodConfig().getLongRunningConfig();
       TypeRef returnType = lroConfig.getReturnType();
@@ -198,15 +197,13 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
       GapicInterfaceContext context) {
     List<GrpcStreamingDetailView> result = new ArrayList<>();
 
-    for (Method method : context.getGrpcStreamingMethods()) {
+    for (MethodModel method : context.getGrpcStreamingMethods()) {
       GrpcStreamingConfig grpcStreamingConfig =
           context.asDynamicMethodContext(method).getMethodConfig().getGrpcStreaming();
       String resourcesFieldGetFunction = null;
       if (grpcStreamingConfig.hasResourceField()) {
         resourcesFieldGetFunction =
-            context
-                .getNamer()
-                .getFieldGetFunctionName(new ProtoField(grpcStreamingConfig.getResourcesField()));
+            context.getNamer().getFieldGetFunctionName(grpcStreamingConfig.getResourcesField());
       }
       result.add(
           GrpcStreamingDetailView.newBuilder()
@@ -242,7 +239,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<String> generateMethodKeys(GapicInterfaceContext context) {
     List<String> methodKeys = new ArrayList<>(context.getInterface().getMethods().size());
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       methodKeys.add(context.getNamer().getMethodKey(method));
     }
 
@@ -252,7 +249,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<ApiMethodView> generateApiMethods(GapicInterfaceContext context) {
     List<ApiMethodView> apiMethods = new ArrayList<>(context.getInterface().getMethods().size());
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       apiMethods.add(apiMethodTransformer.generateMethod(context.asDynamicMethodContext(method)));
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpImportSectionTransformer.java
@@ -15,9 +15,9 @@
 package com.google.api.codegen.transformer.php;
 
 import com.google.api.codegen.metacode.InitCodeNode;
-import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
-import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
@@ -27,13 +27,13 @@ import java.util.Map;
 
 public class PhpImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(InterfaceContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context) {
     return generateImportSection(context.getImportTypeTable().getImports());
   }
 
   @Override
   public ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes) {
+      MethodContext context, Iterable<InitCodeNode> specItemNodes) {
     return generateImportSection(context.getTypeTable().getImports());
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -21,6 +21,7 @@ import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
@@ -114,7 +115,9 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getDynamicLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+  public String getDynamicLangReturnTypeName(MethodContext methodContext) {
+    MethodModel method = methodContext.getMethodModel();
+    MethodConfig methodConfig = methodContext.getMethodConfig();
     if (method.isOutputTypeEmpty()) {
       return "";
     }
@@ -123,7 +126,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
     }
     switch (methodConfig.getGrpcStreamingType()) {
       case NonStreaming:
-        return method.getOutputTypeFullName(getModelTypeFormatter());
+        return method.getOutputTypeName(methodContext.getTypeTable()).getFullName();
       case BidiStreaming:
         return "\\Google\\GAX\\BidiStream";
       case ClientStreaming:

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -16,8 +16,10 @@ package com.google.api.codegen.transformer.php;
 
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
@@ -93,7 +95,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceModel apiInterface) {
     return "resources/"
         + Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore()
         + ".json";
@@ -147,10 +149,15 @@ public class PhpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getGrpcClientTypeName(Interface apiInterface) {
+    return getGrpcClientTypeName(new ProtoInterfaceModel(apiInterface));
+  }
+
+  @Override
+  public String getGrpcClientTypeName(InterfaceModel apiInterface) {
     return qualifiedName(getGrpcClientTypeName(apiInterface, "GrpcClient"));
   }
 
-  private NamePath getGrpcClientTypeName(Interface apiInterface, String suffix) {
+  private NamePath getGrpcClientTypeName(InterfaceModel apiInterface, String suffix) {
     NamePath namePath =
         getTypeNameConverter().getNamePath(getModelTypeFormatter().getFullNameFor(apiInterface));
     String publicClassName =
@@ -169,7 +176,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcStubCallString(Interface apiInterface, MethodModel method) {
+  public String getGrpcStubCallString(InterfaceModel apiInterface, MethodModel method) {
     return '/' + apiInterface.getFullName() + '/' + getGrpcMethodName(method);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -90,7 +90,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "name", "template"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer.php;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -62,7 +62,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldSetFunctionName(FieldType field) {
+  public String getFieldSetFunctionName(FieldModel field) {
     return publicMethodName(Name.from("set").join(field.getSimpleName()));
   }
 
@@ -72,17 +72,17 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldAddFunctionName(FieldType field) {
+  public String getFieldAddFunctionName(FieldModel field) {
     return publicMethodName(Name.from("add").join(field.getSimpleName()));
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType field) {
+  public String getFieldGetFunctionName(FieldModel field) {
     return publicMethodName(Name.from("get").join(field.getSimpleName()));
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     return publicMethodName(Name.from("get").join(identifier));
   }
 
@@ -100,7 +100,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public boolean shouldImportRequestObjectParamType(FieldType field) {
+  public boolean shouldImportRequestObjectParamType(FieldModel field) {
     return field.isMap();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
@@ -35,7 +35,7 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
     if (context.getMethod().getRequestStreaming()) {
       methodParams.add(
           DynamicLangDefaultableParamView.newBuilder()
-              .name(context.getNamer().getRequestVariableName(context.getMethod()))
+              .name(context.getNamer().getRequestVariableName(context.getMethodModel()))
               .defaultValue("")
               .build());
     } else {
@@ -72,7 +72,7 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
   @Override
   public List<ParamDocView> generateParamDocs(GapicMethodContext context) {
     ImmutableList.Builder<ParamDocView> docs = ImmutableList.builder();
-    if (context.getMethod().getRequestStreaming()) {
+    if (context.getMethodModel().getRequestStreaming()) {
       docs.add(generateRequestStreamingParamDoc(context));
     } else {
       docs.addAll(generateMethodParamDocs(context, context.getMethodConfig().getRequiredFields()));

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer.py;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.transformer.ApiMethodParamTransformer;
 import com.google.api.codegen.transformer.GapicMethodContext;
@@ -39,14 +39,14 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
               .defaultValue("")
               .build());
     } else {
-      for (FieldType field : context.getMethodConfig().getRequiredFields()) {
+      for (FieldModel field : context.getMethodConfig().getRequiredFields()) {
         DynamicLangDefaultableParamView.Builder param =
             DynamicLangDefaultableParamView.newBuilder();
         param.name(context.getNamer().getVariableName(field));
         param.defaultValue("");
         methodParams.add(param.build());
       }
-      for (FieldType field : context.getMethodConfig().getOptionalFields()) {
+      for (FieldModel field : context.getMethodConfig().getOptionalFields()) {
         if (isRequestTokenParam(context.getMethodConfig(), field)) {
           continue;
         }
@@ -94,11 +94,11 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
   }
 
   private List<ParamDocView> generateMethodParamDocs(
-      GapicMethodContext context, Iterable<FieldType> fields) {
+      GapicMethodContext context, Iterable<FieldModel> fields) {
     SurfaceNamer namer = context.getNamer();
     MethodConfig methodConfig = context.getMethodConfig();
     ImmutableList.Builder<ParamDocView> docs = ImmutableList.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       if (isRequestTokenParam(methodConfig, field)) {
         continue;
       }
@@ -123,13 +123,13 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
     return docs.build();
   }
 
-  private boolean isPageSizeParam(MethodConfig methodConfig, FieldType field) {
+  private boolean isPageSizeParam(MethodConfig methodConfig, FieldModel field) {
     return methodConfig.isPageStreaming()
         && methodConfig.getPageStreaming().hasPageSizeField()
         && field.equals(methodConfig.getPageStreaming().getPageSizeField());
   }
 
-  private boolean isRequestTokenParam(MethodConfig methodConfig, FieldType field) {
+  private boolean isRequestTokenParam(MethodConfig methodConfig, FieldModel field) {
     return methodConfig.isPageStreaming()
         && field.equals(methodConfig.getPageStreaming().getRequestTokenField());
   }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
@@ -18,7 +18,9 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
@@ -51,7 +53,6 @@ import com.google.api.codegen.viewmodel.testing.MockServiceUsageView;
 import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
 import com.google.api.codegen.viewmodel.testing.TestCaseView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -152,7 +153,7 @@ public class PythonGapicSurfaceTestTransformer implements ModelToViewTransformer
   private List<TestCaseView> createTestCaseViews(GapicInterfaceContext context) {
     ImmutableList.Builder<TestCaseView> testCaseViews = ImmutableList.builder();
     SymbolTable testNameTable = new SymbolTable();
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       GapicMethodContext methodContext = context.asRequestMethodContext(method);
       ClientMethodType clientMethodType = ClientMethodType.OptionalArrayMethod;
       if (methodContext.getMethodConfig().isLongRunningOperation()) {
@@ -213,7 +214,8 @@ public class PythonGapicSurfaceTestTransformer implements ModelToViewTransformer
     String outputPath =
         Joiner.on(File.separator).join("tests", "system", "gapic", version, filename);
 
-    Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+    MethodModel method =
+        new ProtoMethodModel(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
     FlatteningConfig flatteningGroup =
         testCaseTransformer.getSmokeTestFlatteningGroup(
             context.getMethodConfig(method), context.getInterfaceConfig().getSmokeTestConfig());

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTestTransformer.java
@@ -121,7 +121,8 @@ public class PythonGapicSurfaceTestTransformer implements ModelToViewTransformer
               .name(testClassName)
               .apiName(
                   surfacePackageNamer.publicClassName(
-                      Name.upperCamelKeepUpperAcronyms(apiInterface.getSimpleName())))
+                      Name.upperCamelKeepUpperAcronyms(
+                          context.getInterfaceModel().getSimpleName())))
               .testCases(createTestCaseViews(context))
               .apiHasLongRunningMethods(context.getInterfaceConfig().hasLongRunningOperations())
               .missingDefaultServiceAddress(

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -17,7 +17,7 @@ package com.google.api.codegen.transformer.py;
 import com.google.api.codegen.GeneratorVersionProvider;
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.TargetLanguage;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.MethodModel;
@@ -143,8 +143,8 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
     addFieldsImports(typeTable, methodConfig.getOptionalFields());
   }
 
-  private void addFieldsImports(ModelTypeTable typeTable, Iterable<FieldType> fields) {
-    for (FieldType field : fields) {
+  private void addFieldsImports(ModelTypeTable typeTable, Iterable<FieldModel> fields) {
+    for (FieldModel field : fields) {
       typeTable.getAndSaveNicknameFor(field);
     }
   }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -20,6 +20,7 @@ import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.FieldType;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -55,7 +56,6 @@ import com.google.api.codegen.viewmodel.PathTemplateGetterFunctionView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.MessageType;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoContainerElement;
 import com.google.api.tools.framework.model.ProtoFile;
@@ -125,7 +125,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
       }
     }
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       addMethodImports(context.asDynamicMethodContext(method));
     }
   }
@@ -151,7 +151,8 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
 
   private ViewModel generateApiClass(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    String subPath = pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+    String subPath =
+        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
     String name = namer.getApiWrapperClassName(context.getInterfaceConfig());
     List<ApiMethodView> methods = generateApiMethods(context);
 
@@ -210,7 +211,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<ApiMethodView> generateApiMethods(GapicInterfaceContext context) {
     ImmutableList.Builder<ApiMethodView> apiMethods = ImmutableList.builder();
 
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       apiMethods.add(apiMethodTransformer.generateMethod(context.asDynamicMethodContext(method)));
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -152,7 +152,8 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
   private ViewModel generateApiClass(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
     String subPath =
-        pathMapper.getOutputPath(context.getInterfaceFullName(), context.getProductConfig());
+        pathMapper.getOutputPath(
+            context.getInterfaceModel().getFullName(), context.getProductConfig());
     String name = namer.getApiWrapperClassName(context.getInterfaceConfig());
     List<ApiMethodView> methods = generateApiMethods(context);
 
@@ -162,7 +163,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.fileHeader(fileHeaderTransformer.generateFileHeader(context));
     xapiClass.protoFilename(context.getInterface().getFile().getSimpleName());
-    xapiClass.servicePhraseName(namer.getServicePhraseName(context.getInterface()));
+    xapiClass.servicePhraseName(namer.getServicePhraseName(context.getInterfaceModel()));
 
     xapiClass.name(name);
     xapiClass.doc(serviceTransformer.generateServiceDoc(context, methods.get(0)));
@@ -194,10 +195,10 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
-            context.getModelTypeTable(), context.getInterface()));
+            context.getModelTypeTable(), context.getInterfaceModel()));
 
     xapiClass.apiMethods(methods);
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
@@ -20,7 +20,9 @@ import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
 import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelTypeTable;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
@@ -38,19 +40,20 @@ import java.util.TreeSet;
 
 public class PythonImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(InterfaceContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context) {
+    InterfaceContext interfaceContext = (InterfaceContext) context;
     return ImportSectionView.newBuilder()
         .standardImports(generateFileHeaderStandardImports())
-        .externalImports(generateFileHeaderExternalImports(context))
+        .externalImports(generateFileHeaderExternalImports(interfaceContext))
         .appImports(generateFileHeaderAppImports(context.getImportTypeTable().getImports()))
         .build();
   }
 
   @Override
   public ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes) {
+      MethodContext context, Iterable<InitCodeNode> specItemNodes) {
     return ImportSectionView.newBuilder()
-        .appImports(generateInitCodeAppImports(context, specItemNodes))
+        .appImports(generateInitCodeAppImports(((GapicMethodContext) context), specItemNodes))
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -20,7 +20,9 @@ import com.google.api.codegen.SnippetSetRunner;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.gapic.GapicProvider;
 import com.google.api.codegen.transformer.DefaultFeatureConfig;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
@@ -41,7 +43,6 @@ import com.google.api.codegen.viewmodel.SimpleViewModel;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.metadata.ReadmeMetadataView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.snippet.Doc;
 import com.google.common.base.Joiner;
@@ -175,7 +176,8 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer 
     for (Interface apiInterface : new InterfaceView().getElementIterable(model)) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
       if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
-        Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+        MethodModel method =
+            new ProtoMethodModel(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
         FlatteningConfig flatteningGroup =
             testCaseTransformer.getSmokeTestFlatteningGroup(
                 context.getMethodConfig(method), context.getInterfaceConfig().getSmokeTestConfig());

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -19,8 +19,10 @@ import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
@@ -68,8 +70,8 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getServicePhraseName(Interface apiInterface) {
-    return apiInterface.getParent().getFullName() + " " + apiInterface.getSimpleName() + " API";
+  public String getServicePhraseName(InterfaceModel apiInterface) {
+    return apiInterface.getParentFullName() + " " + apiInterface.getSimpleName() + " API";
   }
 
   @Override
@@ -188,12 +190,17 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getGrpcClientTypeName(Interface apiInterface) {
+    return getGrpcClientTypeName(new ProtoInterfaceModel(apiInterface));
+  }
+
+  @Override
+  public String getGrpcClientTypeName(InterfaceModel apiInterface) {
     String fullName = getModelTypeFormatter().getFullNameFor(apiInterface) + "Stub";
     return getTypeNameConverter().getTypeName(fullName).getNickname();
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceModel apiInterface) {
     return classFileNameBase(Name.upperCamel(apiInterface.getSimpleName()).join("client_config"))
         + ".json";
   }
@@ -260,7 +267,7 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcStubCallString(Interface apiInterface, MethodModel method) {
+  public String getGrpcStubCallString(InterfaceModel apiInterface, MethodModel method) {
     return getGrpcMethodName(method);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -75,8 +75,8 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(String apiInterfaceSimpleName) {
-    return getApiWrapperClassName(apiInterfaceSimpleName);
+  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
+    return getApiWrapperClassName(apiInterface.getSimpleName());
   }
 
   @Override
@@ -171,14 +171,14 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return "_"
         + inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   @Override
   public String getFormatFunctionName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -16,7 +16,7 @@ package com.google.api.codegen.transformer.py;
 
 import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.ServiceMessages;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
@@ -265,12 +265,12 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     return publicFieldName(Name.from(type.getSimpleName()));
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType field) {
+  public String getFieldGetFunctionName(FieldModel field) {
     return publicFieldName(Name.from(field.getSimpleName()));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
@@ -219,7 +220,8 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public List<String> getReturnDocLines(
-      TransformationContext context, MethodConfig methodConfig, Synchronicity synchronicity) {
+      TransformationContext context, MethodContext methodContext, Synchronicity synchronicity) {
+    MethodConfig methodConfig = methodContext.getMethodConfig();
     TypeRef outputType = ((GapicMethodConfig) methodConfig).getMethod().getOutputType();
     if (ServiceMessages.s_isEmptyType(outputType)) {
       return ImmutableList.<String>of();

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
@@ -29,9 +29,9 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
   @Override
   public List<DynamicLangDefaultableParamView> generateMethodParams(GapicMethodContext context) {
     ImmutableList.Builder<DynamicLangDefaultableParamView> methodParams = ImmutableList.builder();
-    if (context.getMethod().getRequestStreaming()) {
+    if (context.getMethodModel().getRequestStreaming()) {
       DynamicLangDefaultableParamView.Builder param = DynamicLangDefaultableParamView.newBuilder();
-      param.name(context.getNamer().getRequestVariableName(context.getMethod()));
+      param.name(context.getNamer().getRequestVariableName(context.getMethodModel()));
       param.defaultValue("");
       methodParams.add(param.build());
     } else {
@@ -67,7 +67,7 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
   @Override
   public List<ParamDocView> generateParamDocs(GapicMethodContext context) {
     ImmutableList.Builder<ParamDocView> docs = ImmutableList.builder();
-    if (context.getMethod().getRequestStreaming()) {
+    if (context.getMethodModel().getRequestStreaming()) {
       docs.add(generateRequestStreamingParamDoc(context));
     } else {
       docs.addAll(generateMethodParamDocs(context, context.getMethodConfig().getRequiredFields()));
@@ -79,7 +79,7 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
 
   private ParamDocView generateRequestStreamingParamDoc(GapicMethodContext context) {
     SimpleParamDocView.Builder paramDoc = SimpleParamDocView.newBuilder();
-    paramDoc.paramName(context.getNamer().getRequestVariableName(context.getMethod()));
+    paramDoc.paramName(context.getNamer().getRequestVariableName(context.getMethodModel()));
     paramDoc.lines(ImmutableList.of("The input requests."));
 
     String requestTypeName =

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.transformer.ruby;
 
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.transformer.ApiMethodParamTransformer;
 import com.google.api.codegen.transformer.GapicMethodContext;
@@ -36,14 +36,14 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
       methodParams.add(param.build());
     } else {
       MethodConfig methodConfig = context.getMethodConfig();
-      for (FieldType field : methodConfig.getRequiredFields()) {
+      for (FieldModel field : methodConfig.getRequiredFields()) {
         DynamicLangDefaultableParamView.Builder param =
             DynamicLangDefaultableParamView.newBuilder();
         param.name(context.getNamer().getVariableName(field));
         param.defaultValue("");
         methodParams.add(param.build());
       }
-      for (FieldType field : methodConfig.getOptionalFields()) {
+      for (FieldModel field : methodConfig.getOptionalFields()) {
         if (isRequestTokenParam(methodConfig, field)) {
           continue;
         }
@@ -91,11 +91,11 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
   }
 
   private List<ParamDocView> generateMethodParamDocs(
-      GapicMethodContext context, Iterable<FieldType> fields) {
+      GapicMethodContext context, Iterable<FieldModel> fields) {
     SurfaceNamer namer = context.getNamer();
     MethodConfig methodConfig = context.getMethodConfig();
     ImmutableList.Builder<ParamDocView> docs = ImmutableList.builder();
-    for (FieldType field : fields) {
+    for (FieldModel field : fields) {
       if (isRequestTokenParam(methodConfig, field)) {
         continue;
       }
@@ -133,13 +133,13 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
     return docs.build();
   }
 
-  private boolean isPageSizeParam(MethodConfig methodConfig, FieldType field) {
+  private boolean isPageSizeParam(MethodConfig methodConfig, FieldModel field) {
     return methodConfig.isPageStreaming()
         && methodConfig.getPageStreaming().hasPageSizeField()
         && field.equals(methodConfig.getPageStreaming().getPageSizeField());
   }
 
-  private boolean isRequestTokenParam(MethodConfig methodConfig, FieldType field) {
+  private boolean isRequestTokenParam(MethodConfig methodConfig, FieldModel field) {
     return methodConfig.isPageStreaming()
         && field.equals(methodConfig.getPageStreaming().getRequestTokenField());
   }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceDocTransformer.java
@@ -63,7 +63,7 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
             new RubyModelTypeNameConverter(productConfig.getPackageName()));
     // Use file path for package name to get file-specific package instead of package for the API.
     SurfaceNamer namer = new RubySurfaceNamer(typeTable.getFullNameFor(file));
-    String subPath = pathMapper.getOutputPath(file, productConfig);
+    String subPath = pathMapper.getOutputPath(file.getFullName(), productConfig);
     String baseFilename = namer.getProtoFileName(file);
     GrpcDocView.Builder doc = GrpcDocView.newBuilder();
     doc.templateFileName(DOC_TEMPLATE_FILENAME);

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -55,7 +56,6 @@ import com.google.api.codegen.viewmodel.metadata.VersionIndexRequireView;
 import com.google.api.codegen.viewmodel.metadata.VersionIndexType;
 import com.google.api.codegen.viewmodel.metadata.VersionIndexView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -130,7 +130,8 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
 
   private ViewModel generateApiClass(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    String subPath = pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+    String subPath =
+        pathMapper.getOutputPath(context.getInterface().getFullName(), context.getProductConfig());
     String name = namer.getApiWrapperClassName(context.getInterfaceConfig());
     List<ApiMethodView> methods = generateApiMethods(context);
 
@@ -190,7 +191,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     ImmutableList.Builder<ApiMethodView> apiMethods = ImmutableList.builder();
     boolean packageHasMultipleServices =
         new InterfaceView().hasMultipleServices(context.getModel());
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       apiMethods.add(
           apiMethodTransformer.generateMethod(
               context.asDynamicMethodContext(method), packageHasMultipleServices));

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -172,10 +172,10 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
-            context.getModelTypeTable(), context.getInterface()));
+            context.getModelTypeTable(), context.getInterfaceModel()));
 
     xapiClass.apiMethods(methods);
 
@@ -211,7 +211,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
           VersionIndexRequireView.newBuilder()
               .clientName(namer.getFullyQualifiedApiWrapperClassName(interfaceConfig))
               .fileName(namer.getServiceFileName(interfaceConfig))
-              .serviceName(namer.getPackageServiceName(apiInterface))
+              .serviceName(namer.getPackageServiceName(context.getInterfaceModel()))
               .doc(
                   serviceTransformer.generateServiceDoc(
                       context, generateApiMethods(context).get(0)))
@@ -298,7 +298,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     for (Interface apiInterface : interfaces) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
       String clientName = namer.getPackageName();
-      String serviceName = namer.getPackageServiceName(apiInterface);
+      String serviceName = namer.getPackageServiceName(context.getInterfaceModel());
       if (hasMultipleServices) {
         clientName += "::" + serviceName;
       }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
@@ -14,18 +14,18 @@
  */
 package com.google.api.codegen.transformer.ruby;
 
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
-import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
-import com.google.api.codegen.transformer.InterfaceContext;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.StandardImportSectionTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.transformer.TransformationContext;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.ImportTypeView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Set;
@@ -33,8 +33,9 @@ import java.util.TreeSet;
 
 public class RubyImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(InterfaceContext interfaceContext) {
-    GapicInterfaceContext context = (GapicInterfaceContext) interfaceContext;
+  public ImportSectionView generateImportSection(TransformationContext transformationContext) {
+    // TODO support non-Gapic inputs
+    GapicInterfaceContext context = (GapicInterfaceContext) transformationContext;
     Set<String> importFilenames = generateImportFilenames(context);
     ImportSectionView.Builder importSection = ImportSectionView.newBuilder();
     importSection.standardImports(generateStandardImports());
@@ -46,7 +47,7 @@ public class RubyImportSectionTransformer implements ImportSectionTransformer {
 
   @Override
   public ImportSectionView generateImportSection(
-      GapicMethodContext context, Iterable<InitCodeNode> specItemNodes) {
+      MethodContext context, Iterable<InitCodeNode> specItemNodes) {
     return new StandardImportSectionTransformer().generateImportSection(context, specItemNodes);
   }
 
@@ -99,7 +100,7 @@ public class RubyImportSectionTransformer implements ImportSectionTransformer {
   private Set<String> generateImportFilenames(GapicInterfaceContext context) {
     Set<String> filenames = new TreeSet<>();
     filenames.add(context.getInterface().getFile().getSimpleName());
-    for (Method method : context.getSupportedMethods()) {
+    for (MethodModel method : context.getSupportedMethods()) {
       Interface targetInterface = context.asRequestMethodContext(method).getTargetInterface();
       filenames.add(targetInterface.getFile().getSimpleName());
     }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
@@ -101,7 +101,8 @@ public class RubyImportSectionTransformer implements ImportSectionTransformer {
     Set<String> filenames = new TreeSet<>();
     filenames.add(context.getInterface().getFile().getSimpleName());
     for (MethodModel method : context.getSupportedMethods()) {
-      Interface targetInterface = context.asRequestMethodContext(method).getTargetInterface();
+      Interface targetInterface =
+          context.asRequestMethodContext(method).getTargetInterface().getInterface();
       filenames.add(targetInterface.getFile().getSimpleName());
     }
     return filenames;

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProtoMethodModel;
@@ -46,6 +47,7 @@ import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -258,8 +260,10 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer {
 
     boolean hasSmokeTests = false;
     Iterable<Interface> interfaces = new InterfaceView().getElementIterable(model);
+    List<InterfaceModel> interfaceModels = new LinkedList<>();
     for (Interface apiInterface : interfaces) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
+      interfaceModels.add(context.getInterfaceModel());
       if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
         hasSmokeTests = true;
         break;
@@ -276,13 +280,13 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer {
                 productConfig, ImportSectionView.newBuilder().build(), surfaceNamer))
         .hasSmokeTests(hasSmokeTests)
         .versionPath(surfaceNamer.getVersionIndexFileImportName())
-        .versionNamespace(validVersionNamespace(interfaces, surfaceNamer))
+        .versionNamespace(validVersionNamespace(interfaceModels, surfaceNamer))
         .build();
   }
 
-  private String validVersionNamespace(Iterable<Interface> interfaces, SurfaceNamer namer) {
+  private String validVersionNamespace(Iterable<InterfaceModel> interfaces, SurfaceNamer namer) {
     Set<String> versionNamespaces = new HashSet<>();
-    for (Interface apiInterface : interfaces) {
+    for (InterfaceModel apiInterface : interfaces) {
       versionNamespaces.add(namer.getNamespace(apiInterface));
     }
     if (versionNamespaces.size() > 1) {

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -18,7 +18,9 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
@@ -40,7 +42,6 @@ import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.metadata.ReadmeMetadataView;
 import com.google.api.codegen.viewmodel.metadata.TocContentView;
 import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -188,7 +189,8 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer {
     for (Interface apiInterface : interfaceView.getElementIterable(model)) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
       if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
-        Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+        MethodModel method =
+            new ProtoMethodModel(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
         FlatteningConfig flatteningGroup =
             testCaseTransformer.getSmokeTestFlatteningGroup(
                 context.getMethodConfig(method), context.getInterfaceConfig().getSmokeTestConfig());

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
+import com.google.api.codegen.transformer.MethodContext;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
@@ -178,12 +179,14 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getDynamicLangReturnTypeName(MethodModel method, MethodConfig methodConfig) {
+  public String getDynamicLangReturnTypeName(MethodContext methodContext) {
+    MethodModel method = methodContext.getMethodModel();
+    MethodConfig methodConfig = methodContext.getMethodConfig();
     if (method.isOutputTypeEmpty()) {
       return "";
     }
 
-    String classInfo = method.getOutputTypeFullName(getModelTypeFormatter());
+    String classInfo = method.getOutputTypeName(methodContext.getTypeTable()).getFullName();
     if (method.getResponseStreaming()) {
       return "Enumerable<" + classInfo + ">";
     }
@@ -230,10 +233,11 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   @Override
   public List<String> getReturnDocLines(
-      TransformationContext context, MethodConfig methodConfig, Synchronicity synchronicity) {
-    MethodModel method = methodConfig.getMethodModel();
+      TransformationContext context, MethodContext methodContext, Synchronicity synchronicity) {
+    MethodModel method = methodContext.getMethodModel();
+    MethodConfig methodConfig = methodContext.getMethodConfig();
     if (method.getResponseStreaming()) {
-      String classInfo = method.getOutputTypeFullName(getTypeFormatter());
+      String classInfo = method.getOutputTypeName(methodContext.getTypeTable()).getFullName();
       return ImmutableList.of("An enumerable of " + classInfo + " instances.", "");
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -16,10 +16,11 @@ package com.google.api.codegen.transformer.ruby;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
-import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.InterfaceConfig;
+import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoInterfaceModel;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
@@ -67,7 +68,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   /** The name of the class that implements snippets for a particular proto interface. */
   @Override
-  public String getApiSnippetsClassName(Interface apiInterface) {
+  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
     return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientSnippets"));
   }
 
@@ -97,7 +98,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceModel apiInterface) {
     return Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore()
         + ".json";
   }
@@ -113,7 +114,16 @@ public class RubySurfaceNamer extends SurfaceNamer {
    */
   @Override
   public String getGrpcClientTypeName(Interface apiInterface) {
-    return getModelTypeFormatter().getFullNameFor(apiInterface);
+    return getGrpcClientTypeName(new ProtoInterfaceModel(apiInterface));
+  }
+
+  /**
+   * The type name of the Grpc client class. This needs to match what Grpc generates for the
+   * particular language.
+   */
+  @Override
+  public String getGrpcClientTypeName(InterfaceModel apiInterface) {
+    return getTypeFormatter().getFullNameFor(apiInterface);
   }
 
   @Override
@@ -206,7 +216,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFullyQualifiedStubType(Interface apiInterface) {
+  public String getFullyQualifiedStubType(InterfaceModel apiInterface) {
     NamePath namePath =
         getTypeNameConverter().getNamePath(getModelTypeFormatter().getFullNameFor(apiInterface));
     return qualifiedName(namePath.append("Stub"));
@@ -281,17 +291,17 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getTopLevelAliasedApiClassName(
-      GapicInterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
+      InterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return packageHasMultipleServices
-        ? getTopLevelNamespace() + "::" + getPackageServiceName(interfaceConfig.getInterface())
+        ? getTopLevelNamespace() + "::" + getPackageServiceName(interfaceConfig.getInterfaceModel())
         : getTopLevelNamespace();
   }
 
   @Override
   public String getVersionAliasedApiClassName(
-      GapicInterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
+      InterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return packageHasMultipleServices
-        ? getPackageName() + "::" + getPackageServiceName(interfaceConfig.getInterface())
+        ? getPackageName() + "::" + getPackageServiceName(interfaceConfig.getInterfaceModel())
         : getPackageName();
   }
 
@@ -386,7 +396,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getGrpcStubCallString(Interface apiInterface, MethodModel method) {
+  public String getGrpcStubCallString(InterfaceModel apiInterface, MethodModel method) {
     return getFullyQualifiedStubType(apiInterface);
   }
 
@@ -396,7 +406,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getPackageServiceName(Interface apiInterface) {
+  public String getPackageServiceName(InterfaceModel apiInterface) {
     return publicClassName(getReducedServiceName(apiInterface.getSimpleName()));
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.transformer.ruby;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.config.FieldType;
+import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
@@ -73,7 +73,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   /** The function name to set a field. */
   @Override
-  public String getFieldSetFunctionName(FieldType field) {
+  public String getFieldSetFunctionName(FieldModel field) {
     return getFieldGetFunctionName(field);
   }
 
@@ -117,7 +117,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getParamTypeName(ImportTypeTable typeTable, FieldType type) {
+  public String getParamTypeName(ImportTypeTable typeTable, FieldModel type) {
     if (type.isMap()) {
       String keyTypeName = typeTable.getFullNameForElementType(type.getMapKeyField());
       String valueTypeName = typeTable.getFullNameForElementType(type.getMapValueField());
@@ -151,31 +151,31 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   /** The type name for the message property */
   @Override
-  public String getMessagePropertyTypeName(ImportTypeTable importTypeTable, FieldType fieldType) {
-    if (fieldType.isMap()) {
-      String keyTypeName = importTypeTable.getFullNameForElementType(fieldType.getMapKeyField());
+  public String getMessagePropertyTypeName(ImportTypeTable importTypeTable, FieldModel fieldModel) {
+    if (fieldModel.isMap()) {
+      String keyTypeName = importTypeTable.getFullNameForElementType(fieldModel.getMapKeyField());
       String valueTypeName =
-          importTypeTable.getFullNameForElementType(fieldType.getMapValueField());
+          importTypeTable.getFullNameForElementType(fieldModel.getMapValueField());
       return new TypeName(
-              importTypeTable.getFullNameFor(fieldType),
-              importTypeTable.getNicknameFor(fieldType),
+              importTypeTable.getFullNameFor(fieldModel),
+              importTypeTable.getNicknameFor(fieldModel),
               "%s{%i => %i}",
               new TypeName(keyTypeName),
               new TypeName(valueTypeName))
           .getFullName();
     }
 
-    if (fieldType.isRepeated()) {
-      String elementTypeName = importTypeTable.getFullNameForElementType(fieldType);
+    if (fieldModel.isRepeated()) {
+      String elementTypeName = importTypeTable.getFullNameForElementType(fieldModel);
       return new TypeName(
-              importTypeTable.getFullNameFor(fieldType),
-              importTypeTable.getNicknameFor(fieldType),
+              importTypeTable.getFullNameFor(fieldModel),
+              importTypeTable.getNicknameFor(fieldModel),
               "%s<%i>",
               new TypeName(elementTypeName))
           .getFullName();
     }
 
-    return importTypeTable.getFullNameForElementType(fieldType);
+    return importTypeTable.getFullNameForElementType(fieldModel);
   }
 
   @Override
@@ -381,7 +381,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFieldGetFunctionName(FieldType type, Name identifier) {
+  public String getFieldGetFunctionName(FieldModel type, Name identifier) {
     return keyName(identifier);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -87,7 +87,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   /** The function name to format the entity for the given collection. */
   @Override
   public String getFormatFunctionName(
-      String apiInterfaceSimpleName, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 

--- a/src/main/java/com/google/api/codegen/util/Name.java
+++ b/src/main/java/com/google/api/codegen/util/Name.java
@@ -82,6 +82,10 @@ public class Name {
     return camelInternal(CheckCase.UPPER, AcronymMode.CAMEL_CASE, pieces);
   }
 
+  public static Name anyCamelKeepUpperAcronyms(String... pieces) {
+    return camelInternal(CheckCase.NO_CHECK, AcronymMode.UPPER_CASE, pieces);
+  }
+
   public static Name upperCamelKeepUpperAcronyms(String... pieces) {
     return camelInternal(CheckCase.UPPER, AcronymMode.UPPER_CASE, pieces);
   }

--- a/src/main/resources/com/google/api/codegen/java/message.snip
+++ b/src/main/resources/com/google/api/codegen/java/message.snip
@@ -15,9 +15,7 @@
 
     {@constructors(schema)}
 
-    @if schema.isRequestMessage
-      {@populateMapMethod(schema)}
-    @end
+    {@populateMapMethod(schema)}
 
     {@getters(schema)}
 
@@ -43,7 +41,7 @@
         @if param.canRepeat
           fieldMap.put("{@param.name}", {@param.name});
         @else
-          fieldMap.put("{@param.name}", Collections.singletonList({@param.name}));
+          fieldMap.put("{@param.name}", Collections.singletonList(String.valueOf({@param.name})));
         @end
       }
     @end

--- a/src/test/java/com/google/api/codegen/DiscoGapicTestBase.java
+++ b/src/test/java/com/google/api/codegen/DiscoGapicTestBase.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /** Base class for Discovery code generator baseline tests. */
 public abstract class DiscoGapicTestBase extends ConfigBaselineTestCase {
@@ -39,14 +40,24 @@ public abstract class DiscoGapicTestBase extends ConfigBaselineTestCase {
   private final String discoveryDocFileName;
   private final List<String> gapicConfigFilePaths = new LinkedList<>();
   private final String[] gapicConfigFileNames;
+  @Nullable private final String packageConfigFileName;
   protected ConfigProto config;
   List<DiscoGapicProvider> discoGapicProviders;
 
   public DiscoGapicTestBase(
       String name, String discoveryDocFileName, String[] gapicConfigFileNames) {
+    this(name, discoveryDocFileName, gapicConfigFileNames, null);
+  }
+
+  public DiscoGapicTestBase(
+      String name,
+      String discoveryDocFileName,
+      String[] gapicConfigFileNames,
+      String packageConfigFileName) {
     this.name = name;
     this.discoveryDocFileName = discoveryDocFileName;
     this.gapicConfigFileNames = gapicConfigFileNames;
+    this.packageConfigFileName = packageConfigFileName;
 
     for (String fileName : gapicConfigFileNames) {
       gapicConfigFilePaths.add(getTestDataLocator().findTestData(fileName).getFile());
@@ -59,7 +70,7 @@ public abstract class DiscoGapicTestBase extends ConfigBaselineTestCase {
           DiscoGapicGeneratorApi.getProviders(
               getTestDataLocator().findTestData(discoveryDocFileName).getPath(),
               gapicConfigFilePaths,
-              null,
+              getTestDataLocator().findTestData(packageConfigFileName).getPath(),
               new LinkedList<String>());
     } catch (IOException e) {
       throw new IllegalArgumentException("Problem creating DiscoGapic generator.");

--- a/src/test/java/com/google/api/codegen/JavaDiscoGapicGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/JavaDiscoGapicGeneratorTest.java
@@ -28,8 +28,11 @@ import org.junit.runners.Parameterized.Parameters;
 public class JavaDiscoGapicGeneratorTest extends DiscoGapicTestBase {
 
   public JavaDiscoGapicGeneratorTest(
-      String name, String discoveryDocFileName, String[] gapicConfigFileNames) {
-    super(name, discoveryDocFileName, gapicConfigFileNames);
+      String name,
+      String discoveryDocFileName,
+      String[] gapicConfigFileNames,
+      String packageConfigFileName) {
+    super(name, discoveryDocFileName, gapicConfigFileNames, packageConfigFileName);
   }
 
   /**
@@ -51,8 +54,9 @@ public class JavaDiscoGapicGeneratorTest extends DiscoGapicTestBase {
             "discogapic/" + fileName,
             new String[] {
               "com/google/api/codegen/java/java_discogapic.yaml",
-              "com/google/api/codegen/testdata/fakebilling_gapic.yaml"
-            }
+              "com/google/api/codegen/testdata/fakebilling_gapic.yaml",
+            },
+            "com/google/api/codegen/testdata/fakebilling_pkg.yaml"
           });
     }
     return builder.build();

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_fakebilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_fakebilling.v1.json.baseline
@@ -17,6 +17,7 @@
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -50,6 +51,26 @@ public final class AttachedDisk implements ApiMessage {
     this.type = type;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("index")) {
+      fieldMap.put("index", Collections.singletonList(String.valueOf(index)));
+    }
+    if (fieldNames.contains("interface2")) {
+      fieldMap.put("interface2", Collections.singletonList(String.valueOf(interface2)));
+    }
+    if (fieldNames.contains("licenses")) {
+      fieldMap.put("licenses", Collections.singletonList(String.valueOf(licenses)));
+    }
+    if (fieldNames.contains("mode")) {
+      fieldMap.put("mode", Collections.singletonList(String.valueOf(mode)));
+    }
+    if (fieldNames.contains("type")) {
+      fieldMap.put("type", Collections.singletonList(String.valueOf(type)));
+    }
+    return fieldMap;
+  }
 
   public Integer getIndex() {
     return index;
@@ -224,6 +245,7 @@ public final class AttachedDisk implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -248,6 +270,17 @@ public final class BillingAccount implements ApiMessage {
     this.open = open;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("name")) {
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
+    }
+    if (fieldNames.contains("open")) {
+      fieldMap.put("open", Collections.singletonList(String.valueOf(open)));
+    }
+    return fieldMap;
+  }
 
   public String getName() {
     return name;
@@ -359,6 +392,7 @@ public final class BillingAccount implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -383,6 +417,17 @@ public final class Data implements ApiMessage {
     this.value = value;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("key")) {
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
+    }
+    if (fieldNames.contains("value")) {
+      fieldMap.put("value", Collections.singletonList(String.valueOf(value)));
+    }
+    return fieldMap;
+  }
 
   public String getKey() {
     return key;
@@ -494,6 +539,7 @@ public final class Data implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -515,6 +561,14 @@ public final class Error implements ApiMessage {
     this.errors = errors;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("errors")) {
+      fieldMap.put("errors", Collections.singletonList(String.valueOf(errors)));
+    }
+    return fieldMap;
+  }
 
   public List<Errors> getErrors() {
     return errors;
@@ -605,6 +659,7 @@ public final class Error implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -632,6 +687,20 @@ public final class Errors implements ApiMessage {
     this.message = message;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("code")) {
+      fieldMap.put("code", Collections.singletonList(String.valueOf(code)));
+    }
+    if (fieldNames.contains("location")) {
+      fieldMap.put("location", Collections.singletonList(String.valueOf(location)));
+    }
+    if (fieldNames.contains("message")) {
+      fieldMap.put("message", Collections.singletonList(String.valueOf(message)));
+    }
+    return fieldMap;
+  }
 
   public String getCode() {
     return code;
@@ -764,6 +833,7 @@ public final class Errors implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -791,6 +861,20 @@ public final class Interface implements ApiMessage {
     this.interface2 = interface2;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("face")) {
+      fieldMap.put("face", Collections.singletonList(String.valueOf(face)));
+    }
+    if (fieldNames.contains("inter")) {
+      fieldMap.put("inter", Collections.singletonList(String.valueOf(inter)));
+    }
+    if (fieldNames.contains("interface2")) {
+      fieldMap.put("interface2", Collections.singletonList(String.valueOf(interface2)));
+    }
+    return fieldMap;
+  }
 
   public String getFace() {
     return face;
@@ -923,6 +1007,7 @@ public final class Interface implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -947,6 +1032,17 @@ public final class ListBillingAccountsResponse implements ApiMessage {
     this.nextPageToken = nextPageToken;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("billingAccounts")) {
+      fieldMap.put("billingAccounts", Collections.singletonList(String.valueOf(billingAccounts)));
+    }
+    if (fieldNames.contains("nextPageToken")) {
+      fieldMap.put("nextPageToken", Collections.singletonList(String.valueOf(nextPageToken)));
+    }
+    return fieldMap;
+  }
 
   public List<BillingAccount> getBillingAccounts() {
     return billingAccounts;
@@ -1058,6 +1154,7 @@ public final class ListBillingAccountsResponse implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -1082,6 +1179,17 @@ public final class ListProjectBillingInfoResponse implements ApiMessage {
     this.projectBillingInfo = projectBillingInfo;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("nextPageToken")) {
+      fieldMap.put("nextPageToken", Collections.singletonList(String.valueOf(nextPageToken)));
+    }
+    if (fieldNames.contains("projectBillingInfo")) {
+      fieldMap.put("projectBillingInfo", Collections.singletonList(String.valueOf(projectBillingInfo)));
+    }
+    return fieldMap;
+  }
 
   public String getNextPageToken() {
     return nextPageToken;
@@ -1193,6 +1301,7 @@ public final class ListProjectBillingInfoResponse implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -1235,6 +1344,35 @@ public final class Operation implements ApiMessage {
     this.warnings = warnings;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("creationTimestamp")) {
+      fieldMap.put("creationTimestamp", Collections.singletonList(String.valueOf(creationTimestamp)));
+    }
+    if (fieldNames.contains("description")) {
+      fieldMap.put("description", Collections.singletonList(String.valueOf(description)));
+    }
+    if (fieldNames.contains("error")) {
+      fieldMap.put("error", Collections.singletonList(String.valueOf(error)));
+    }
+    if (fieldNames.contains("httpErrorStatusCode")) {
+      fieldMap.put("httpErrorStatusCode", Collections.singletonList(String.valueOf(httpErrorStatusCode)));
+    }
+    if (fieldNames.contains("id")) {
+      fieldMap.put("id", Collections.singletonList(String.valueOf(id)));
+    }
+    if (fieldNames.contains("name")) {
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
+    }
+    if (fieldNames.contains("status")) {
+      fieldMap.put("status", Collections.singletonList(String.valueOf(status)));
+    }
+    if (fieldNames.contains("warnings")) {
+      fieldMap.put("warnings", Collections.singletonList(String.valueOf(warnings)));
+    }
+    return fieldMap;
+  }
 
   public String getCreationTimestamp() {
     return creationTimestamp;
@@ -1472,6 +1610,7 @@ public final class Operation implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -1496,6 +1635,17 @@ public final class ProjectBillingInfo implements ApiMessage {
     this.projectId = projectId;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("billingEnabled")) {
+      fieldMap.put("billingEnabled", Collections.singletonList(String.valueOf(billingEnabled)));
+    }
+    if (fieldNames.contains("projectId")) {
+      fieldMap.put("projectId", Collections.singletonList(String.valueOf(projectId)));
+    }
+    return fieldMap;
+  }
 
   public Boolean getBillingEnabled() {
     return billingEnabled;
@@ -1607,6 +1757,7 @@ public final class ProjectBillingInfo implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -1637,6 +1788,23 @@ public final class Warnings implements ApiMessage {
     this.projectBillingInfo = projectBillingInfo;
   }
 
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("code")) {
+      fieldMap.put("code", Collections.singletonList(String.valueOf(code)));
+    }
+    if (fieldNames.contains("data")) {
+      fieldMap.put("data", Collections.singletonList(String.valueOf(data)));
+    }
+    if (fieldNames.contains("message")) {
+      fieldMap.put("message", Collections.singletonList(String.valueOf(message)));
+    }
+    if (fieldNames.contains("projectBillingInfo")) {
+      fieldMap.put("projectBillingInfo", Collections.singletonList(String.valueOf(projectBillingInfo)));
+    }
+    return fieldMap;
+  }
 
   public String getCode() {
     return code;
@@ -1790,6 +1958,7 @@ public final class Warnings implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -1839,31 +2008,31 @@ public final class BillingAccountsGetHttpRequest implements ApiMessage {
   public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
     Map<String, List<String>> fieldMap = new HashMap<>();
     if (fieldNames.contains("access_token")) {
-      fieldMap.put("access_token", Collections.singletonList(access_token));
+      fieldMap.put("access_token", Collections.singletonList(String.valueOf(access_token)));
     }
     if (fieldNames.contains("callback")) {
-      fieldMap.put("callback", Collections.singletonList(callback));
+      fieldMap.put("callback", Collections.singletonList(String.valueOf(callback)));
     }
     if (fieldNames.contains("fields")) {
-      fieldMap.put("fields", Collections.singletonList(fields));
+      fieldMap.put("fields", Collections.singletonList(String.valueOf(fields)));
     }
     if (fieldNames.contains("fooRepeated")) {
       fieldMap.put("fooRepeated", fooRepeated);
     }
     if (fieldNames.contains("key")) {
-      fieldMap.put("key", Collections.singletonList(key));
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
     }
     if (fieldNames.contains("name")) {
-      fieldMap.put("name", Collections.singletonList(name));
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
     }
     if (fieldNames.contains("prettyPrint")) {
-      fieldMap.put("prettyPrint", Collections.singletonList(prettyPrint));
+      fieldMap.put("prettyPrint", Collections.singletonList(String.valueOf(prettyPrint)));
     }
     if (fieldNames.contains("quotaUser")) {
-      fieldMap.put("quotaUser", Collections.singletonList(quotaUser));
+      fieldMap.put("quotaUser", Collections.singletonList(String.valueOf(quotaUser)));
     }
     if (fieldNames.contains("userIp")) {
-      fieldMap.put("userIp", Collections.singletonList(userIp));
+      fieldMap.put("userIp", Collections.singletonList(String.valueOf(userIp)));
     }
     return fieldMap;
   }
@@ -2132,6 +2301,7 @@ public final class BillingAccountsGetHttpRequest implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -2184,34 +2354,34 @@ public final class BillingAccountsListHttpRequest implements ApiMessage {
   public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
     Map<String, List<String>> fieldMap = new HashMap<>();
     if (fieldNames.contains("access_token")) {
-      fieldMap.put("access_token", Collections.singletonList(access_token));
+      fieldMap.put("access_token", Collections.singletonList(String.valueOf(access_token)));
     }
     if (fieldNames.contains("callback")) {
-      fieldMap.put("callback", Collections.singletonList(callback));
+      fieldMap.put("callback", Collections.singletonList(String.valueOf(callback)));
     }
     if (fieldNames.contains("fields")) {
-      fieldMap.put("fields", Collections.singletonList(fields));
+      fieldMap.put("fields", Collections.singletonList(String.valueOf(fields)));
     }
     if (fieldNames.contains("key")) {
-      fieldMap.put("key", Collections.singletonList(key));
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
     }
     if (fieldNames.contains("maxResults")) {
-      fieldMap.put("maxResults", Collections.singletonList(maxResults));
+      fieldMap.put("maxResults", Collections.singletonList(String.valueOf(maxResults)));
     }
     if (fieldNames.contains("pageSize")) {
-      fieldMap.put("pageSize", Collections.singletonList(pageSize));
+      fieldMap.put("pageSize", Collections.singletonList(String.valueOf(pageSize)));
     }
     if (fieldNames.contains("pageToken")) {
-      fieldMap.put("pageToken", Collections.singletonList(pageToken));
+      fieldMap.put("pageToken", Collections.singletonList(String.valueOf(pageToken)));
     }
     if (fieldNames.contains("prettyPrint")) {
-      fieldMap.put("prettyPrint", Collections.singletonList(prettyPrint));
+      fieldMap.put("prettyPrint", Collections.singletonList(String.valueOf(prettyPrint)));
     }
     if (fieldNames.contains("quotaUser")) {
-      fieldMap.put("quotaUser", Collections.singletonList(quotaUser));
+      fieldMap.put("quotaUser", Collections.singletonList(String.valueOf(quotaUser)));
     }
     if (fieldNames.contains("userIp")) {
-      fieldMap.put("userIp", Collections.singletonList(userIp));
+      fieldMap.put("userIp", Collections.singletonList(String.valueOf(userIp)));
     }
     return fieldMap;
   }
@@ -2494,6 +2664,7 @@ public final class BillingAccountsListHttpRequest implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -2540,28 +2711,28 @@ public final class ProjectsGetBillingInfoHttpRequest implements ApiMessage {
   public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
     Map<String, List<String>> fieldMap = new HashMap<>();
     if (fieldNames.contains("access_token")) {
-      fieldMap.put("access_token", Collections.singletonList(access_token));
+      fieldMap.put("access_token", Collections.singletonList(String.valueOf(access_token)));
     }
     if (fieldNames.contains("callback")) {
-      fieldMap.put("callback", Collections.singletonList(callback));
+      fieldMap.put("callback", Collections.singletonList(String.valueOf(callback)));
     }
     if (fieldNames.contains("fields")) {
-      fieldMap.put("fields", Collections.singletonList(fields));
+      fieldMap.put("fields", Collections.singletonList(String.valueOf(fields)));
     }
     if (fieldNames.contains("key")) {
-      fieldMap.put("key", Collections.singletonList(key));
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
     }
     if (fieldNames.contains("name")) {
-      fieldMap.put("name", Collections.singletonList(name));
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
     }
     if (fieldNames.contains("prettyPrint")) {
-      fieldMap.put("prettyPrint", Collections.singletonList(prettyPrint));
+      fieldMap.put("prettyPrint", Collections.singletonList(String.valueOf(prettyPrint)));
     }
     if (fieldNames.contains("quotaUser")) {
-      fieldMap.put("quotaUser", Collections.singletonList(quotaUser));
+      fieldMap.put("quotaUser", Collections.singletonList(String.valueOf(quotaUser)));
     }
     if (fieldNames.contains("userIp")) {
-      fieldMap.put("userIp", Collections.singletonList(userIp));
+      fieldMap.put("userIp", Collections.singletonList(String.valueOf(userIp)));
     }
     return fieldMap;
   }
@@ -2809,6 +2980,7 @@ public final class ProjectsGetBillingInfoHttpRequest implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -2861,34 +3033,34 @@ public final class ProjectsListHttpRequest implements ApiMessage {
   public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
     Map<String, List<String>> fieldMap = new HashMap<>();
     if (fieldNames.contains("access_token")) {
-      fieldMap.put("access_token", Collections.singletonList(access_token));
+      fieldMap.put("access_token", Collections.singletonList(String.valueOf(access_token)));
     }
     if (fieldNames.contains("callback")) {
-      fieldMap.put("callback", Collections.singletonList(callback));
+      fieldMap.put("callback", Collections.singletonList(String.valueOf(callback)));
     }
     if (fieldNames.contains("fields")) {
-      fieldMap.put("fields", Collections.singletonList(fields));
+      fieldMap.put("fields", Collections.singletonList(String.valueOf(fields)));
     }
     if (fieldNames.contains("key")) {
-      fieldMap.put("key", Collections.singletonList(key));
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
     }
     if (fieldNames.contains("name")) {
-      fieldMap.put("name", Collections.singletonList(name));
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
     }
     if (fieldNames.contains("pageSize")) {
-      fieldMap.put("pageSize", Collections.singletonList(pageSize));
+      fieldMap.put("pageSize", Collections.singletonList(String.valueOf(pageSize)));
     }
     if (fieldNames.contains("pageToken")) {
-      fieldMap.put("pageToken", Collections.singletonList(pageToken));
+      fieldMap.put("pageToken", Collections.singletonList(String.valueOf(pageToken)));
     }
     if (fieldNames.contains("prettyPrint")) {
-      fieldMap.put("prettyPrint", Collections.singletonList(prettyPrint));
+      fieldMap.put("prettyPrint", Collections.singletonList(String.valueOf(prettyPrint)));
     }
     if (fieldNames.contains("quotaUser")) {
-      fieldMap.put("quotaUser", Collections.singletonList(quotaUser));
+      fieldMap.put("quotaUser", Collections.singletonList(String.valueOf(quotaUser)));
     }
     if (fieldNames.contains("userIp")) {
-      fieldMap.put("userIp", Collections.singletonList(userIp));
+      fieldMap.put("userIp", Collections.singletonList(String.valueOf(userIp)));
     }
     return fieldMap;
   }
@@ -3178,6 +3350,7 @@ public final class ProjectsListHttpRequest implements ApiMessage {
 package com.google.cloud.fakebilling.v1;
 
 import com.google.api.core.BetaApi;
+import com.google.api.gax.core.ApiMessage;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Collections;
@@ -3227,31 +3400,31 @@ public final class ProjectsUpdateBillingInfoHttpRequest implements ApiMessage {
   public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
     Map<String, List<String>> fieldMap = new HashMap<>();
     if (fieldNames.contains("access_token")) {
-      fieldMap.put("access_token", Collections.singletonList(access_token));
+      fieldMap.put("access_token", Collections.singletonList(String.valueOf(access_token)));
     }
     if (fieldNames.contains("callback")) {
-      fieldMap.put("callback", Collections.singletonList(callback));
+      fieldMap.put("callback", Collections.singletonList(String.valueOf(callback)));
     }
     if (fieldNames.contains("fields")) {
-      fieldMap.put("fields", Collections.singletonList(fields));
+      fieldMap.put("fields", Collections.singletonList(String.valueOf(fields)));
     }
     if (fieldNames.contains("key")) {
-      fieldMap.put("key", Collections.singletonList(key));
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
     }
     if (fieldNames.contains("name")) {
-      fieldMap.put("name", Collections.singletonList(name));
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
     }
     if (fieldNames.contains("prettyPrint")) {
-      fieldMap.put("prettyPrint", Collections.singletonList(prettyPrint));
+      fieldMap.put("prettyPrint", Collections.singletonList(String.valueOf(prettyPrint)));
     }
     if (fieldNames.contains("quotaUser")) {
-      fieldMap.put("quotaUser", Collections.singletonList(quotaUser));
+      fieldMap.put("quotaUser", Collections.singletonList(String.valueOf(quotaUser)));
     }
     if (fieldNames.contains("request")) {
-      fieldMap.put("request", Collections.singletonList(request));
+      fieldMap.put("request", Collections.singletonList(String.valueOf(request)));
     }
     if (fieldNames.contains("userIp")) {
-      fieldMap.put("userIp", Collections.singletonList(userIp));
+      fieldMap.put("userIp", Collections.singletonList(String.valueOf(userIp)));
     }
     return fieldMap;
   }
@@ -3501,3 +3674,1755 @@ public final class ProjectsUpdateBillingInfoHttpRequest implements ApiMessage {
   }
 }
 
+============== file: src/main/java/com/google/cloud/fakebilling/v1/BillingAccountAdminClient.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import static com.google.cloud.fakebilling.v1.PagedResponseWrappers.BillingAccountsListPagedResponse;
+import com.google.cloud.fakebilling.v1.stub.BillingAccountAdminStub;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND SERVICE
+/**
+ * Service Description: Test Discovery doc.
+ *
+ * <p>This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * <pre>
+ * <code>
+ * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+ *
+ *   BillingAccount response = billingAccountAdminClient.billingAccountsGet();
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>Note: close() needs to be called on the billingAccountAdminClient object to clean up resources such
+ * as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's methods:
+ *
+ * <ol>
+ * <li> A "flattened" method. With this type of method, the fields of the request type have been
+ * converted into function parameters. It may be the case that not all fields are available
+ * as parameters, and not every API method will have a flattened method entry point.
+ * <li> A "request object" method. This type of method only takes one parameter, a request
+ * object, which must be constructed before the call. Not every API method will have a request
+ * object method.
+ * <li> A "callable" method. This type of method takes no parameters and returns an immutable
+ * API callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist
+ * with these names, this class includes a format method for each type of name, and additionally
+ * a parse method to extract the individual identifiers contained within names that are
+ * returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of BillingAccountAdminSettings to
+ * create(). For example:
+ *
+ * <pre>
+ * <code>
+ * BillingAccountAdminSettings billingAccountAdminSettings =
+ *     BillingAccountAdminSettings.defaultBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * BillingAccountAdminClient billingAccountAdminClient =
+ *     BillingAccountAdminClient.create(billingAccountAdminSettings);
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+public class BillingAccountAdminClient implements BackgroundResource {
+  private final BillingAccountAdminSettings settings;
+  private final BillingAccountAdminStub stub;
+
+  private static final PathTemplate BILLING_ACCOUNT_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("billingAccounts/{billing_account}");
+
+  /**
+   * Formats a string containing the fully-qualified path to represent
+   * a billing_account resource.
+   */
+  public static final String formatBillingAccountName(String billingAccount) {
+    return BILLING_ACCOUNT_PATH_TEMPLATE.instantiate(
+        "billing_account", billingAccount);
+  }
+
+  /**
+   * Parses the billing_account from the given fully-qualified path which
+   * represents a billing_account resource.
+   */
+  public static final String parseBillingAccountFromBillingAccountName(String billingAccountName) {
+    return BILLING_ACCOUNT_PATH_TEMPLATE.parse(billingAccountName).get("billing_account");
+  }
+
+  /**
+   * Constructs an instance of BillingAccountAdminClient with default settings.
+   */
+  public static final BillingAccountAdminClient create() throws IOException {
+    return create(BillingAccountAdminSettings.defaultBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of BillingAccountAdminClient, using the given settings.
+   * The channels are created based on the settings passed in, or defaults for any
+   * settings that are not set.
+   */
+  public static final BillingAccountAdminClient create(BillingAccountAdminSettings settings) throws IOException {
+    return new BillingAccountAdminClient(settings);
+  }
+
+  /**
+   * Constructs an instance of BillingAccountAdminClient, using the given stub for making calls. This is for
+   * advanced usage - prefer to use BillingAccountAdminSettings}.
+   */
+  public static final BillingAccountAdminClient create(BillingAccountAdminStub stub) {
+    return new BillingAccountAdminClient(stub);
+  }
+
+  /**
+   * Constructs an instance of BillingAccountAdminClient, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected BillingAccountAdminClient(BillingAccountAdminSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = settings.createStub();
+  }
+
+  protected BillingAccountAdminClient(BillingAccountAdminStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final BillingAccountAdminSettings getSettings() {
+    return settings;
+  }
+
+  public BillingAccountAdminStub getStub() {
+    return stub;
+  }
+
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists the billing accounts that the current authenticated user
+   * [owns](https://support.google.com/cloud/answer/4430947).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+   *
+   *   for (ListBillingAccountsResponse element : billingAccountAdminClient.billingAccountsList().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final BillingAccountsListPagedResponse billingAccountsList(BillingAccountsListHttpRequest request) {
+    return billingAccountsListPagedCallable()
+        .call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists the billing accounts that the current authenticated user
+   * [owns](https://support.google.com/cloud/answer/4430947).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+   *
+   *   ApiFuture&lt;BillingAccountsListPagedResponse&gt; future = billingAccountAdminClient.billingAccountsListPagedCallable().futureCall();
+   *   // Do something
+   *   for (ListBillingAccountsResponse element : future.get().iterateAll()) {
+   *     // doThingsWith(element);
+   *   }
+   * }
+   * </code></pre>
+   */
+  @BetaApi
+  public final UnaryCallable<BillingAccountsListHttpRequest, BillingAccountsListPagedResponse> billingAccountsListPagedCallable() {
+    return stub.billingAccountsListPagedCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Lists the billing accounts that the current authenticated user
+   * [owns](https://support.google.com/cloud/answer/4430947).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+   *
+   *   while (true) {
+   *     BillingAccountsListHttpResponse response = billingAccountAdminClient.billingAccountsListCallable().call();
+   *     for (ListBillingAccountsResponse element : response.getResponse()) {
+   *       // doThingsWith(element);
+   *     }
+   *     String nextPageToken = response.getNextPageToken();
+   *     if (!Strings.isNullOrEmpty(nextPageToken)) {
+   *       request = request.toBuilder().setPageToken(nextPageToken).build();
+   *     } else {
+   *       break;
+   *     }
+   *   }
+   * }
+   * </code></pre>
+   */
+  @BetaApi
+  public final UnaryCallable<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse> billingAccountsListCallable() {
+    return stub.billingAccountsListCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets information about a billing account. The current authenticated user
+   * must be an [owner of the billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+   *
+   *   BillingAccount response = billingAccountAdminClient.billingAccountsGet();
+   * }
+   * </code></pre>
+   *
+   * @param name The resource name of the billing account to retrieve. For example,
+   * `billingAccounts/012345-567890-ABCDEF`.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final BillingAccount billingAccountsGet(String name) {
+
+    BillingAccountsGetHttpRequest request =
+        BillingAccountsGetHttpRequest.newBuilder()
+        .setName(name)
+        .build();
+    return billingAccountsGet(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets information about a billing account. The current authenticated user
+   * must be an [owner of the billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+   *
+   *   BillingAccount response = billingAccountAdminClient.billingAccountsGet();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  private final BillingAccount billingAccountsGet(BillingAccountsGetHttpRequest request) {
+    return billingAccountsGetCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets information about a billing account. The current authenticated user
+   * must be an [owner of the billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+   *
+   *   ApiFuture&lt;BillingAccount&gt; future = billingAccountAdminClient.billingAccountsGetCallable().futureCall();
+   *   // Do something
+   *   BillingAccountsGetHttpResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi
+  public final UnaryCallable<BillingAccountsGetHttpRequest, BillingAccountsGetHttpResponse> billingAccountsGetCallable() {
+    return stub.billingAccountsGetCallable();
+  }
+
+  @Override
+  public final void close() throws Exception {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/BillingAccountAdminSettings.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.core.PropertiesProvider;
+import com.google.api.gax.grpc.ChannelProvider;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.grpc.GrpcTransport;
+import com.google.api.gax.grpc.GrpcTransportProvider;
+import com.google.api.gax.grpc.InstantiatingChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.PagedListDescriptor;
+import com.google.api.gax.rpc.PagedListResponseFactory;
+import com.google.api.gax.rpc.SimpleCallSettings;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.TransportProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.auth.Credentials;
+import static com.google.cloud.fakebilling.v1.PagedResponseWrappers.BillingAccountsListPagedResponse;
+import com.google.cloud.fakebilling.v1.stub.BillingAccountAdminStub;
+import com.google.cloud.fakebilling.v1.stub.GrpcBillingAccountAdminStub;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link BillingAccountAdminClient}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ * <li>The default service address (Service address.) and default port (443)
+ * are used.
+ * <li>Credentials are acquired automatically through Application Default Credentials.
+ * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders.
+ * When build() is called, the tree of builders is called to create the complete settings
+ * object. For example, to set the total timeout of billingAccountsGet to 30 seconds:
+ *
+ * <pre>
+ * <code>
+ * BillingAccountAdminSettings.Builder billingAccountAdminSettingsBuilder =
+ *     BillingAccountAdminSettings.defaultBuilder();
+ * billingAccountAdminSettingsBuilder.billingAccountsGetSettings().getRetrySettingsBuilder()
+ *     .setTotalTimeout(Duration.ofSeconds(30));
+ * BillingAccountAdminSettings billingAccountAdminSettings = billingAccountAdminSettingsBuilder.build();
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+public class BillingAccountAdminSettings extends ClientSettings {
+  /**
+   * The default scopes of the service.
+   */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES = ImmutableList.<String>builder()
+      .add("https://www.googleapis.com/auth/cloud-platform")
+      .build();
+
+  private static final String DEFAULT_GAPIC_NAME = "gapic";
+  private static final String DEFAULT_GAPIC_VERSION = "";
+
+  private static final String PROPERTIES_FILE = "/com/google/cloud/fakebilling/project.properties";
+  private static final String META_VERSION_KEY = "artifact.version";
+
+  private static String gapicVersion;
+
+  private final PagedCallSettings<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, BillingAccountsListPagedResponse> billingAccountsListSettings;
+  private final SimpleCallSettings<BillingAccountsGetHttpRequest, BillingAccountsGetHttpResponse> billingAccountsGetSettings;
+
+  /**
+   * Returns the object with the settings used for calls to billingAccountsList.
+   */
+  public PagedCallSettings<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, BillingAccountsListPagedResponse> billingAccountsListSettings() {
+    return billingAccountsListSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to billingAccountsGet.
+   */
+  public SimpleCallSettings<BillingAccountsGetHttpRequest, BillingAccountsGetHttpResponse> billingAccountsGetSettings() {
+    return billingAccountsGetSettings;
+  }
+
+
+  public BillingAccountAdminStub createStub() throws IOException {
+    if (getTransportProvider().getTransportName().equals(GrpcTransport.getGrpcTransportName())) {
+      return GrpcBillingAccountAdminStub.create(this);
+    } else {
+      throw new UnsupportedOperationException(
+          "Transport not supported: " + getTransportProvider().getTransportName());
+    }
+  }
+
+  /**
+   * Returns a builder for the default ExecutorProvider for this service.
+   */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /**
+   * Returns the default service endpoint.
+   */
+  public static String getDefaultEndpoint() {
+    return "Service address.:443";
+  }
+
+
+  /**
+   * Returns the default service scopes.
+   */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+
+  /**
+   * Returns a builder for the default credentials for this service.
+   */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        ;
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingChannelProvider.Builder defaultGrpcChannelProviderBuilder() {
+    return InstantiatingChannelProvider.newBuilder()
+        .setEndpoint(getDefaultEndpoint())
+        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion());
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static GrpcTransportProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return GrpcTransportProvider.newBuilder()
+        .setChannelProvider(defaultGrpcChannelProviderBuilder().build());
+  }
+
+  public static TransportProvider defaultTransportProvider() {
+    return defaultGrpcTransportProviderBuilder().build();
+  }
+
+  private static String getGapicVersion() {
+    if (gapicVersion == null) {
+      gapicVersion = PropertiesProvider.loadProperty(
+          BillingAccountAdminSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
+      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
+    }
+    return gapicVersion;
+  }
+
+  /**
+   * Returns a builder for this class with recommended defaults.
+   */
+  public static Builder defaultBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a builder for this class with recommended defaults for API methods, and the given
+   * ClientContext used for executor/transport/credentials.
+   */
+  public static Builder defaultBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private BillingAccountAdminSettings(Builder settingsBuilder) throws IOException {
+    super(
+        settingsBuilder.getExecutorProvider(),
+        settingsBuilder.getTransportProvider(),
+        settingsBuilder.getCredentialsProvider(),
+        settingsBuilder.getClock());
+
+    billingAccountsListSettings = settingsBuilder.billingAccountsListSettings().build();
+    billingAccountsGetSettings = settingsBuilder.billingAccountsGetSettings().build();
+  }
+
+  private static final PagedListDescriptor<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse> BILLING_ACCOUNTS_LIST_PAGE_STR_DESC =
+      new PagedListDescriptor<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse>() {
+        @Override
+        public String emptyToken() {
+          return ListBillingAccountsResponse.newBuilder().build();
+        }
+        @Override
+        public BillingAccountsListHttpRequest injectToken(BillingAccountsListHttpRequest payload, String token) {
+          return BillingAccountsListHttpRequest
+            .newBuilder(payload)
+            .setPageToken(token)
+            .build();
+        }
+        @Override
+        public BillingAccountsListHttpRequest injectPageSize(BillingAccountsListHttpRequest payload, int pageSize) {
+          return BillingAccountsListHttpRequest
+            .newBuilder(payload)
+            .setMaxResults(pageSize)
+            .build();
+        }
+        @Override
+        public Integer extractPageSize(BillingAccountsListHttpRequest payload) {
+          return payload.getMaxResults();
+        }
+        @Override
+        public String extractNextToken(BillingAccountsListHttpResponse payload) {
+          return payload.getListBillingAccountsResponse();
+        }
+        @Override
+        public Iterable<ListBillingAccountsResponse> extractResources(BillingAccountsListHttpResponse payload) {
+          return payload.getResponse();
+        }
+      };
+
+  private static final PagedListResponseFactory<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, BillingAccountsListPagedResponse> BILLING_ACCOUNTS_LIST_PAGE_STR_FACT =
+      new PagedListResponseFactory<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, BillingAccountsListPagedResponse>() {
+        @Override
+        public ApiFuture<BillingAccountsListPagedResponse> getFuturePagedResponse(
+            UnaryCallable<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse> callable,
+            BillingAccountsListHttpRequest request,
+            ApiCallContext context,
+            ApiFuture<BillingAccountsListHttpResponse> futureResponse) {
+          PageContext<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse> pageContext =
+              PageContext.create(callable, BILLING_ACCOUNTS_LIST_PAGE_STR_DESC, request, context);
+          return BillingAccountsListPagedResponse.createAsync(pageContext, futureResponse);
+        }
+      };
+
+
+  /**
+   * Builder for BillingAccountAdminSettings.
+   */
+  public static class Builder extends ClientSettings.Builder {
+    private final ImmutableList<UnaryCallSettings.Builder> unaryMethodSettingsBuilders;
+
+    private final PagedCallSettings.Builder<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, BillingAccountsListPagedResponse> billingAccountsListSettings;
+    private final SimpleCallSettings.Builder<BillingAccountsGetHttpRequest, BillingAccountsGetHttpResponse> billingAccountsGetSettings;
+
+    private static final ImmutableMap<String, ImmutableSet<StatusCode>> RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode>> definitions = ImmutableMap.builder();
+      definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode>newArrayList(GrpcStatusCode.of(Status.Code.DEADLINE_EXCEEDED), GrpcStatusCode.of(Status.Code.UNAVAILABLE))));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(100L))
+          .setRetryDelayMultiplier(1.3)
+          .setMaxRetryDelay(Duration.ofMillis(60000L))
+          .setInitialRpcTimeout(Duration.ofMillis(60000L))
+          .setRpcTimeoutMultiplier(1.0)
+          .setMaxRpcTimeout(Duration.ofMillis(60000L))
+          .setTotalTimeout(Duration.ofMillis(600000L))
+          .build();
+      definitions.put("default", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    private Builder() {
+      this((ClientContext) null);
+    }
+
+    private Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      billingAccountsListSettings = PagedCallSettings.newBuilder(
+          BILLING_ACCOUNTS_LIST_PAGE_STR_FACT);
+
+      billingAccountsGetSettings = SimpleCallSettings.newBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+          billingAccountsListSettings,
+          billingAccountsGetSettings
+      );
+
+      initDefaults(this);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder((ClientContext) null);
+      builder.setTransportProvider(defaultTransportProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+
+      builder.billingAccountsListSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.billingAccountsGetSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      return builder;
+    }
+
+    private Builder(BillingAccountAdminSettings settings) {
+      super(settings);
+
+      billingAccountsListSettings = settings.billingAccountsListSettings.toBuilder();
+      billingAccountsGetSettings = settings.billingAccountsGetSettings.toBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+          billingAccountsListSettings,
+          billingAccountsGetSettings
+      );
+    }
+
+    @Override
+    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
+      super.setExecutorProvider(executorProvider);
+      return this;
+    }
+
+    @Override
+    public Builder setTransportProvider(TransportProvider transportProvider) {
+      super.setTransportProvider(transportProvider);
+      return this;
+    }
+
+    @Override
+    public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
+      super.setCredentialsProvider(credentialsProvider);
+      return this;
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(ApiFunction<UnaryCallSettings.Builder, Void> settingsUpdater) throws Exception {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to billingAccountsList.
+     */
+    public PagedCallSettings.Builder<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, BillingAccountsListPagedResponse> billingAccountsListSettings() {
+      return billingAccountsListSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to billingAccountsGet.
+     */
+    public SimpleCallSettings.Builder<BillingAccountsGetHttpRequest, BillingAccountsGetHttpResponse> billingAccountsGetSettings() {
+      return billingAccountsGetSettings;
+    }
+
+    @Override
+    public BillingAccountAdminSettings build() throws IOException {
+      return new BillingAccountAdminSettings(this);
+    }
+  }
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/stub/BillingAccountAdminStub.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.fakebilling.v1.BillingAccount;
+import com.google.cloud.fakebilling.v1.ListBillingAccountsResponse;
+import static com.google.cloud.fakebilling.v1.PagedResponseWrappers.BillingAccountsListPagedResponse;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Base stub class for fakebilling.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by GAPIC v0.0.5")
+public abstract class BillingAccountAdminStub implements BackgroundResource {
+
+
+  @BetaApi
+  public UnaryCallable<BillingAccountsListHttpRequest, BillingAccountsListPagedResponse> billingAccountsListPagedCallable() {
+    throw new UnsupportedOperationException("Not implemented: billingAccountsListPagedCallable()");
+  }
+
+  @BetaApi
+  public UnaryCallable<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse> billingAccountsListCallable() {
+    throw new UnsupportedOperationException("Not implemented: billingAccountsListCallable()");
+  }
+
+  @BetaApi
+  public UnaryCallable<BillingAccountsGetHttpRequest, BillingAccountsGetHttpResponse> billingAccountsGetCallable() {
+    throw new UnsupportedOperationException("Not implemented: billingAccountsGetCallable()");
+  }
+
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/ProjectAdminClient.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.cloud.fakebilling.v1.stub.ProjectAdminStub;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND SERVICE
+/**
+ * Service Description: Test Discovery doc.
+ *
+ * Configure billing projects.
+ *
+ * <p>This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * <pre>
+ * <code>
+ * try (ProjectAdminClient projectAdminClient = ProjectAdminClient.create()) {
+ *
+ *   ProjectBillingInfo response = projectAdminClient.projectsUpdateBillingInfo();
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>Note: close() needs to be called on the projectAdminClient object to clean up resources such
+ * as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's methods:
+ *
+ * <ol>
+ * <li> A "flattened" method. With this type of method, the fields of the request type have been
+ * converted into function parameters. It may be the case that not all fields are available
+ * as parameters, and not every API method will have a flattened method entry point.
+ * <li> A "request object" method. This type of method only takes one parameter, a request
+ * object, which must be constructed before the call. Not every API method will have a request
+ * object method.
+ * <li> A "callable" method. This type of method takes no parameters and returns an immutable
+ * API callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist
+ * with these names, this class includes a format method for each type of name, and additionally
+ * a parse method to extract the individual identifiers contained within names that are
+ * returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of ProjectAdminSettings to
+ * create(). For example:
+ *
+ * <pre>
+ * <code>
+ * ProjectAdminSettings projectAdminSettings =
+ *     ProjectAdminSettings.defaultBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * ProjectAdminClient projectAdminClient =
+ *     ProjectAdminClient.create(projectAdminSettings);
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+public class ProjectAdminClient implements BackgroundResource {
+  private final ProjectAdminSettings settings;
+  private final ProjectAdminStub stub;
+
+  private static final PathTemplate PROJECT_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}");
+
+  /**
+   * Formats a string containing the fully-qualified path to represent
+   * a project resource.
+   */
+  public static final String formatProjectName(String project) {
+    return PROJECT_PATH_TEMPLATE.instantiate(
+        "project", project);
+  }
+
+  /**
+   * Parses the project from the given fully-qualified path which
+   * represents a project resource.
+   */
+  public static final String parseProjectFromProjectName(String projectName) {
+    return PROJECT_PATH_TEMPLATE.parse(projectName).get("project");
+  }
+
+  /**
+   * Constructs an instance of ProjectAdminClient with default settings.
+   */
+  public static final ProjectAdminClient create() throws IOException {
+    return create(ProjectAdminSettings.defaultBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of ProjectAdminClient, using the given settings.
+   * The channels are created based on the settings passed in, or defaults for any
+   * settings that are not set.
+   */
+  public static final ProjectAdminClient create(ProjectAdminSettings settings) throws IOException {
+    return new ProjectAdminClient(settings);
+  }
+
+  /**
+   * Constructs an instance of ProjectAdminClient, using the given stub for making calls. This is for
+   * advanced usage - prefer to use ProjectAdminSettings}.
+   */
+  public static final ProjectAdminClient create(ProjectAdminStub stub) {
+    return new ProjectAdminClient(stub);
+  }
+
+  /**
+   * Constructs an instance of ProjectAdminClient, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected ProjectAdminClient(ProjectAdminSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = settings.createStub();
+  }
+
+  protected ProjectAdminClient(ProjectAdminStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final ProjectAdminSettings getSettings() {
+    return settings;
+  }
+
+  public ProjectAdminStub getStub() {
+    return stub;
+  }
+
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Sets or updates the billing account associated with a project. You specify
+   * the new billing account by setting the `billing_account_name` in the
+   * `ProjectBillingInfo` resource to the resource name of a billing account.
+   * Associating a project with an open billing account enables billing on the
+   * project and allows charges for resource usage. If the project already had a
+   * billing account, this method changes the billing account used for resource
+   * usage charges.
+   *
+   * &#42;Note:&#42; Incurred charges that have not yet been reported in the transaction
+   * history of the Google Cloud Console may be billed to the new billing
+   * account, even if the charge occurred before the new billing account was
+   * assigned to the project.
+   *
+   * The current authenticated user must have ownership privileges for both the
+   * [project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo
+   * ) and the [billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   *
+   * You can disable billing on the project by setting the
+   * `billing_account_name` field to empty. This action disassociates the
+   * current billing account from the project. Any billable activity of your
+   * in-use services will stop, and your application could stop functioning as
+   * expected. Any unbilled charges to date will be billed to the previously
+   * associated account. The current authenticated user must be either an owner
+   * of the project or an owner of the billing account for the project.
+   *
+   * Note that associating a project with a &#42;closed&#42; billing account will have
+   * much the same effect as disabling billing on the project: any paid
+   * resources used by the project will be shut down. Thus, unless you wish to
+   * disable billing, you should always call this method with the name of an
+   * &#42;open&#42; billing account.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (ProjectAdminClient projectAdminClient = ProjectAdminClient.create()) {
+   *
+   *   ProjectBillingInfo response = projectAdminClient.projectsUpdateBillingInfo();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final ProjectBillingInfo projectsUpdateBillingInfo(ProjectsUpdateBillingInfoHttpRequest request) {
+    return projectsUpdateBillingInfoCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Sets or updates the billing account associated with a project. You specify
+   * the new billing account by setting the `billing_account_name` in the
+   * `ProjectBillingInfo` resource to the resource name of a billing account.
+   * Associating a project with an open billing account enables billing on the
+   * project and allows charges for resource usage. If the project already had a
+   * billing account, this method changes the billing account used for resource
+   * usage charges.
+   *
+   * &#42;Note:&#42; Incurred charges that have not yet been reported in the transaction
+   * history of the Google Cloud Console may be billed to the new billing
+   * account, even if the charge occurred before the new billing account was
+   * assigned to the project.
+   *
+   * The current authenticated user must have ownership privileges for both the
+   * [project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo
+   * ) and the [billing
+   * account](https://support.google.com/cloud/answer/4430947).
+   *
+   * You can disable billing on the project by setting the
+   * `billing_account_name` field to empty. This action disassociates the
+   * current billing account from the project. Any billable activity of your
+   * in-use services will stop, and your application could stop functioning as
+   * expected. Any unbilled charges to date will be billed to the previously
+   * associated account. The current authenticated user must be either an owner
+   * of the project or an owner of the billing account for the project.
+   *
+   * Note that associating a project with a &#42;closed&#42; billing account will have
+   * much the same effect as disabling billing on the project: any paid
+   * resources used by the project will be shut down. Thus, unless you wish to
+   * disable billing, you should always call this method with the name of an
+   * &#42;open&#42; billing account.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (ProjectAdminClient projectAdminClient = ProjectAdminClient.create()) {
+   *
+   *   ApiFuture&lt;ProjectBillingInfo&gt; future = projectAdminClient.projectsUpdateBillingInfoCallable().futureCall();
+   *   // Do something
+   *   ProjectsUpdateBillingInfoHttpResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi
+  public final UnaryCallable<ProjectsUpdateBillingInfoHttpRequest, ProjectsUpdateBillingInfoHttpResponse> projectsUpdateBillingInfoCallable() {
+    return stub.projectsUpdateBillingInfoCallable();
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets the billing information for a project. The current authenticated user
+   * must have [permission to view the
+   * project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo
+   * ).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (ProjectAdminClient projectAdminClient = ProjectAdminClient.create()) {
+   *
+   *   ProjectBillingInfo response = projectAdminClient.projectsGetBillingInfo();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final ProjectBillingInfo projectsGetBillingInfo(ProjectsGetBillingInfoHttpRequest request) {
+    return projectsGetBillingInfoCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Gets the billing information for a project. The current authenticated user
+   * must have [permission to view the
+   * project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo
+   * ).
+   *
+   * Sample code:
+   * <pre><code>
+   * try (ProjectAdminClient projectAdminClient = ProjectAdminClient.create()) {
+   *
+   *   ApiFuture&lt;ProjectBillingInfo&gt; future = projectAdminClient.projectsGetBillingInfoCallable().futureCall();
+   *   // Do something
+   *   ProjectsGetBillingInfoHttpResponse response = future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi
+  public final UnaryCallable<ProjectsGetBillingInfoHttpRequest, ProjectsGetBillingInfoHttpResponse> projectsGetBillingInfoCallable() {
+    return stub.projectsGetBillingInfoCallable();
+  }
+
+  @Override
+  public final void close() throws Exception {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/ProjectAdminSettings.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.core.PropertiesProvider;
+import com.google.api.gax.grpc.ChannelProvider;
+import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.grpc.GrpcTransport;
+import com.google.api.gax.grpc.GrpcTransportProvider;
+import com.google.api.gax.grpc.InstantiatingChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.SimpleCallSettings;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.TransportProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.auth.Credentials;
+import com.google.cloud.fakebilling.v1.stub.GrpcProjectAdminStub;
+import com.google.cloud.fakebilling.v1.stub.ProjectAdminStub;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link ProjectAdminClient}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ * <li>The default service address (Service address.) and default port (443)
+ * are used.
+ * <li>Credentials are acquired automatically through Application Default Credentials.
+ * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders.
+ * When build() is called, the tree of builders is called to create the complete settings
+ * object. For example, to set the total timeout of projectsUpdateBillingInfo to 30 seconds:
+ *
+ * <pre>
+ * <code>
+ * ProjectAdminSettings.Builder projectAdminSettingsBuilder =
+ *     ProjectAdminSettings.defaultBuilder();
+ * projectAdminSettingsBuilder.projectsUpdateBillingInfoSettings().getRetrySettingsBuilder()
+ *     .setTotalTimeout(Duration.ofSeconds(30));
+ * ProjectAdminSettings projectAdminSettings = projectAdminSettingsBuilder.build();
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+public class ProjectAdminSettings extends ClientSettings {
+  /**
+   * The default scopes of the service.
+   */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES = ImmutableList.<String>builder()
+      .add("https://www.googleapis.com/auth/cloud-platform")
+      .build();
+
+  private static final String DEFAULT_GAPIC_NAME = "gapic";
+  private static final String DEFAULT_GAPIC_VERSION = "";
+
+  private static final String PROPERTIES_FILE = "/com/google/cloud/fakebilling/project.properties";
+  private static final String META_VERSION_KEY = "artifact.version";
+
+  private static String gapicVersion;
+
+  private final SimpleCallSettings<ProjectsUpdateBillingInfoHttpRequest, ProjectsUpdateBillingInfoHttpResponse> projectsUpdateBillingInfoSettings;
+  private final SimpleCallSettings<ProjectsGetBillingInfoHttpRequest, ProjectsGetBillingInfoHttpResponse> projectsGetBillingInfoSettings;
+
+  /**
+   * Returns the object with the settings used for calls to projectsUpdateBillingInfo.
+   */
+  public SimpleCallSettings<ProjectsUpdateBillingInfoHttpRequest, ProjectsUpdateBillingInfoHttpResponse> projectsUpdateBillingInfoSettings() {
+    return projectsUpdateBillingInfoSettings;
+  }
+
+  /**
+   * Returns the object with the settings used for calls to projectsGetBillingInfo.
+   */
+  public SimpleCallSettings<ProjectsGetBillingInfoHttpRequest, ProjectsGetBillingInfoHttpResponse> projectsGetBillingInfoSettings() {
+    return projectsGetBillingInfoSettings;
+  }
+
+
+  public ProjectAdminStub createStub() throws IOException {
+    if (getTransportProvider().getTransportName().equals(GrpcTransport.getGrpcTransportName())) {
+      return GrpcProjectAdminStub.create(this);
+    } else {
+      throw new UnsupportedOperationException(
+          "Transport not supported: " + getTransportProvider().getTransportName());
+    }
+  }
+
+  /**
+   * Returns a builder for the default ExecutorProvider for this service.
+   */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /**
+   * Returns the default service endpoint.
+   */
+  public static String getDefaultEndpoint() {
+    return "Service address.:443";
+  }
+
+
+  /**
+   * Returns the default service scopes.
+   */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+
+  /**
+   * Returns a builder for the default credentials for this service.
+   */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        ;
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingChannelProvider.Builder defaultGrpcChannelProviderBuilder() {
+    return InstantiatingChannelProvider.newBuilder()
+        .setEndpoint(getDefaultEndpoint())
+        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion());
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static GrpcTransportProvider.Builder defaultGrpcTransportProviderBuilder() {
+    return GrpcTransportProvider.newBuilder()
+        .setChannelProvider(defaultGrpcChannelProviderBuilder().build());
+  }
+
+  public static TransportProvider defaultTransportProvider() {
+    return defaultGrpcTransportProviderBuilder().build();
+  }
+
+  private static String getGapicVersion() {
+    if (gapicVersion == null) {
+      gapicVersion = PropertiesProvider.loadProperty(
+          ProjectAdminSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
+      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
+    }
+    return gapicVersion;
+  }
+
+  /**
+   * Returns a builder for this class with recommended defaults.
+   */
+  public static Builder defaultBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a builder for this class with recommended defaults for API methods, and the given
+   * ClientContext used for executor/transport/credentials.
+   */
+  public static Builder defaultBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private ProjectAdminSettings(Builder settingsBuilder) throws IOException {
+    super(
+        settingsBuilder.getExecutorProvider(),
+        settingsBuilder.getTransportProvider(),
+        settingsBuilder.getCredentialsProvider(),
+        settingsBuilder.getClock());
+
+    projectsUpdateBillingInfoSettings = settingsBuilder.projectsUpdateBillingInfoSettings().build();
+    projectsGetBillingInfoSettings = settingsBuilder.projectsGetBillingInfoSettings().build();
+  }
+
+
+
+
+  /**
+   * Builder for ProjectAdminSettings.
+   */
+  public static class Builder extends ClientSettings.Builder {
+    private final ImmutableList<UnaryCallSettings.Builder> unaryMethodSettingsBuilders;
+
+    private final SimpleCallSettings.Builder<ProjectsUpdateBillingInfoHttpRequest, ProjectsUpdateBillingInfoHttpResponse> projectsUpdateBillingInfoSettings;
+    private final SimpleCallSettings.Builder<ProjectsGetBillingInfoHttpRequest, ProjectsGetBillingInfoHttpResponse> projectsGetBillingInfoSettings;
+
+    private static final ImmutableMap<String, ImmutableSet<StatusCode>> RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode>> definitions = ImmutableMap.builder();
+      definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode>newArrayList(GrpcStatusCode.of(Status.Code.DEADLINE_EXCEEDED), GrpcStatusCode.of(Status.Code.UNAVAILABLE))));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(100L))
+          .setRetryDelayMultiplier(1.3)
+          .setMaxRetryDelay(Duration.ofMillis(60000L))
+          .setInitialRpcTimeout(Duration.ofMillis(60000L))
+          .setRpcTimeoutMultiplier(1.0)
+          .setMaxRpcTimeout(Duration.ofMillis(60000L))
+          .setTotalTimeout(Duration.ofMillis(600000L))
+          .build();
+      definitions.put("default", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    private Builder() {
+      this((ClientContext) null);
+    }
+
+    private Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      projectsUpdateBillingInfoSettings = SimpleCallSettings.newBuilder();
+
+      projectsGetBillingInfoSettings = SimpleCallSettings.newBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+          projectsUpdateBillingInfoSettings,
+          projectsGetBillingInfoSettings
+      );
+
+      initDefaults(this);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder((ClientContext) null);
+      builder.setTransportProvider(defaultTransportProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+
+      builder.projectsUpdateBillingInfoSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      builder.projectsGetBillingInfoSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      return builder;
+    }
+
+    private Builder(ProjectAdminSettings settings) {
+      super(settings);
+
+      projectsUpdateBillingInfoSettings = settings.projectsUpdateBillingInfoSettings.toBuilder();
+      projectsGetBillingInfoSettings = settings.projectsGetBillingInfoSettings.toBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+          projectsUpdateBillingInfoSettings,
+          projectsGetBillingInfoSettings
+      );
+    }
+
+    @Override
+    public Builder setExecutorProvider(ExecutorProvider executorProvider) {
+      super.setExecutorProvider(executorProvider);
+      return this;
+    }
+
+    @Override
+    public Builder setTransportProvider(TransportProvider transportProvider) {
+      super.setTransportProvider(transportProvider);
+      return this;
+    }
+
+    @Override
+    public Builder setCredentialsProvider(CredentialsProvider credentialsProvider) {
+      super.setCredentialsProvider(credentialsProvider);
+      return this;
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(ApiFunction<UnaryCallSettings.Builder, Void> settingsUpdater) throws Exception {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to projectsUpdateBillingInfo.
+     */
+    public SimpleCallSettings.Builder<ProjectsUpdateBillingInfoHttpRequest, ProjectsUpdateBillingInfoHttpResponse> projectsUpdateBillingInfoSettings() {
+      return projectsUpdateBillingInfoSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to projectsGetBillingInfo.
+     */
+    public SimpleCallSettings.Builder<ProjectsGetBillingInfoHttpRequest, ProjectsGetBillingInfoHttpResponse> projectsGetBillingInfoSettings() {
+      return projectsGetBillingInfoSettings;
+    }
+
+    @Override
+    public ProjectAdminSettings build() throws IOException {
+      return new ProjectAdminSettings(this);
+    }
+  }
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/stub/ProjectAdminStub.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.fakebilling.v1.ProjectBillingInfo;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Base stub class for fakebilling.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by GAPIC v0.0.5")
+public abstract class ProjectAdminStub implements BackgroundResource {
+
+
+  @BetaApi
+  public UnaryCallable<ProjectsUpdateBillingInfoHttpRequest, ProjectsUpdateBillingInfoHttpResponse> projectsUpdateBillingInfoCallable() {
+    throw new UnsupportedOperationException("Not implemented: projectsUpdateBillingInfoCallable()");
+  }
+
+  @BetaApi
+  public UnaryCallable<ProjectsGetBillingInfoHttpRequest, ProjectsGetBillingInfoHttpResponse> projectsGetBillingInfoCallable() {
+    throw new UnsupportedOperationException("Not implemented: projectsGetBillingInfoCallable()");
+  }
+
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/PagedResponseWrappers.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.fakebilling.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.paging.AbstractFixedSizeCollection;
+import com.google.api.gax.paging.AbstractPage;
+import com.google.api.gax.paging.AbstractPagedListResponse;
+import com.google.api.gax.paging.FixedSizeCollection;
+import com.google.api.gax.paging.Page;
+import com.google.api.gax.paging.PagedListResponse;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.api.gax.rpc.PageContext;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Wrapper class to contain paged response types for page streaming methods.
+ * Each static class inside this wrapper class is used as the return type of
+ * one of an API method that implements the page streaming pattern.
+ */
+@Generated("by GAPIC")
+public class PagedResponseWrappers {
+
+  public static class BillingAccountsListPagedResponse extends AbstractPagedListResponse<
+      BillingAccountsListHttpRequest,
+      BillingAccountsListHttpResponse,
+      ListBillingAccountsResponse,
+      BillingAccountsListPage,
+      BillingAccountsListFixedSizeCollection> {
+
+    public static ApiFuture<BillingAccountsListPagedResponse> createAsync(
+        PageContext<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse> context,
+        ApiFuture<BillingAccountsListHttpResponse> futureResponse) {
+      ApiFuture<BillingAccountsListPage> futurePage =
+          BillingAccountsListPage.createEmptyPage().createPageAsync(context, futureResponse);
+      return ApiFutures.transform(
+          futurePage,
+          new ApiFunction<BillingAccountsListPage, BillingAccountsListPagedResponse>() {
+            @Override
+            public BillingAccountsListPagedResponse apply(BillingAccountsListPage input) {
+              return new BillingAccountsListPagedResponse(input);
+            }
+          });
+    }
+
+    private BillingAccountsListPagedResponse(BillingAccountsListPage page) {
+      super(page, BillingAccountsListFixedSizeCollection.createEmptyCollection());
+    }
+
+
+  }
+
+  public static class BillingAccountsListPage extends AbstractPage<
+      BillingAccountsListHttpRequest,
+      BillingAccountsListHttpResponse,
+      ListBillingAccountsResponse,
+      BillingAccountsListPage> {
+
+    private BillingAccountsListPage(
+        PageContext<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse> context,
+        BillingAccountsListHttpResponse response) {
+      super(context, response);
+    }
+
+    private static BillingAccountsListPage createEmptyPage() {
+      return new BillingAccountsListPage(null, null);
+    }
+
+    @Override
+    protected BillingAccountsListPage createPage(
+        PageContext<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse> context,
+        BillingAccountsListHttpResponse response) {
+      return new BillingAccountsListPage(context, response);
+    }
+
+    @Override
+    public ApiFuture<BillingAccountsListPage> createPageAsync(
+        PageContext<BillingAccountsListHttpRequest, BillingAccountsListHttpResponse, ListBillingAccountsResponse> context,
+        ApiFuture<BillingAccountsListHttpResponse> futureResponse) {
+      return super.createPageAsync(context, futureResponse);
+    }
+
+
+
+
+  }
+
+  public static class BillingAccountsListFixedSizeCollection extends AbstractFixedSizeCollection<
+      BillingAccountsListHttpRequest,
+      BillingAccountsListHttpResponse,
+      ListBillingAccountsResponse,
+      BillingAccountsListPage,
+      BillingAccountsListFixedSizeCollection> {
+
+    private BillingAccountsListFixedSizeCollection(List<BillingAccountsListPage> pages, int collectionSize) {
+      super(pages, collectionSize);
+    }
+
+    private static BillingAccountsListFixedSizeCollection createEmptyCollection() {
+      return new BillingAccountsListFixedSizeCollection(null, 0);
+    }
+
+    @Override
+    protected BillingAccountsListFixedSizeCollection createCollection(
+        List<BillingAccountsListPage> pages, int collectionSize) {
+      return new BillingAccountsListFixedSizeCollection(pages, collectionSize);
+    }
+
+
+  }
+
+}
+============== file: src/main/java/com/google/cloud/fakebilling/v1/package-info.java ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A client to Service title..
+ *
+ * The interfaces provided are listed below, along with usage samples.
+ *
+ * =========================
+ * BillingAccountAdminClient
+ * =========================
+ *
+ * Service Description: Test Discovery doc.
+ *
+ * Sample for BillingAccountAdminClient:
+ * <pre>
+ * <code>
+ * try (BillingAccountAdminClient billingAccountAdminClient = BillingAccountAdminClient.create()) {
+ *
+ *   BillingAccount response = billingAccountAdminClient.billingAccountsGet();
+ * }
+ * </code>
+ * </pre>
+ *
+ * ==================
+ * ProjectAdminClient
+ * ==================
+ *
+ * Service Description: Test Discovery doc.
+ *
+ * Configure billing projects.
+ *
+ * Sample for ProjectAdminClient:
+ * <pre>
+ * <code>
+ * try (ProjectAdminClient projectAdminClient = ProjectAdminClient.create()) {
+ *
+ *   ProjectBillingInfo response = projectAdminClient.projectsUpdateBillingInfo();
+ * }
+ * </code>
+ * </pre>
+ *
+ */
+
+package com.google.cloud.fakebilling.v1;

--- a/src/test/java/com/google/api/codegen/testdata/fakebilling_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/fakebilling_pkg.yaml
@@ -1,0 +1,110 @@
+# Common configuration
+short_name: fakebilling
+major_version: v1
+proto_path: google/fakebilling
+author: Google, Inc.
+email: googleapis-packages@google.com
+homepage: https://github.com/googleapis/googleapis
+license: Apache-2.0
+proto_deps:
+- google-common-protos
+- google-some-other-package-v1
+proto_test_deps:
+- google-some-test-package-v1
+
+# Language-dependent configuration
+package_name:
+  default: google-cloud-fakebilling-v1
+
+generated_package_version:
+  python:
+    lower: '0.15.0'
+    upper: '0.16dev'
+  nodejs:
+    lower: '0.7.1'
+  php:
+    lower: '0.1.0'
+  ruby:
+    lower: '0.6.8'
+
+release_level:
+  python: ALPHA
+  java: GA
+
+# Dependencies
+auth_version:
+  python:
+    lower: '2.0.0'
+    upper: '4.0dev'
+  nodejs:
+    lower: '0.9.8'
+  ruby:
+    lower: '0.5.1'
+
+gax_version:
+  python:
+    lower: '0.15.0'
+    upper: '0.16.0'
+  nodejs:
+    lower: '^0.7.0'
+  php:
+    lower: '0.6.*'
+  ruby:
+    lower: '0.8.0'
+  java:
+    lower: '1.0.0'
+
+gax_grpc_version:
+  java:
+    lower: '0.18.0'
+
+grpc_version:
+  python:
+    lower: '1.0.2'
+    upper: '2.0dev'
+  nodejs:
+    lower: '0.15.0'
+  php:
+    lower: '0.14.1'
+  ruby:
+    lower: '1.0'
+
+proto_version:
+  python:
+    lower: '3.0.0'
+    upper: '4.0dev'
+  nodejs:
+    lower: '^0.8.3'
+  php:
+    lower: '0.7.*'
+  ruby:
+    lower: '3.0'
+
+api_common_version:
+  java:
+    lower: '0.0.2'
+
+google-common-protos_version:
+  python:
+    name_override: googleapis-common-protos
+    lower: '1.5.0'
+    upper: '2.0dev'
+  nodejs:
+    name_override: google-proto-files
+    lower: '0.8.2'
+  ruby:
+    lower: '1.3.1'
+
+google-some-other-package-v1_version:
+  python:
+    name_override: python-other-package
+    lower: '12.1.0'
+    upper: '13.5.1'
+  nodejs:
+    lower: '0.2.1'
+  ruby:
+    lower: '0.2.1'
+
+google-some-test-package-v1_version:
+  java:
+    lower: '0.0.0'

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -17,6 +17,8 @@ package com.google.api.codegen.transformer.go;
 import com.google.api.codegen.CodegenTestUtil;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.ProtoMethodModel;
 import com.google.api.codegen.gapic.PackageNameCodePathMapper;
 import com.google.api.codegen.transformer.DefaultFeatureConfig;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
@@ -86,7 +88,7 @@ public class GoGapicSurfaceTransformerTest {
 
   @Test
   public void testGetImportsPlain() {
-    Method method = getMethod(context.getInterface(), "SimpleMethod");
+    MethodModel method = new ProtoMethodModel(getMethod(context.getInterface(), "SimpleMethod"));
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).doesNotContainKey("time");
@@ -96,7 +98,7 @@ public class GoGapicSurfaceTransformerTest {
 
   @Test
   public void testGetImportsRetry() {
-    Method method = getMethod(context.getInterface(), "RetryMethod");
+    MethodModel method = new ProtoMethodModel(getMethod(context.getInterface(), "RetryMethod"));
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).containsKey("time");
@@ -106,7 +108,8 @@ public class GoGapicSurfaceTransformerTest {
 
   @Test
   public void testGetImportsPageStream() {
-    Method method = getMethod(context.getInterface(), "PageStreamMethod");
+    MethodModel method =
+        new ProtoMethodModel(getMethod(context.getInterface(), "PageStreamMethod"));
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).containsKey("math");
@@ -116,7 +119,7 @@ public class GoGapicSurfaceTransformerTest {
 
   @Test
   public void testGetImportsLro() {
-    Method method = getMethod(context.getInterface(), "LroMethod");
+    MethodModel method = new ProtoMethodModel(getMethod(context.getInterface(), "LroMethod"));
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).doesNotContainKey("math");
@@ -126,7 +129,7 @@ public class GoGapicSurfaceTransformerTest {
 
   @Test
   public void testGetImportsNotLro() {
-    Method method = getMethod(context.getInterface(), "NotLroMethod");
+    MethodModel method = new ProtoMethodModel(getMethod(context.getInterface(), "NotLroMethod"));
     transformer.addXApiImports(context, Collections.singletonList(method));
     Truth.assertThat(context.getImportTypeTable().getImports())
         .doesNotContainKey("cloud.google.com/go/longrunning");
@@ -134,21 +137,24 @@ public class GoGapicSurfaceTransformerTest {
 
   @Test
   public void testGetExampleImportsServerStream() {
-    Method method = getMethod(context.getInterface(), "ServerStreamMethod");
+    MethodModel method =
+        new ProtoMethodModel(getMethod(context.getInterface(), "ServerStreamMethod"));
     transformer.addXExampleImports(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).containsKey("io");
   }
 
   @Test
   public void testGetExampleImportsBidiStream() {
-    Method method = getMethod(context.getInterface(), "BidiStreamMethod");
+    MethodModel method =
+        new ProtoMethodModel(getMethod(context.getInterface(), "BidiStreamMethod"));
     transformer.addXExampleImports(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).containsKey("io");
   }
 
   @Test
   public void testGetExampleImportsClientStream() {
-    Method method = getMethod(context.getInterface(), "ClientStreamMethod");
+    MethodModel method =
+        new ProtoMethodModel(getMethod(context.getInterface(), "ClientStreamMethod"));
     transformer.addXExampleImports(context, Collections.singletonList(method));
     Truth.assertThat(context.getModelTypeTable().getImports()).doesNotContainKey("io");
   }


### PR DESCRIPTION
- Create a new MethodModel class abstracts API source details from method objects.
- Fill in ViewModels for JavaDiscoGapicSurfaceTransformer, with corresponding updated baseline.
- Move to using the abstract interfaces InterfaceContext, MethodContext, InterfaceConfig, MethodConfig instead of the gapic/discogapic variants whenever possible.