### PR TITLE
Divide streaming into client/server/bidi

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicInterfaceConfig.java
@@ -399,6 +399,15 @@ public abstract class GapicInterfaceConfig implements InterfaceConfig {
     return false;
   }
 
+  public boolean hasGrpcStreamingMethods(GrpcStreamingConfig.GrpcStreamingType streamingType) {
+    for (GapicMethodConfig methodConfig : getMethodConfigs()) {
+      if (methodConfig.isGrpcStreaming() && methodConfig.getGrpcStreamingType() == streamingType) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public boolean hasLongRunningOperations() {
     for (GapicMethodConfig methodConfig : getMethodConfigs()) {
       if (methodConfig.isLongRunningOperation()) {

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -103,8 +103,8 @@ public class ApiCallableTransformer {
 
     ApiCallableImplType callableImplType = ApiCallableImplType.SimpleApiCallable;
     if (methodConfig.isGrpcStreaming()) {
-      callableImplType = ApiCallableImplType.StreamingApiCallable;
-      apiCallableBuilder.grpcStreamingType(methodConfig.getGrpcStreaming().getType());
+      callableImplType = ApiCallableImplType.of(methodConfig.getGrpcStreamingType());
+      apiCallableBuilder.grpcStreamingType(methodConfig.getGrpcStreamingType());
     } else if (methodConfig.isBatching()) {
       callableImplType = ApiCallableImplType.BatchingApiCallable;
     } else if (methodConfig.isLongRunningOperation()) {
@@ -230,7 +230,7 @@ public class ApiCallableTransformer {
         namer.getNotImplementedString(notImplementedPrefix + "batchingDescriptorName"));
 
     if (methodConfig.isGrpcStreaming()) {
-      settings.type(ApiCallableImplType.StreamingApiCallable);
+      settings.type(ApiCallableImplType.of(methodConfig.getGrpcStreamingType()));
       if (methodConfig.getGrpcStreaming().hasResourceField()) {
         TypeRef resourceType = methodConfig.getGrpcStreaming().getResourcesField().getType();
         settings.resourceTypeName(typeTable.getAndSaveNicknameForElementType(resourceType));
@@ -289,7 +289,8 @@ public class ApiCallableTransformer {
 
     ServiceMethodType callableInterfaceType = ServiceMethodType.UnaryMethod;
     if (methodConfig.isGrpcStreaming()) {
-      callableInterfaceType = ServiceMethodType.GrpcStreamingMethod;
+      callableInterfaceType =
+          ApiCallableImplType.of(methodConfig.getGrpcStreamingType()).serviceMethodType();
       callableBuilder.grpcStreamingType(methodConfig.getGrpcStreaming().getType());
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -19,7 +19,6 @@ import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
-import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.ApiCallableTransformer;
@@ -188,9 +187,8 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
       if (call.type() == ApiCallableImplType.SimpleApiCallable
           || call.type() == ApiCallableImplType.BatchingApiCallable
           || call.type() == ApiCallableImplType.InitialOperationApiCallable
-          || (call.type() == ApiCallableImplType.StreamingApiCallable
-              && (call.grpcStreamingType() == GrpcStreamingType.BidiStreaming
-                  || call.grpcStreamingType() == GrpcStreamingType.ServerStreaming))) {
+          || call.type() == ApiCallableImplType.BidiStreamingApiCallable
+          || call.type() == ApiCallableImplType.ServerStreamingApiCallable) {
         callables.add(call);
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -206,7 +206,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
           // Issue: https://github.com/googleapis/toolkit/issues/946
           continue;
         }
-        addGrpcStreamingTestImports(context);
+        addGrpcStreamingTestImports(context, methodConfig.getGrpcStreamingType());
         GapicMethodContext methodContext = context.asRequestMethodContext(method);
         InitCodeContext initCodeContext =
             initCodeTransformer.createRequestInitCodeContext(
@@ -394,10 +394,23 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("io.grpc.ServerServiceDefinition");
   }
 
-  private void addGrpcStreamingTestImports(GapicInterfaceContext context) {
+  private void addGrpcStreamingTestImports(
+      GapicInterfaceContext context, GrpcStreamingType streamingType) {
     ModelTypeTable typeTable = context.getModelTypeTable();
     typeTable.saveNicknameFor("com.google.api.gax.grpc.testing.MockStreamObserver");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiStreamObserver");
-    typeTable.saveNicknameFor("com.google.api.gax.rpc.StreamingCallable");
+    switch (streamingType) {
+      case BidiStreaming:
+        typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
+        break;
+      case ClientStreaming:
+        typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientStreamingCallable");
+        break;
+      case ServerStreaming:
+        typeTable.saveNicknameFor("com.google.api.gax.rpc.ServerStreamingCallable");
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid streaming type: " + streamingType);
+    }
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.codegen.config.GrpcStreamingConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ProductServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -684,8 +685,17 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("javax.annotation.Generated");
 
     GapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
-    if (interfaceConfig.hasGrpcStreamingMethods()) {
-      typeTable.saveNicknameFor("com.google.api.gax.rpc.StreamingCallable");
+    if (interfaceConfig.hasGrpcStreamingMethods(
+        GrpcStreamingConfig.GrpcStreamingType.BidiStreaming)) {
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
+    }
+    if (interfaceConfig.hasGrpcStreamingMethods(
+        GrpcStreamingConfig.GrpcStreamingType.ServerStreaming)) {
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.ServerStreamingCallable");
+    }
+    if (interfaceConfig.hasGrpcStreamingMethods(
+        GrpcStreamingConfig.GrpcStreamingType.ClientStreaming)) {
+      typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientStreamingCallable");
     }
     if (interfaceConfig.hasLongRunningOperations()) {
       typeTable.saveNicknameFor("com.google.longrunning.Operation");
@@ -768,7 +778,21 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
         apiMethods.add(
             apiMethodTransformer.generateUnpagedListCallableMethod(requestMethodContext));
       } else if (methodConfig.isGrpcStreaming()) {
-        context.getModelTypeTable().saveNicknameFor("com.google.api.gax.rpc.StreamingCallable");
+        ModelTypeTable typeTable = context.getModelTypeTable();
+        switch (methodConfig.getGrpcStreamingType()) {
+          case BidiStreaming:
+            typeTable.saveNicknameFor("com.google.api.gax.rpc.BidiStreamingCallable");
+            break;
+          case ClientStreaming:
+            typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientStreamingCallable");
+            break;
+          case ServerStreaming:
+            typeTable.saveNicknameFor("com.google.api.gax.rpc.ServerStreamingCallable");
+            break;
+          default:
+            throw new IllegalArgumentException(
+                "Invalid streaming type: " + methodConfig.getGrpcStreamingType());
+        }
         apiMethods.add(apiMethodTransformer.generateCallableMethod(requestMethodContext));
       } else if (methodConfig.isLongRunningOperation()) {
         context.getModelTypeTable().saveNicknameFor("com.google.api.gax.rpc.OperationCallable");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -203,8 +203,12 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     switch (serviceMethodType) {
       case UnaryMethod:
         return "UnaryCallable";
-      case GrpcStreamingMethod:
-        return "StreamingCallable";
+      case GrpcBidiStreamingMethod:
+        return "BidiStreamingCallable";
+      case GrpcServerStreamingMethod:
+        return "ServerStreamingCallable";
+      case GrpcClientStreamingMethod:
+        return "ClientStreamingCallable";
       case LongRunningMethod:
         return "OperationCallable";
       default:
@@ -217,8 +221,12 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     switch (serviceMethodType) {
       case UnaryMethod:
         return "UnaryCallable";
-      case GrpcStreamingMethod:
-        return "StreamingCallable";
+      case GrpcBidiStreamingMethod:
+        return "BidiStreamingCallable";
+      case GrpcServerStreamingMethod:
+        return "ServerStreamingCallable";
+      case GrpcClientStreamingMethod:
+        return "ClientStreamingCallable";
       default:
         return getNotImplementedString("getDirectCallableTypeName() for " + serviceMethodType);
     }
@@ -229,8 +237,12 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     switch (serviceMethodType) {
       case UnaryMethod:
         return "createDirectCallable";
-      case GrpcStreamingMethod:
-        return "createDirectStreamingCallable";
+      case GrpcBidiStreamingMethod:
+        return "createDirectBidiStreamingCallable";
+      case GrpcServerStreamingMethod:
+        return "createDirectServerStreamingCallable";
+      case GrpcClientStreamingMethod:
+        return "createDirectClientStreamingCallable";
       default:
         return getNotImplementedString("getDirectCallableTypeName() for " + serviceMethodType);
     }

--- a/src/main/java/com/google/api/codegen/viewmodel/ApiCallableImplType.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ApiCallableImplType.java
@@ -14,12 +14,16 @@
  */
 package com.google.api.codegen.viewmodel;
 
+import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
+
 /** The concrete callable class type */
 public enum ApiCallableImplType {
   SimpleApiCallable(ServiceMethodType.UnaryMethod),
   PagedApiCallable(ServiceMethodType.UnaryMethod),
   BatchingApiCallable(ServiceMethodType.UnaryMethod),
-  StreamingApiCallable(ServiceMethodType.GrpcStreamingMethod),
+  BidiStreamingApiCallable(ServiceMethodType.GrpcBidiStreamingMethod),
+  ServerStreamingApiCallable(ServiceMethodType.GrpcServerStreamingMethod),
+  ClientStreamingApiCallable(ServiceMethodType.GrpcClientStreamingMethod),
   InitialOperationApiCallable(ServiceMethodType.UnaryMethod),
   OperationApiCallable(ServiceMethodType.LongRunningMethod);
 
@@ -31,5 +35,18 @@ public enum ApiCallableImplType {
 
   public ServiceMethodType serviceMethodType() {
     return serviceMethodType;
+  }
+
+  public static ApiCallableImplType of(GrpcStreamingType streamingType) {
+    switch (streamingType) {
+      case BidiStreaming:
+        return BidiStreamingApiCallable;
+      case ServerStreaming:
+        return ServerStreamingApiCallable;
+      case ClientStreaming:
+        return ClientStreamingApiCallable;
+      default:
+        throw new IllegalArgumentException("Invalid gRPC streaming type: " + streamingType);
+    }
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/CallableMethodDetailView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CallableMethodDetailView.java
@@ -20,6 +20,8 @@ import com.google.auto.value.AutoValue;
 public abstract class CallableMethodDetailView {
   public abstract String callableName();
 
+  public abstract String interfaceTypeName();
+
   public abstract String genericAwareResponseType();
 
   public static Builder newBuilder() {
@@ -29,6 +31,8 @@ public abstract class CallableMethodDetailView {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder callableName(String name);
+
+    public abstract Builder interfaceTypeName(String name);
 
     public abstract Builder genericAwareResponseType(String name);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/ServiceMethodType.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ServiceMethodType.java
@@ -17,6 +17,8 @@ package com.google.api.codegen.viewmodel;
 /** The type of the underlying method in the service API. */
 public enum ServiceMethodType {
   UnaryMethod,
-  GrpcStreamingMethod,
+  GrpcBidiStreamingMethod,
+  GrpcClientStreamingMethod,
+  GrpcServerStreamingMethod,
   LongRunningMethod
 }

--- a/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
@@ -88,18 +88,20 @@
 @end
 
 @private apiCallableMember(callable)
-  @switch callable.type.serviceMethodType
-  @case "UnaryMethod"
+  @if callable.isStreaming
     private final {@callable.interfaceTypeName}<{@callable.requestTypeName}, \
-      {@callable.responseTypeName}> {@callable.name};
-  @case "GrpcStreamingMethod"
-    private final {@callable.interfaceTypeName}<{@callable.requestTypeName}, \
-      {@callable.responseTypeName}> {@callable.name};
-  @case "LongRunningMethod"
-    private final {@callable.interfaceTypeName}<{@callable.requestTypeName}, \
-      {@callable.responseTypeName}, {@callable.metadataTypeName}, Operation> {@callable.name};
-  @default
-    $unhandledCase: {@callable.type.serviceMethodType}$
+        {@callable.responseTypeName}> {@callable.name};
+  @else
+    @switch callable.type.serviceMethodType
+    @case "UnaryMethod"
+      private final {@callable.interfaceTypeName}<{@callable.requestTypeName}, \
+        {@callable.responseTypeName}> {@callable.name};
+    @case "LongRunningMethod"
+      private final {@callable.interfaceTypeName}<{@callable.requestTypeName}, \
+        {@callable.responseTypeName}, {@callable.metadataTypeName}, Operation> {@callable.name};
+    @default
+      $unhandledCase: {@callable.type.serviceMethodType}$
+    @end
   @end
 @end
 
@@ -123,31 +125,32 @@
     @end
 
     @join callable : stubClass.apiCallables
-      @switch callable.type
-      @case "SimpleApiCallable"
+      @if callable.isStreaming
         this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
-            settings.{@callable.settingsFunctionName}(), clientContext);
-      @case "PagedApiCallable"
-        this.{@callable.name} =
-            GrpcCallableFactory.createPagedVariant({@callable.grpcDirectCallableName},\
-            settings.{@callable.settingsFunctionName}(), clientContext);
-      @case "BatchingApiCallable"
-        this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
-            settings.{@callable.settingsFunctionName}(), clientContext);
-      @case "StreamingApiCallable"
-        this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
-            settings.{@callable.settingsFunctionName}(), clientContext);
-      @case "InitialOperationApiCallable"
-        this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
-            settings.{@callable.settingsFunctionName}().getInitialCallSettings(), clientContext);
-      @case "OperationApiCallable"
-        this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
-            settings.{@callable.settingsFunctionName}(), clientContext, this.operationsStub);
-      @default
-        $unhandledCase: {@callable.type}$
+                settings.{@callable.settingsFunctionName}(), clientContext);
+      @else
+        @switch callable.type
+        @case "SimpleApiCallable"
+          this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
+              settings.{@callable.settingsFunctionName}(), clientContext);
+        @case "PagedApiCallable"
+          this.{@callable.name} =
+              GrpcCallableFactory.createPagedVariant({@callable.grpcDirectCallableName},\
+              settings.{@callable.settingsFunctionName}(), clientContext);
+        @case "BatchingApiCallable"
+          this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
+              settings.{@callable.settingsFunctionName}(), clientContext);
+        @case "InitialOperationApiCallable"
+          this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
+              settings.{@callable.settingsFunctionName}().getInitialCallSettings(), clientContext);
+        @case "OperationApiCallable"
+          this.{@callable.name} = GrpcCallableFactory.create({@callable.grpcDirectCallableName},\
+              settings.{@callable.settingsFunctionName}(), clientContext, this.operationsStub);
+        @default
+          $unhandledCase: {@callable.type}$
+        @end
       @end
     @end
-
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
   {@""}
@@ -202,7 +205,7 @@
     {@apiMethod.releaseLevelAnnotation}
 
   @end
-  public StreamingCallable<{@apiMethod.serviceRequestTypeName}, \
+  public {@apiMethod.callableMethod.interfaceTypeName}<{@apiMethod.serviceRequestTypeName}, \
       {@apiMethod.responseTypeName}> {@apiMethod.name}() {
     return {@apiMethod.callableMethod.callableName};
   }

--- a/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
@@ -151,6 +151,7 @@
         @end
       @end
     @end
+
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
   {@""}

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -291,7 +291,6 @@
     @case "RequestObjectMethod"
       {@requestObjectMethod(apiMethod)}
     @case "CallableMethod"
-    # TODO create a GrpcStreaming ApiMethodType
       @if apiMethod.isStreaming
         {@streamingCallableMethod(apiMethod)}
       @else
@@ -455,7 +454,8 @@
     {@apiMethod.releaseLevelAnnotation}
 
   @end
-  {@apiMethod.visibility} final StreamingCallable<{@apiMethod.serviceRequestTypeName}, \
+  {@apiMethod.visibility} final {@apiMethod.callableMethod.interfaceTypeName}\
+      <{@apiMethod.serviceRequestTypeName}, \
       {@apiMethod.responseTypeName}> {@apiMethod.name}() {
     return stub.{@apiMethod.callableMethod.callableName}();
   }

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -201,26 +201,28 @@
 
 @private methodMembers(xsettingsClass)
   @join settings : xsettingsClass.callSettings
-    @switch settings.type
-    @case "SimpleApiCallable"
-      private final SimpleCallSettings<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.memberName};
-    @case "PagedApiCallable"
-      private final PagedCallSettings<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}, \
-          {@settings.pagedListResponseTypeName}> {@settings.memberName};
-    @case "BatchingApiCallable"
-      private final BatchingCallSettings<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.memberName};
-    @case "StreamingApiCallable"
+    @if settings.isStreaming
       private final StreamingCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
-    @case "OperationApiCallable"
-      private final OperationCallSettings<{@settings.requestTypeName}, \
-          {@settings.operationMethod.operationPayloadTypeName}, \
-          {@settings.operationMethod.metadataTypeName}, Operation> {@settings.memberName};
-    @default
-      $unhandledCase: {@settings.type}$
+    @else
+      @switch settings.type
+      @case "SimpleApiCallable"
+        private final SimpleCallSettings<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.memberName};
+      @case "PagedApiCallable"
+        private final PagedCallSettings<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}, \
+            {@settings.pagedListResponseTypeName}> {@settings.memberName};
+      @case "BatchingApiCallable"
+        private final BatchingCallSettings<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.memberName};
+      @case "OperationApiCallable"
+        private final OperationCallSettings<{@settings.requestTypeName}, \
+            {@settings.operationMethod.operationPayloadTypeName}, \
+            {@settings.operationMethod.metadataTypeName}, Operation> {@settings.memberName};
+      @default
+        $unhandledCase: {@settings.type}$
+      @end
     @end
   @end
   {@BREAK}
@@ -231,37 +233,39 @@
     /**
      * Returns the object with the settings used for calls to {@settings.methodName}.
      */
-    @switch settings.type
-    @case "SimpleApiCallable"
-        public SimpleCallSettings<{@settings.requestTypeName}, \
-            {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
-          return {@settings.memberName};
-       }
-    @case "PagedApiCallable"
-      public PagedCallSettings<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}, \
-          {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @case "BatchingApiCallable"
-      public BatchingCallSettings<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @case "StreamingApiCallable"
+    @if settings.isStreaming
       public StreamingCallSettings<{@settings.requestTypeName}, \
             {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
-    @case "OperationApiCallable"
-      public OperationCallSettings<{@settings.requestTypeName}, \
-            {@settings.operationMethod.operationPayloadTypeName}, \
-            {@settings.operationMethod.metadataTypeName}, Operation> \
-            {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @default
-      $unhandledCase: {@settings.type}$
+    @else
+      @switch settings.type
+      @case "SimpleApiCallable"
+          public SimpleCallSettings<{@settings.requestTypeName}, \
+              {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
+            return {@settings.memberName};
+         }
+      @case "PagedApiCallable"
+        public PagedCallSettings<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}, \
+            {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @case "BatchingApiCallable"
+        public BatchingCallSettings<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @case "OperationApiCallable"
+        public OperationCallSettings<{@settings.requestTypeName}, \
+              {@settings.operationMethod.operationPayloadTypeName}, \
+              {@settings.operationMethod.metadataTypeName}, Operation> \
+              {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @default
+        $unhandledCase: {@settings.type}$
+      @end
     @end
     {@""}
   @end
@@ -459,26 +463,28 @@
 
 @private builderMembers(xsettingsClass)
   @join settings : xsettingsClass.callSettings
-    @switch settings.type.toString
-    @case "SimpleApiCallable"
-      private final SimpleCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.memberName};
-    @case "PagedApiCallable"
-      private final PagedCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}, \
-          {@settings.pagedListResponseTypeName}> {@settings.memberName};
-    @case "BatchingApiCallable"
-      private final BatchingCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.memberName};
-    @case "StreamingApiCallable"
+    @if settings.isStreaming
       private final StreamingCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.memberName};
-    @case "OperationApiCallable"
-          private final OperationCallSettings.Builder<{@settings.requestTypeName}, \
-              {@settings.operationMethod.operationPayloadTypeName}, \
-              {@settings.operationMethod.metadataTypeName}, Operation> {@settings.memberName};
-    @default
-      $unhandledCase: {@settings.type.toString}$
+            {@settings.responseTypeName}> {@settings.memberName};
+    @else
+      @switch settings.type.toString
+      @case "SimpleApiCallable"
+        private final SimpleCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.memberName};
+      @case "PagedApiCallable"
+        private final PagedCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}, \
+            {@settings.pagedListResponseTypeName}> {@settings.memberName};
+      @case "BatchingApiCallable"
+        private final BatchingCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.memberName};
+      @case "OperationApiCallable"
+            private final OperationCallSettings.Builder<{@settings.requestTypeName}, \
+                {@settings.operationMethod.operationPayloadTypeName}, \
+                {@settings.operationMethod.metadataTypeName}, Operation> {@settings.memberName};
+      @default
+        $unhandledCase: {@settings.type.toString}$
+      @end
     @end
   @end
 @end
@@ -532,22 +538,24 @@
     super(clientContext);
 
     @join settings : xsettingsClass.callSettings
-      @switch settings.type.toString
-      @case "SimpleApiCallable"
-        {@settings.memberName} = SimpleCallSettings.newBuilder();
-      @case "PagedApiCallable"
-        {@settings.memberName} = PagedCallSettings.newBuilder(
-            {@settings.pagedListResponseFactoryName});
-      @case "BatchingApiCallable"
-        {@settings.memberName} = BatchingCallSettings.newBuilder(
-            {@settings.batchingDescriptorName})
-                .setBatchingSettings(BatchingSettings.newBuilder().build());
-      @case "StreamingApiCallable"
+      @if settings.isStreaming
         {@settings.memberName} = StreamingCallSettings.newBuilder();
-      @case "OperationApiCallable"
-        {@settings.memberName} = OperationCallSettings.newBuilder();
-      @default
-        $unhandledCase: {@settings.type.toString}$
+      @else
+        @switch settings.type.toString
+        @case "SimpleApiCallable"
+          {@settings.memberName} = SimpleCallSettings.newBuilder();
+        @case "PagedApiCallable"
+          {@settings.memberName} = PagedCallSettings.newBuilder(
+              {@settings.pagedListResponseFactoryName});
+        @case "BatchingApiCallable"
+          {@settings.memberName} = BatchingCallSettings.newBuilder(
+              {@settings.batchingDescriptorName})
+                  .setBatchingSettings(BatchingSettings.newBuilder().build());         
+        @case "OperationApiCallable"
+          {@settings.memberName} = OperationCallSettings.newBuilder();
+        @default
+          $unhandledCase: {@settings.type.toString}$
+        @end
       @end
       {@BREAK}
     @end
@@ -672,36 +680,38 @@
     /**
      * Returns the builder for the settings used for calls to {@settings.methodName}.
      */
-    @switch settings.type
-    @case "SimpleApiCallable"
-      public SimpleCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @case "PagedApiCallable"
-      public PagedCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}, {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @case "BatchingApiCallable"
-      public BatchingCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @case "StreamingApiCallable"
+    @if settings.isStreaming
       public StreamingCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
-    @case "OperationApiCallable"
-      public OperationCallSettings.Builder<{@settings.requestTypeName}, \
-          {@settings.operationMethod.operationPayloadTypeName}, \
-          {@settings.operationMethod.metadataTypeName}, Operation> \
-          {@settings.settingsGetFunction}() {
-        return {@settings.memberName};
-      }
-    @default
-      $unhandledCase: {@settings.type}$
+    @else
+      @switch settings.type
+      @case "SimpleApiCallable"
+        public SimpleCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @case "PagedApiCallable"
+        public PagedCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}, {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @case "BatchingApiCallable"
+        public BatchingCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @case "OperationApiCallable"
+        public OperationCallSettings.Builder<{@settings.requestTypeName}, \
+            {@settings.operationMethod.operationPayloadTypeName}, \
+            {@settings.operationMethod.metadataTypeName}, Operation> \
+            {@settings.settingsGetFunction}() {
+          return {@settings.memberName};
+        }
+      @default
+        $unhandledCase: {@settings.type}$
+      @end
     @end
     {@""}
   @end

--- a/src/main/resources/com/google/api/codegen/java/stub_interface.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub_interface.snip
@@ -83,7 +83,7 @@
     {@apiMethod.releaseLevelAnnotation}
 
   @end
-  public StreamingCallable<{@apiMethod.serviceRequestTypeName}, \
+  public {@apiMethod.callableMethod.interfaceTypeName}<{@apiMethod.serviceRequestTypeName}, \
       {@apiMethod.responseTypeName}> {@apiMethod.name}() {
     throw new UnsupportedOperationException("Not implemented: {@apiMethod.name}()");
   }
@@ -94,6 +94,7 @@
     {@apiMethod.releaseLevelAnnotation}
 
   @end
+
   public OperationCallable<{@apiMethod.serviceRequestTypeName}, \
       {@apiMethod.responseTypeName}, {@apiMethod.operationMethod.metadataTypeName}, Operation> \
       {@apiMethod.name}() {

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -206,7 +206,7 @@
 @private bidiStreamingCall(test)
   MockStreamObserver<{@test.responseTypeName}> responseObserver = new MockStreamObserver<>();
 
-  StreamingCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
+  BidiStreamingCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
       client.{@test.clientMethodName}();
   ApiStreamObserver<{@test.requestTypeName}> requestObserver =
       callable.bidiStreamingCall(responseObserver);
@@ -217,7 +217,7 @@
 @private serverStreamingCall(test)
   MockStreamObserver<{@test.responseTypeName}> responseObserver = new MockStreamObserver<>();
 
-  StreamingCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
+  ServerStreamingCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
       client.{@test.clientMethodName}();
   callable.serverStreamingCall(request, responseObserver);
 @end

--- a/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_library.baseline
@@ -390,6 +390,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingCallable = GrpcCallableFactory.create(directGetBigNothingCallable,settings.getBigNothingSettings().getInitialCallSettings(), clientContext);
     this.getBigNothingOperationCallable = GrpcCallableFactory.create(directGetBigNothingCallable,settings.getBigNothingSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = GrpcCallableFactory.create(directTestOptionalRequiredFlatteningParamsCallable,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
+
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_library.baseline
@@ -21,9 +21,11 @@ import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.core.BackgroundResourceAggregation;
 import com.google.api.gax.grpc.GrpcCallableFactory;
 import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
-import com.google.api.gax.rpc.StreamingCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
@@ -225,29 +227,29 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
               "google.example.library.v1.LibraryService/UpdateBookIndex",
               io.grpc.protobuf.ProtoUtils.marshaller(UpdateBookIndexRequest.getDefaultInstance()),
               io.grpc.protobuf.ProtoUtils.marshaller(Empty.getDefaultInstance())));
-  private static final StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> directStreamShelvesCallable =
-      GrpcCallableFactory.createDirectStreamingCallable(
+  private static final ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> directStreamShelvesCallable =
+      GrpcCallableFactory.createDirectServerStreamingCallable(
           io.grpc.MethodDescriptor.create(
               io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
               "google.example.library.v1.LibraryService/StreamShelves",
               io.grpc.protobuf.ProtoUtils.marshaller(StreamShelvesRequest.getDefaultInstance()),
               io.grpc.protobuf.ProtoUtils.marshaller(StreamShelvesResponse.getDefaultInstance())));
-  private static final StreamingCallable<StreamBooksRequest, Book> directStreamBooksCallable =
-      GrpcCallableFactory.createDirectStreamingCallable(
+  private static final ServerStreamingCallable<StreamBooksRequest, Book> directStreamBooksCallable =
+      GrpcCallableFactory.createDirectServerStreamingCallable(
           io.grpc.MethodDescriptor.create(
               io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
               "google.example.library.v1.LibraryService/StreamBooks",
               io.grpc.protobuf.ProtoUtils.marshaller(StreamBooksRequest.getDefaultInstance()),
               io.grpc.protobuf.ProtoUtils.marshaller(Book.getDefaultInstance())));
-  private static final StreamingCallable<DiscussBookRequest, Comment> directDiscussBookCallable =
-      GrpcCallableFactory.createDirectStreamingCallable(
+  private static final BidiStreamingCallable<DiscussBookRequest, Comment> directDiscussBookCallable =
+      GrpcCallableFactory.createDirectBidiStreamingCallable(
           io.grpc.MethodDescriptor.create(
               io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
               "google.example.library.v1.LibraryService/DiscussBook",
               io.grpc.protobuf.ProtoUtils.marshaller(DiscussBookRequest.getDefaultInstance()),
               io.grpc.protobuf.ProtoUtils.marshaller(Comment.getDefaultInstance())));
-  private static final StreamingCallable<DiscussBookRequest, Comment> directMonologAboutBookCallable =
-      GrpcCallableFactory.createDirectStreamingCallable(
+  private static final ClientStreamingCallable<DiscussBookRequest, Comment> directMonologAboutBookCallable =
+      GrpcCallableFactory.createDirectClientStreamingCallable(
           io.grpc.MethodDescriptor.create(
               io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
               "google.example.library.v1.LibraryService/MonologAboutBook",
@@ -320,10 +322,10 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private final UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable;
   private final UnaryCallable<GetBookFromAbsolutelyAnywhereRequest, BookFromAnywhere> getBookFromAbsolutelyAnywhereCallable;
   private final UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable;
-  private final StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable;
-  private final StreamingCallable<StreamBooksRequest, Book> streamBooksCallable;
-  private final StreamingCallable<DiscussBookRequest, Comment> discussBookCallable;
-  private final StreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable;
+  private final ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable;
+  private final ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable;
+  private final BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable;
+  private final ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable;
   private final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable;
   private final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable;
   private final UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable;
@@ -388,7 +390,6 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     this.getBigNothingCallable = GrpcCallableFactory.create(directGetBigNothingCallable,settings.getBigNothingSettings().getInitialCallSettings(), clientContext);
     this.getBigNothingOperationCallable = GrpcCallableFactory.create(directGetBigNothingCallable,settings.getBigNothingSettings(), clientContext, this.operationsStub);
     this.testOptionalRequiredFlatteningParamsCallable = GrpcCallableFactory.create(directTestOptionalRequiredFlatteningParamsCallable,settings.testOptionalRequiredFlatteningParamsSettings(), clientContext);
-
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 
@@ -479,19 +480,19 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     return updateBookIndexCallable;
   }
 
-  public StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
+  public ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
     return streamShelvesCallable;
   }
 
-  public StreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
+  public ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
     return streamBooksCallable;
   }
 
-  public StreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
+  public BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
     return discussBookCallable;
   }
 
-  public StreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
+  public ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
     return monologAboutBookCallable;
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_no_path_templates.baseline
@@ -68,7 +68,6 @@ public class GrpcNoTemplatesApiServiceStub extends NoTemplatesApiServiceStub {
   protected GrpcNoTemplatesApiServiceStub(NoTemplatesApiServiceSettings settings, ClientContext clientContext) throws IOException {
 
     this.incrementCallable = GrpcCallableFactory.create(directIncrementCallable,settings.incrementSettings(), clientContext);
-
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_grpc_stub_no_path_templates.baseline
@@ -68,6 +68,7 @@ public class GrpcNoTemplatesApiServiceStub extends NoTemplatesApiServiceStub {
   protected GrpcNoTemplatesApiServiceStub(NoTemplatesApiServiceSettings settings, ClientContext clientContext) throws IOException {
 
     this.incrementCallable = GrpcCallableFactory.create(directIncrementCallable,settings.incrementSettings(), clientContext);
+
     backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -18,9 +18,11 @@ package com.google.gcloud.pubsub.v1;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
 import com.google.api.gax.rpc.OperationFuture;
-import com.google.api.gax.rpc.StreamingCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
@@ -1810,7 +1812,7 @@ public class LibraryClient implements BackgroundResource {
    * }
    * </code></pre>
    */
-  public final StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
+  public final ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
     return stub.streamShelvesCallable();
   }
 
@@ -1849,7 +1851,7 @@ public class LibraryClient implements BackgroundResource {
    * }
    * </code></pre>
    */
-  public final StreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
+  public final ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
     return stub.streamBooksCallable();
   }
 
@@ -1889,7 +1891,7 @@ public class LibraryClient implements BackgroundResource {
    * }
    * </code></pre>
    */
-  public final StreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
+  public final BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
     return stub.discussBookCallable();
   }
 
@@ -1929,7 +1931,7 @@ public class LibraryClient implements BackgroundResource {
    * }
    * </code></pre>
    */
-  public final StreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
+  public final ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
     return stub.monologAboutBookCallable();
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_stub_interface_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_stub_interface_library.baseline
@@ -19,8 +19,10 @@ package com.google.gcloud.pubsub.v1.stub;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.grpc.OperationFuture;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientStreamingCallable;
 import com.google.api.gax.rpc.OperationCallable;
-import com.google.api.gax.rpc.StreamingCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
@@ -181,19 +183,19 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: updateBookIndexCallable()");
   }
 
-  public StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
+  public ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable() {
     throw new UnsupportedOperationException("Not implemented: streamShelvesCallable()");
   }
 
-  public StreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
+  public ServerStreamingCallable<StreamBooksRequest, Book> streamBooksCallable() {
     throw new UnsupportedOperationException("Not implemented: streamBooksCallable()");
   }
 
-  public StreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
+  public BidiStreamingCallable<DiscussBookRequest, Comment> discussBookCallable() {
     throw new UnsupportedOperationException("Not implemented: discussBookCallable()");
   }
 
-  public StreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
+  public ClientStreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable() {
     throw new UnsupportedOperationException("Not implemented: monologAboutBookCallable()");
   }
 
@@ -214,6 +216,7 @@ public abstract class LibraryServiceStub implements BackgroundResource {
     throw new UnsupportedOperationException("Not implemented: addLabelCallable()");
   }
 
+
   public OperationCallable<GetBookRequest, Book, GetBigBookMetadata, Operation> getBigBookOperationCallable() {
     throw new UnsupportedOperationException("Not implemented: getBigBookOperationCallable()");
   }
@@ -221,6 +224,7 @@ public abstract class LibraryServiceStub implements BackgroundResource {
   public UnaryCallable<GetBookRequest, Operation> getBigBookCallable() {
     throw new UnsupportedOperationException("Not implemented: getBigBookCallable()");
   }
+
 
   public OperationCallable<GetBookRequest, Empty, GetBigBookMetadata, Operation> getBigNothingOperationCallable() {
     throw new UnsupportedOperationException("Not implemented: getBigNothingOperationCallable()");

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -24,7 +24,8 @@ import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.grpc.testing.MockStreamObserver;
 import com.google.api.gax.rpc.ApiStreamObserver;
-import com.google.api.gax.rpc.StreamingCallable;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.Lists;
 import com.google.example.library.v1.AddCommentsRequest;
@@ -1143,7 +1144,7 @@ public class LibraryClientTest {
 
     MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
-    StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
+    ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
         client.streamShelvesCallable();
     callable.serverStreamingCall(request, responseObserver);
 
@@ -1161,7 +1162,7 @@ public class LibraryClientTest {
 
     MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
-    StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
+    ServerStreamingCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
         client.streamShelvesCallable();
     callable.serverStreamingCall(request, responseObserver);
 
@@ -1196,7 +1197,7 @@ public class LibraryClientTest {
 
     MockStreamObserver<Book> responseObserver = new MockStreamObserver<>();
 
-    StreamingCallable<StreamBooksRequest, Book> callable =
+    ServerStreamingCallable<StreamBooksRequest, Book> callable =
         client.streamBooksCallable();
     callable.serverStreamingCall(request, responseObserver);
 
@@ -1217,7 +1218,7 @@ public class LibraryClientTest {
 
     MockStreamObserver<Book> responseObserver = new MockStreamObserver<>();
 
-    StreamingCallable<StreamBooksRequest, Book> callable =
+    ServerStreamingCallable<StreamBooksRequest, Book> callable =
         client.streamBooksCallable();
     callable.serverStreamingCall(request, responseObserver);
 
@@ -1248,7 +1249,7 @@ public class LibraryClientTest {
 
     MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();
 
-    StreamingCallable<DiscussBookRequest, Comment> callable =
+    BidiStreamingCallable<DiscussBookRequest, Comment> callable =
         client.discussBookCallable();
     ApiStreamObserver<DiscussBookRequest> requestObserver =
         callable.bidiStreamingCall(responseObserver);
@@ -1273,7 +1274,7 @@ public class LibraryClientTest {
 
     MockStreamObserver<Comment> responseObserver = new MockStreamObserver<>();
 
-    StreamingCallable<DiscussBookRequest, Comment> callable =
+    BidiStreamingCallable<DiscussBookRequest, Comment> callable =
         client.discussBookCallable();
     ApiStreamObserver<DiscussBookRequest> requestObserver =
         callable.bidiStreamingCall(responseObserver);


### PR DESCRIPTION
The motivation behind this change is that currently user need to decide
the streaming type by themselves based on the server implementation. We should
only provide one streaming type in the client for better user
experience.

Corresponding GAX PR: https://github.com/googleapis/gax-java/pull/350