### PR TITLE
ruby discovery: cache name map

### DIFF
--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -136,7 +136,7 @@ public class DiscoveryFragmentGeneratorApi {
     ApiaryConfig apiaryConfig = discovery.getConfig();
     apiaryConfig.setAuthInstructionsUrl(parseAuthInstructionsUrl(authInstructions, id));
 
-    File rubyNamesFile = new File(options.get(RUBY_NAMES_FILE));
+    String rubyNamesFile = options.get(RUBY_NAMES_FILE);
 
     DiscoveryProviderFactory providerFactory = createProviderFactory(factory);
     DiscoveryProvider provider =

--- a/src/main/java/com/google/api/codegen/discovery/DiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/DiscoveryProviderFactory.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.discovery;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.api.Service;
 import com.google.api.codegen.ApiaryConfig;
-import java.io.File;
 import java.util.List;
 
 /** A factory for DiscoveryProviders which perform code generation. */
@@ -26,6 +25,6 @@ public interface DiscoveryProviderFactory {
       Service service,
       ApiaryConfig apiaryConfig,
       List<JsonNode> sampleConfigOverrides,
-      File rubyNamesFile,
+      String rubyNamesFile,
       String id);
 }

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -39,7 +39,6 @@ import com.google.api.codegen.rendering.CommonSnippetSetRunner;
 import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -88,7 +87,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
       Service service,
       ApiaryConfig apiaryConfig,
       List<JsonNode> sampleConfigOverrides,
-      File rubyNamesFile,
+      String rubyNamesFile,
       String id) {
     // Use nodes corresponding to language pattern fields matching current language.
     List<JsonNode> overrides = new ArrayList<JsonNode>();
@@ -141,7 +140,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
       Service service,
       ApiaryConfig apiaryConfig,
       List<JsonNode> sampleConfigOverrides,
-      File rubyNamesFile,
+      String rubyNamesFile,
       String id) {
     return defaultCreate(service, apiaryConfig, sampleConfigOverrides, rubyNamesFile, id);
   }


### PR DESCRIPTION
During tests, we previously open and parse YAML file for name mapping
every time.
This commit caches the name map.
Ruby discovery testing time reduces from ~13 seconds on my machine
to ~2 seconds.