### PR TITLE
build.gradle: downgrade autovalue to 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
     // Guava 23.0 is for Java 8, Java 7 needs to use 23.0-android.
     guava: 'com.google.guava:guava:23.0-android',
     jsr305: 'com.google.code.findbugs:jsr305:3.0.0',
-    autovalue: 'com.google.auto.value:auto-value:1.5',
+    autovalue: 'com.google.auto.value:auto-value:1.4',
     commonsLang: 'org.apache.commons:commons-lang3:3.6',
     commonsCli: 'commons-cli:commons-cli:1.4',
     snakeyaml: 'org.yaml:snakeyaml:1.18',


### PR DESCRIPTION
1.5 does not fully support Java 7.
The code that 1.5 generates is Java 7 compatible,
but the code generator itself needs Java 8.
This caused our Java 7 CI to silently succeed.

This commit downgrades to 1.4, the last version
to fully support Java 7.