### PR TITLE
Ruby: Remove app_name and app_version

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -145,8 +145,6 @@
       scopes: ALL_SCOPES,
       client_config: {},
       timeout: DEFAULT_TIMEOUT,
-      app_name: nil,
-      app_version: nil,
       lib_name: nil,
       lib_version: ""
     @# These require statements are intentionally placed here to initialize
@@ -163,9 +161,6 @@
       credentials ||= chan_creds
       credentials ||= updater_proc
     end
-    if app_name || app_version
-      warn "`app_name` and `app_version` are no longer being used in the request headers."
-    end
 
     credentials ||= {@xapiClass.fullyQualifiedCredentialsClassName}.default
 
@@ -177,8 +172,6 @@
         scopes: scopes,
         client_config: client_config,
         timeout: timeout,
-        app_name: app_name,
-        app_version: app_version,
         lib_name: lib_name,
         lib_version: lib_version,
       )

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
@@ -201,8 +201,6 @@ module Library
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
-          app_name: nil,
-          app_version: nil,
           lib_name: nil,
           lib_version: ""
         # These require statements are intentionally placed here to initialize
@@ -219,9 +217,6 @@ module Library
           credentials ||= chan_creds
           credentials ||= updater_proc
         end
-        if app_name || app_version
-          warn "`app_name` and `app_version` are no longer being used in the request headers."
-        end
 
         credentials ||= Library::Credentials.default
 
@@ -232,8 +227,6 @@ module Library
           scopes: scopes,
           client_config: client_config,
           timeout: timeout,
-          app_name: app_name,
-          app_version: app_version,
           lib_name: lib_name,
           lib_version: lib_version,
         )
@@ -1630,4 +1623,3 @@ module Library
     end
   end
 end
-

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
@@ -201,8 +201,6 @@ module Library
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
-          app_name: nil,
-          app_version: nil,
           lib_name: nil,
           lib_version: ""
         # These require statements are intentionally placed here to initialize
@@ -219,9 +217,6 @@ module Library
           credentials ||= chan_creds
           credentials ||= updater_proc
         end
-        if app_name || app_version
-          warn "`app_name` and `app_version` are no longer being used in the request headers."
-        end
 
         credentials ||= Library::Credentials.default
 
@@ -232,8 +227,6 @@ module Library
           scopes: scopes,
           client_config: client_config,
           timeout: timeout,
-          app_name: app_name,
-          app_version: app_version,
           lib_name: lib_name,
           lib_version: lib_version,
         )
@@ -1630,4 +1623,3 @@ module Library
     end
   end
 end
-

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_longrunning.baseline
@@ -122,8 +122,6 @@ module Google
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
-          app_name: nil,
-          app_version: nil,
           lib_name: nil,
           lib_version: ""
         # These require statements are intentionally placed here to initialize
@@ -138,9 +136,6 @@ module Google
           credentials ||= channel
           credentials ||= chan_creds
           credentials ||= updater_proc
-        end
-        if app_name || app_version
-          warn "`app_name` and `app_version` are no longer being used in the request headers."
         end
 
         credentials ||= Google::Gax::Credentials.default
@@ -366,4 +361,3 @@ module Google
     end
   end
 end
-

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_multiple_services.baseline
@@ -91,8 +91,6 @@ module Google
             scopes: ALL_SCOPES,
             client_config: {},
             timeout: DEFAULT_TIMEOUT,
-            app_name: nil,
-            app_version: nil,
             lib_name: nil,
             lib_version: ""
           # These require statements are intentionally placed here to initialize
@@ -107,9 +105,6 @@ module Google
             credentials ||= channel
             credentials ||= chan_creds
             credentials ||= updater_proc
-          end
-          if app_name || app_version
-            warn "`app_name` and `app_version` are no longer being used in the request headers."
           end
 
           credentials ||= Google::Example::Credentials.default
@@ -284,8 +279,6 @@ module Google
             scopes: ALL_SCOPES,
             client_config: {},
             timeout: DEFAULT_TIMEOUT,
-            app_name: nil,
-            app_version: nil,
             lib_name: nil,
             lib_version: ""
           # These require statements are intentionally placed here to initialize
@@ -300,9 +293,6 @@ module Google
             credentials ||= channel
             credentials ||= chan_creds
             credentials ||= updater_proc
-          end
-          if app_name || app_version
-            warn "`app_name` and `app_version` are no longer being used in the request headers."
           end
 
           credentials ||= Google::Example::Credentials.default
@@ -383,4 +373,3 @@ module Google
     end
   end
 end
-


### PR DESCRIPTION
They have been deprecated for over 6 months and should be removed.