### PR TITLE
Python: change the import path of protos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+# Workaround for Travis CI issue 5227, which results in a buffer overflow
+# caused by Java when running the build on OpenJDK.
+# https://github.com/travis-ci/travis-ci/issues/5227
+before_install:
+    - cat /etc/hosts # optionally check the content *before*
+    - sudo hostname "$(hostname | cut -c1-63)"
+    - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+    - cat /etc/hosts # optionally check the content *after*
 sudo: false
 language: java
 dist: precise

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonModelTypeNameConverter.java
@@ -38,8 +38,6 @@ public class PythonModelTypeNameConverter implements ModelTypeNameConverter {
 
   private static final String GOOGLE_CLOUD_PREFIX = GOOGLE_PREFIX + ".cloud";
 
-  private static final String GOOGLE_CLOUD_PROTO_PREFIX = GOOGLE_CLOUD_PREFIX + ".proto";
-
   /** A map from primitive type to its corresponding Python types */
   private static final Map<Type, String> PRIMITIVE_TYPE_MAP =
       ImmutableMap.<Type, String>builder()
@@ -92,9 +90,15 @@ public class PythonModelTypeNameConverter implements ModelTypeNameConverter {
           "google.logging.type");
 
   private final TypeNameConverter typeNameConverter;
+  private String protoNamespace;
 
   public PythonModelTypeNameConverter(String implicitPackageName) {
     typeNameConverter = new PythonTypeTable(implicitPackageName);
+    if (implicitPackageName.endsWith(".gapic")) {
+      protoNamespace = implicitPackageName.replace(".gapic", ".proto");
+    } else {
+      protoNamespace = String.format("%s.proto", implicitPackageName);
+    }
   }
 
   @Override
@@ -235,7 +239,7 @@ public class PythonModelTypeNameConverter implements ModelTypeNameConverter {
 
     String prefix =
         protoPackage.startsWith(GOOGLE_CLOUD_PREFIX) ? GOOGLE_CLOUD_PREFIX : GOOGLE_PREFIX;
-    return GOOGLE_CLOUD_PROTO_PREFIX + protoPackage.substring(prefix.length());
+    return String.format("%s%s", protoNamespace, protoPackage.substring(prefix.length()));
   }
 
   private String getPbFileName(String filename) {

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -348,7 +348,7 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getTestPackageName() {
-    return "tests." + getPackageName();
+    return getPackageName();
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/testdata/py/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_main_library.baseline
@@ -39,9 +39,9 @@ import google.gax
 
 from google.cloud.example.library_v1.gapic import enums
 from google.cloud.example.library_v1.gapic import library_service_client_config
-from google.cloud.proto.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
-from google.cloud.proto.example.library.v1 import library_pb2
-from google.cloud.proto.tagger.v1 import tagger_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import library_pb2
+from google.cloud.example.library_v1.proto.tagger.v1 import tagger_pb2
 from google.protobuf import empty_pb2
 from google.protobuf import field_mask_pb2 as protobuf_field_mask_pb2
 
@@ -1206,7 +1206,7 @@ class LibraryServiceClient(object):
             ...     pass
 
         Args:
-            requests (iterator[dict|google.cloud.proto.example.library.v1.library_pb2.DiscussBookRequest]): The input objects. If a dict is provided, it must be of the
+            requests (iterator[dict|google.cloud.example.library_v1.proto.example.library.v1.library_pb2.DiscussBookRequest]): The input objects. If a dict is provided, it must be of the
                 same form as the protobuf message :class:`~google.cloud.example.library_v1.types.DiscussBookRequest`
             options (~google.gax.CallOptions): Overrides the default
                 settings for this call, e.g, timeout, retries etc.
@@ -1242,7 +1242,7 @@ class LibraryServiceClient(object):
             >>> response = client.monolog_about_book(requests)
 
         Args:
-            requests (iterator[dict|google.cloud.proto.example.library.v1.library_pb2.DiscussBookRequest]): The input objects. If a dict is provided, it must be of the
+            requests (iterator[dict|google.cloud.example.library_v1.proto.example.library.v1.library_pb2.DiscussBookRequest]): The input objects. If a dict is provided, it must be of the
                 same form as the protobuf message :class:`~google.cloud.example.library_v1.types.DiscussBookRequest`
             options (~google.gax.CallOptions): Overrides the default
                 settings for this call, e.g, timeout, retries etc.
@@ -1702,3 +1702,4 @@ class LibraryServiceClient(object):
             optional_repeated_fixed64=optional_repeated_fixed64,
             optional_map=optional_map)
         return self._test_optional_required_flattening_params(request, options)
+

--- a/src/test/java/com/google/api/codegen/testdata/py/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_main_no_path_templates.baseline
@@ -36,7 +36,7 @@ from google.gax import path_template
 import google.gax
 
 from example.gapic import no_templates_api_service_client_config
-from google.cloud.proto.example.v1 import no_path_templates_pb2
+from example.proto.example.v1 import no_path_templates_pb2
 
 
 class NoTemplatesAPIServiceClient(object):
@@ -170,3 +170,4 @@ class NoTemplatesAPIServiceClient(object):
         """
         request = no_path_templates_pb2.IncrementRequest()
         self._increment(request, options)
+

--- a/src/test/java/com/google/api/codegen/testdata/py/python_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_smoke_test_library.baseline
@@ -19,8 +19,8 @@ import unittest
 
 from google.cloud.example import library_v1
 from google.cloud.example.library_v1 import enums
-from google.cloud.proto.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
-from google.cloud.proto.example.library.v1 import library_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import library_pb2
 from google.protobuf import field_mask_pb2 as protobuf_field_mask_pb2
 
 

--- a/src/test/java/com/google/api/codegen/testdata/py/python_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_test_library.baseline
@@ -23,9 +23,9 @@ from google.rpc import status_pb2
 
 from google.cloud.example import library_v1
 from google.cloud.example.library_v1 import enums
-from google.cloud.proto.example.library.v1 import book_from_anywhere_pb2
-from google.cloud.proto.example.library.v1 import library_pb2
-from google.cloud.proto.tagger.v1 import tagger_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import book_from_anywhere_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import library_pb2
+from google.cloud.example.library_v1.proto.tagger.v1 import tagger_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
 

--- a/src/test/java/com/google/api/codegen/testdata/py/python_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_test_no_path_templates.baseline
@@ -20,7 +20,7 @@ import unittest
 
 from google.gax import errors
 
-from google.cloud.proto.example.v1 import no_path_templates_pb2
+from example.proto.example.v1 import no_path_templates_pb2
 from google.protobuf import empty_pb2
 import example
 

--- a/src/test/java/com/google/api/codegen/testdata/py/python_types_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_types_library.baseline
@@ -20,12 +20,12 @@ import sys
 from google.gax.utils.messages import get_messages
 
 from google.api import http_pb2
-from google.cloud.proto.example.library.v1 import book_from_anywhere_pb2
-from google.cloud.proto.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
-from google.cloud.proto.example.library.v1 import library_pb2
-from google.cloud.proto.tagger.v1 import tagger_pb2
-from google.cloud.proto.test.shared.data import other_shared_type_pb2
-from google.cloud.proto.test.shared.data import shared_type_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import book_from_anywhere_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
+from google.cloud.example.library_v1.proto.example.library.v1 import library_pb2
+from google.cloud.example.library_v1.proto.tagger.v1 import tagger_pb2
+from google.cloud.example.library_v1.proto.test.shared.data import other_shared_type_pb2
+from google.cloud.example.library_v1.proto.test.shared.data import shared_type_pb2
 from google.longrunning import operations_pb2
 from google.protobuf import any_pb2
 from google.protobuf import descriptor_pb2

--- a/src/test/java/com/google/api/codegen/testdata/py/python_types_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_types_no_path_templates.baseline
@@ -19,15 +19,15 @@ import sys
 
 from google.gax.utils.messages import get_messages
 
+from example.proto.example.v1 import no_path_templates_pb2
 from google.api import http_pb2
-from google.cloud.proto.example.v1 import no_path_templates_pb2
 from google.protobuf import descriptor_pb2
 from google.protobuf import empty_pb2
 
 
 names = []
-for module in (http_pb2,
-               no_path_templates_pb2,
+for module in (no_path_templates_pb2,
+               http_pb2,
                descriptor_pb2,
                empty_pb2,):
     for name, message in get_messages(module).items():


### PR DESCRIPTION
This change corresponds to an upcoming change in artman that will move the protos into the `google.cloud.example_v1.proto` path.

Going to explore changing the package name in the gapic yaml from `google.cloud.example_v1.gapic` -> `google.cloud.example_v1` in a subsequent PR.