### PR TITLE
Apache HttpStatus for http status codes

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/LanguageTransformer.java
@@ -87,6 +87,7 @@ public class LanguageTransformer {
       this.shouldCapitalize = shouldCapitalize;
     }
 
+    @Override
     public String getFormattedPackageName(String packageName) {
       for (RewriteRule rewriteRule : rewriteRules) {
         packageName = rewriteRule.rewrite(packageName);
@@ -137,6 +138,7 @@ public class LanguageTransformer {
   }
 
   private static class NodeJSLanguageFormatter implements LanguageFormatter {
+    @Override
     public String getFormattedPackageName(String packageName) {
       List<String> nameComponents = Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName);
       return nameComponents.get(nameComponents.size() - 2)

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -714,12 +714,12 @@ public class JavaSurfaceTransformer {
         typeTable.saveNicknameFor("io.grpc.Status");
         break;
       case DISCOVERY:
-        typeTable.saveNicknameFor("com.google.api.client.http.HttpStatusCodes");
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonStatusCode");
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonTransport");
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonTransportProvider");
         typeTable.saveNicknameFor(
             "com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider");
+        typeTable.saveNicknameFor("org.apache.http.HttpStatus");
         break;
     }
   }

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -542,7 +542,7 @@
       @case "GRPC"
         GrpcStatusCode.of(Status.Code.{@code})
       @case "HTTP"
-        HttpJsonStatusCode.of(HttpStatusCodes.{@code})
+        HttpJsonStatusCode.of(HttpStatus.{@code})
     @end
   @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -5099,7 +5099,6 @@ public class AddressAdminClient implements BackgroundResource {
  */
 package com.google.cloud.simplecompute.v1;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
@@ -5138,6 +5137,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Generated;
+import org.apache.http.HttpStatus;
 import org.threeten.bp.Duration;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
@@ -5413,7 +5413,10 @@ public class AddressAdminSettings extends ClientSettings {
       ImmutableMap.Builder<String, ImmutableSet<StatusCode>> definitions = ImmutableMap.builder();
       definitions.put(
           "idempotent",
-          ImmutableSet.copyOf(Lists.<StatusCode>newArrayList(HttpJsonStatusCode.of(HttpStatusCodes.STATUS_CODE_SERVER_ERROR), HttpJsonStatusCode.of(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE))));
+          ImmutableSet.copyOf(Lists.<StatusCode>newArrayList(HttpJsonStatusCode.of(HttpStatus.SC_GATEWAY_TIMEOUT), HttpJsonStatusCode.of(HttpStatus.SC_SERVICE_UNAVAILABLE))));
+      definitions.put(
+          "non_idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode>newArrayList()));
       RETRYABLE_CODE_DEFINITIONS = definitions.build();
     }
 
@@ -5426,9 +5429,9 @@ public class AddressAdminSettings extends ClientSettings {
           .setInitialRetryDelay(Duration.ofMillis(100L))
           .setRetryDelayMultiplier(1.3)
           .setMaxRetryDelay(Duration.ofMillis(60000L))
-          .setInitialRpcTimeout(Duration.ofMillis(60000L))
+          .setInitialRpcTimeout(Duration.ofMillis(20000L))
           .setRpcTimeoutMultiplier(1.0)
-          .setMaxRpcTimeout(Duration.ofMillis(60000L))
+          .setMaxRpcTimeout(Duration.ofMillis(20000L))
           .setTotalTimeout(Duration.ofMillis(600000L))
           .build();
       definitions.put("default", settings);

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_gapic.yaml
@@ -1,4 +1,5 @@
 type: com.google.api.codegen.ConfigProto
+# The settings of generated code in a specific language.
 language_settings:
   java:
     package_name: com.google.cloud.simplecompute.v1
@@ -17,30 +18,91 @@ language_settings:
   nodejs:
     package_name: simplecompute.v1
     domain_layer_location: google-cloud
+# The configuration for the license header to put on generated files.
 license_header:
+  # The file containing the copyright line(s).
   copyright_file: copyright-google.txt
+  # The file containing the raw license header without any copyright line(s).
   license_file: license-header-apache-2.0.txt
+# A list of API interface configurations.
 interfaces:
+  # The fully qualified name of the API interface.
 - name: google.simplecompute.v1.Addresses
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
   collections:
-  - name_pattern: project/{project}/regions/{region}/addresses/{address}
-    entity_name: address
   - name_pattern: project/{project}/regions/{region}
     entity_name: region
+  - name_pattern: project/{project}/regions/{region}/addresses/{address}
+    entity_name: address
+  # Definition for retryable codes.
   retry_codes_def:
   - name: idempotent
     retry_codes:
-    - STATUS_CODE_SERVICE_UNAVAILABLE
-    - STATUS_CODE_SERVER_ERROR
+    - SC_SERVICE_UNAVAILABLE
+    - SC_GATEWAY_TIMEOUT
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
   retry_params_def:
   - name: default
     initial_retry_delay_millis: 100
     retry_delay_multiplier: 1.3
-    max_retry_delay_millis: 60000 # 60 seconds
-    initial_rpc_timeout_millis: 60000 # 60 seconds
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
     rpc_timeout_multiplier: 1
-    max_rpc_timeout_millis: 60000 # 60 seconds
-    total_timeout_millis: 600000 # 10 minutes
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
   methods:
   - name: compute.addresses.insert
     flattening:


### PR DESCRIPTION
Apache's HttpStatus util class is more complete than the current library's. Use theirs for exposing HTTP status codes.