### PR TITLE
Ruby: Remove deprecation warning from service_path and port

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -161,7 +161,7 @@
       credentials ||= chan_creds
       credentials ||= updater_proc
     end
-    if service_path || port
+    if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
       warn "`service_path` and `port` parameters are deprecated and will be removed"
     end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
@@ -213,7 +213,7 @@ module Library
           credentials ||= chan_creds
           credentials ||= updater_proc
         end
-        if service_path || port
+        if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
           warn "`service_path` and `port` parameters are deprecated and will be removed"
         end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
@@ -213,7 +213,7 @@ module Library
           credentials ||= chan_creds
           credentials ||= updater_proc
         end
-        if service_path || port
+        if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
           warn "`service_path` and `port` parameters are deprecated and will be removed"
         end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_longrunning.baseline
@@ -133,7 +133,7 @@ module Google
           credentials ||= chan_creds
           credentials ||= updater_proc
         end
-        if service_path || port
+        if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
           warn "`service_path` and `port` parameters are deprecated and will be removed"
         end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_multiple_services.baseline
@@ -102,7 +102,7 @@ module Google
             credentials ||= chan_creds
             credentials ||= updater_proc
           end
-          if service_path || port
+          if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
             warn "`service_path` and `port` parameters are deprecated and will be removed"
           end
 
@@ -289,7 +289,7 @@ module Google
             credentials ||= chan_creds
             credentials ||= updater_proc
           end
-          if service_path || port
+          if service_path != SERVICE_ADDRESS || port != DEFAULT_SERVICE_PORT
             warn "`service_path` and `port` parameters are deprecated and will be removed"
           end
 


### PR DESCRIPTION
Only removes the warning when the parameters are not assigned. Fixes #1543 
Tested locally with the monitoring library.