### PR TITLE
Ruby documentation fixes

### DIFF
--- a/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
+++ b/src/main/java/com/google/api/codegen/util/CommonRenderingUtil.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.util;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,5 +91,15 @@ public class CommonRenderingUtil {
    */
   private static boolean isLineWrapChar(char c) {
     return Character.isWhitespace(c) || "([".indexOf(c) >= 0;
+  }
+
+  /** Creates a whitespace string of the specified width. */
+  public static String padding(int width) {
+    return Strings.repeat(" ", width);
+  }
+
+  /** Helper function for referencing integers from templates. */
+  public static int toInt(String value) {
+    return Integer.valueOf(value);
   }
 }

--- a/src/main/resources/com/google/api/codegen/ruby/common.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/common.snip
@@ -17,8 +17,12 @@
 @end
 
 @snippet toComments(commentLines)
+  {@toComments(commentLines, util.toInt(1))}
+@end
+
+@snippet toComments(commentLines, indentWidth)
   @join comment : commentLines
-    @# {@comment}
+    @#{@util.padding(indentWidth)}{@comment}
   @end
 @end
 
@@ -35,29 +39,28 @@
 @end
 
 @snippet initMethodComments()
-  @# @@param credentials
-  @#   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-  @#   Provides the means for authenticating requests made by the client. This parameter can
-  @#   be many types.
-  @#   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
-  @#   authenticating requests made by this client.
-  @#   A `String` will be treated as the path to the keyfile to be used for the construction of
-  @#   credentials for this client.
-  @#   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-  @#   credentials for this client.
-  @#   A `GRPC::Core::Channel` will be used to make calls through.
-  @#   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-  @#   should already be composed with a `GRPC::Core::CallCredentials` object.
-  @#   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-  @#   metadata for requests, generally, to give OAuth credentials.
-  @# @@param scopes [Array<String>]
-  @#   The OAuth scopes for this service. This parameter is ignored if
-  @#   an updater_proc is supplied.
-  @# @@param client_config[Hash]
-  @#   A Hash for call options for each method. See
-  @#   Google::Gax#construct_settings for the structure of
-  @#   this data. Falls back to the default config if not specified
-  @#   or the specified config is missing data points.
-  @# @@param timeout [Numeric]
-  @#   The default timeout, in seconds, for calls made through this client.
+  @@param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+    Provides the means for authenticating requests made by the client. This parameter can
+    be many types.
+    A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
+    authenticating requests made by this client.
+    A `String` will be treated as the path to the keyfile to be used for the construction of
+    credentials for this client.
+    A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+    credentials for this client.
+    A `GRPC::Core::Channel` will be used to make calls through.
+    A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+    should already be composed with a `GRPC::Core::CallCredentials` object.
+    A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+    metadata for requests, generally, to give OAuth credentials.
+  @@param scopes [Array<String>]
+    The OAuth scopes for this service. This parameter is ignored if
+    an updater_proc is supplied.
+  @@param client_config [Hash]
+    A Hash for call options for each method. See
+    Google::Gax#construct_settings for the structure of
+    this data. Falls back to the default config if not specified
+    or the specified config is missing data points.
+  @@param timeout [Numeric]
+    The default timeout, in seconds, for calls made through this client.
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -134,7 +134,7 @@
 @end
 
 @private initMethodSection(xapiClass)
-  {@initMethodComments()}
+  {@toComments(util.getDocLines(initMethodComments()))}
   def initialize @\
       service_path: SERVICE_ADDRESS,
       port: DEFAULT_SERVICE_PORT,

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -21,6 +21,7 @@
   @if index.modules
     {@modules(index.modules.iterator, index.type, body(index))}
   @end
+
 @end
 
 @private modules(iterator, indexType, content)
@@ -120,10 +121,10 @@
     FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("{@index.versionFileBasePath}"))
 
     AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
-      .select {|file| File.directory?(file)}
-      .select {|dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir))}
-      .select {|dir| File.exist?(dir + ".rb")}
-      .map {|dir| File.basename(dir)}
+      .select { |file| File.directory?(file) }
+      .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
+      .select { |dir| File.exist?(dir + ".rb") }
+      .map { |dir| File.basename(dir) }
 
   @default
   @end
@@ -145,9 +146,26 @@
     {@toComments(@requireView.doc.lines)}
   @#
   @end
-  {@initMethodComments()}
-  def self.new(*args, **kwargs)
-    {@requireView.clientName}.new(*args, **kwargs)
+  {@toComments(util.getDocLines(initMethodComments()))}
+  def self.new
+      service_path: nil,
+      port: nil,
+      channel: nil,
+      chan_creds: nil,
+      updater_proc: nil,
+      credentials: nil,
+      scopes: nil,
+      client_config: nil,
+      timeout: nil,
+      lib_name: nil,
+      lib_version: nil
+    kwargs = Hash[
+      *method(__method__).parameters
+        .select { |_, param| binding.local_variable_get(param) != nil }
+        .map { |_, param| [param, binding.local_variable_get(param)] }
+        .flatten(1)
+      ]
+    {@requireView.clientName}.new(**kwargs)
   end
 @end
 
@@ -157,10 +175,11 @@
     {@toComments(@requireView.doc.lines)}
   @#
   @end
-  @# @@param version [Symbol, String]
-  @#   The major version of the service to be used. By default :{@index.apiVersion}
-  @#   is used.
-  {@initMethodComments()}
+  @# @@overload
+  @#   @@param version [Symbol, String]
+  @#     The major version of the service to be used. By default :{@index.apiVersion}
+  @#     is used.
+  {@toComments(util.getDocLines(initMethodComments()), util.toInt(3))}
   def self.new(*args, version: :{@index.apiVersion}, **kwargs)
     # Check if the version provided is available.
     unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -156,10 +156,10 @@
     {@toComments(@requireView.doc.lines)}
   @#
   @end
+  @# @@param version [Symbol, String]
+  @#   The major version of the service to be used. By default :{@index.apiVersion}
+  @#   is used.
   @# @@overload
-  @#   @@param version [Symbol, String]
-  @#     The major version of the service to be used. By default :{@index.apiVersion}
-  @#     is used.
   {@toComments(util.getDocLines(initMethodComments()), util.toInt(3))}
   def self.new(*args, version: :{@index.apiVersion}, **kwargs)
     # Check if the version provided is available.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
@@ -162,8 +162,7 @@ module Library
         )
       end
 
-      # @param credentials
-      #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+      # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #   Provides the means for authenticating requests made by the client. This parameter can
       #   be many types.
       #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -180,7 +179,7 @@ module Library
       # @param scopes [Array<String>]
       #   The OAuth scopes for this service. This parameter is ignored if
       #   an updater_proc is supplied.
-      # @param client_config[Hash]
+      # @param client_config [Hash]
       #   A Hash for call options for each method. See
       #   Google::Gax#construct_settings for the structure of
       #   this data. Falls back to the default config if not specified

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
@@ -86,10 +86,10 @@ module Library
   #
   # Service comment may include special characters: <>&"+'@.
   #
+  # @param version [Symbol, String]
+  #   The major version of the service to be used. By default :v1
+  #   is used.
   # @overload
-  #   @param version [Symbol, String]
-  #     The major version of the service to be used. By default :v1
-  #     is used.
   #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
   #     Provides the means for authenticating requests made by the client. This parameter can
   #     be many types.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
@@ -65,10 +65,10 @@ module Library
   FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("library"))
 
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
-    .select {|file| File.directory?(file)}
-    .select {|dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir))}
-    .select {|dir| File.exist?(dir + ".rb")}
-    .map {|dir| File.basename(dir)}
+    .select { |file| File.directory?(file) }
+    .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
+    .select { |dir| File.exist?(dir + ".rb") }
+    .map { |dir| File.basename(dir) }
 
   ##
   # This API represents a simple digital library.  It lets you manage Shelf
@@ -86,34 +86,34 @@ module Library
   #
   # Service comment may include special characters: <>&"+'@.
   #
-  # @param version [Symbol, String]
-  #   The major version of the service to be used. By default :v1
-  #   is used.
-  # @param credentials
-  #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-  #   Provides the means for authenticating requests made by the client. This parameter can
-  #   be many types.
-  #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
-  #   authenticating requests made by this client.
-  #   A `String` will be treated as the path to the keyfile to be used for the construction of
-  #   credentials for this client.
-  #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-  #   credentials for this client.
-  #   A `GRPC::Core::Channel` will be used to make calls through.
-  #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-  #   should already be composed with a `GRPC::Core::CallCredentials` object.
-  #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-  #   metadata for requests, generally, to give OAuth credentials.
-  # @param scopes [Array<String>]
-  #   The OAuth scopes for this service. This parameter is ignored if
-  #   an updater_proc is supplied.
-  # @param client_config[Hash]
-  #   A Hash for call options for each method. See
-  #   Google::Gax#construct_settings for the structure of
-  #   this data. Falls back to the default config if not specified
-  #   or the specified config is missing data points.
-  # @param timeout [Numeric]
-  #   The default timeout, in seconds, for calls made through this client.
+  # @overload
+  #   @param version [Symbol, String]
+  #     The major version of the service to be used. By default :v1
+  #     is used.
+  #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+  #     Provides the means for authenticating requests made by the client. This parameter can
+  #     be many types.
+  #     A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
+  #     authenticating requests made by this client.
+  #     A `String` will be treated as the path to the keyfile to be used for the construction of
+  #     credentials for this client.
+  #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+  #     credentials for this client.
+  #     A `GRPC::Core::Channel` will be used to make calls through.
+  #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+  #     should already be composed with a `GRPC::Core::CallCredentials` object.
+  #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+  #     metadata for requests, generally, to give OAuth credentials.
+  #   @param scopes [Array<String>]
+  #     The OAuth scopes for this service. This parameter is ignored if
+  #     an updater_proc is supplied.
+  #   @param client_config [Hash]
+  #     A Hash for call options for each method. See
+  #     Google::Gax#construct_settings for the structure of
+  #     this data. Falls back to the default config if not specified
+  #     or the specified config is missing data points.
+  #   @param timeout [Numeric]
+  #     The default timeout, in seconds, for calls made through this client.
   def self.new(*args, version: :v1, **kwargs)
     unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
       raise "The version: #{version} is not available. The available versions " \
@@ -128,6 +128,7 @@ module Library
     Library.const_get(version_module).new(*args, **kwargs)
   end
 end
+
 ============== file: lib/library/v1.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
@@ -219,8 +220,7 @@ module Library
     #
     # Service comment may include special characters: <>&"+'@.
     #
-    # @param credentials
-    #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+    # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
     #   Provides the means for authenticating requests made by the client. This parameter can
     #   be many types.
     #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -237,15 +237,32 @@ module Library
     # @param scopes [Array<String>]
     #   The OAuth scopes for this service. This parameter is ignored if
     #   an updater_proc is supplied.
-    # @param client_config[Hash]
+    # @param client_config [Hash]
     #   A Hash for call options for each method. See
     #   Google::Gax#construct_settings for the structure of
     #   this data. Falls back to the default config if not specified
     #   or the specified config is missing data points.
     # @param timeout [Numeric]
     #   The default timeout, in seconds, for calls made through this client.
-    def self.new(*args, **kwargs)
-      Library::V1::LibraryServiceClient.new(*args, **kwargs)
+    def self.new
+        service_path: nil,
+        port: nil,
+        channel: nil,
+        chan_creds: nil,
+        updater_proc: nil,
+        credentials: nil,
+        scopes: nil,
+        client_config: nil,
+        timeout: nil,
+        lib_name: nil,
+        lib_version: nil
+      kwargs = Hash[
+        *method(__method__).parameters
+          .select { |_, param| binding.local_variable_get(param) != nil }
+          .map { |_, param| [param, binding.local_variable_get(param)] }
+          .flatten(1)
+        ]
+      Library::V1::LibraryServiceClient.new(**kwargs)
     end
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
@@ -162,8 +162,7 @@ module Library
         )
       end
 
-      # @param credentials
-      #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+      # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #   Provides the means for authenticating requests made by the client. This parameter can
       #   be many types.
       #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -180,7 +179,7 @@ module Library
       # @param scopes [Array<String>]
       #   The OAuth scopes for this service. This parameter is ignored if
       #   an updater_proc is supplied.
-      # @param client_config[Hash]
+      # @param client_config [Hash]
       #   A Hash for call options for each method. See
       #   Google::Gax#construct_settings for the structure of
       #   this data. Falls back to the default config if not specified

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_longrunning.baseline
@@ -83,8 +83,7 @@ module Google
       ALL_SCOPES = [
       ].freeze
 
-      # @param credentials
-      #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+      # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #   Provides the means for authenticating requests made by the client. This parameter can
       #   be many types.
       #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -101,7 +100,7 @@ module Google
       # @param scopes [Array<String>]
       #   The OAuth scopes for this service. This parameter is ignored if
       #   an updater_proc is supplied.
-      # @param client_config[Hash]
+      # @param client_config [Hash]
       #   A Hash for call options for each method. See
       #   Google::Gax#construct_settings for the structure of
       #   this data. Falls back to the default config if not specified

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_multiple_services.baseline
@@ -52,8 +52,7 @@ module Google
         ALL_SCOPES = [
         ].freeze
 
-        # @param credentials
-        #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
         #   Provides the means for authenticating requests made by the client. This parameter can
         #   be many types.
         #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -70,7 +69,7 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if
         #   an updater_proc is supplied.
-        # @param client_config[Hash]
+        # @param client_config [Hash]
         #   A Hash for call options for each method. See
         #   Google::Gax#construct_settings for the structure of
         #   this data. Falls back to the default config if not specified
@@ -239,8 +238,7 @@ module Google
         ALL_SCOPES = [
         ].freeze
 
-        # @param credentials
-        #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
         #   Provides the means for authenticating requests made by the client. This parameter can
         #   be many types.
         #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -257,7 +255,7 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if
         #   an updater_proc is supplied.
-        # @param client_config[Hash]
+        # @param client_config [Hash]
         #   A Hash for call options for each method. See
         #   Google::Gax#construct_settings for the structure of
         #   this data. Falls back to the default config if not specified

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
@@ -86,10 +86,10 @@ module Library
   #
   # Service comment may include special characters: <>&"+'@.
   #
+  # @param version [Symbol, String]
+  #   The major version of the service to be used. By default :v1
+  #   is used.
   # @overload
-  #   @param version [Symbol, String]
-  #     The major version of the service to be used. By default :v1
-  #     is used.
   #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
   #     Provides the means for authenticating requests made by the client. This parameter can
   #     be many types.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
@@ -65,10 +65,10 @@ module Library
   FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("library"))
 
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
-    .select {|file| File.directory?(file)}
-    .select {|dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir))}
-    .select {|dir| File.exist?(dir + ".rb")}
-    .map {|dir| File.basename(dir)}
+    .select { |file| File.directory?(file) }
+    .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
+    .select { |dir| File.exist?(dir + ".rb") }
+    .map { |dir| File.basename(dir) }
 
   ##
   # This API represents a simple digital library.  It lets you manage Shelf
@@ -86,34 +86,34 @@ module Library
   #
   # Service comment may include special characters: <>&"+'@.
   #
-  # @param version [Symbol, String]
-  #   The major version of the service to be used. By default :v1
-  #   is used.
-  # @param credentials
-  #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-  #   Provides the means for authenticating requests made by the client. This parameter can
-  #   be many types.
-  #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
-  #   authenticating requests made by this client.
-  #   A `String` will be treated as the path to the keyfile to be used for the construction of
-  #   credentials for this client.
-  #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-  #   credentials for this client.
-  #   A `GRPC::Core::Channel` will be used to make calls through.
-  #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-  #   should already be composed with a `GRPC::Core::CallCredentials` object.
-  #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-  #   metadata for requests, generally, to give OAuth credentials.
-  # @param scopes [Array<String>]
-  #   The OAuth scopes for this service. This parameter is ignored if
-  #   an updater_proc is supplied.
-  # @param client_config[Hash]
-  #   A Hash for call options for each method. See
-  #   Google::Gax#construct_settings for the structure of
-  #   this data. Falls back to the default config if not specified
-  #   or the specified config is missing data points.
-  # @param timeout [Numeric]
-  #   The default timeout, in seconds, for calls made through this client.
+  # @overload
+  #   @param version [Symbol, String]
+  #     The major version of the service to be used. By default :v1
+  #     is used.
+  #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+  #     Provides the means for authenticating requests made by the client. This parameter can
+  #     be many types.
+  #     A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
+  #     authenticating requests made by this client.
+  #     A `String` will be treated as the path to the keyfile to be used for the construction of
+  #     credentials for this client.
+  #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+  #     credentials for this client.
+  #     A `GRPC::Core::Channel` will be used to make calls through.
+  #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+  #     should already be composed with a `GRPC::Core::CallCredentials` object.
+  #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+  #     metadata for requests, generally, to give OAuth credentials.
+  #   @param scopes [Array<String>]
+  #     The OAuth scopes for this service. This parameter is ignored if
+  #     an updater_proc is supplied.
+  #   @param client_config [Hash]
+  #     A Hash for call options for each method. See
+  #     Google::Gax#construct_settings for the structure of
+  #     this data. Falls back to the default config if not specified
+  #     or the specified config is missing data points.
+  #   @param timeout [Numeric]
+  #     The default timeout, in seconds, for calls made through this client.
   def self.new(*args, version: :v1, **kwargs)
     unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
       raise "The version: #{version} is not available. The available versions " \
@@ -128,6 +128,7 @@ module Library
     Library.const_get(version_module).new(*args, **kwargs)
   end
 end
+
 ============== file: lib/library/v1.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
@@ -219,8 +220,7 @@ module Library
     #
     # Service comment may include special characters: <>&"+'@.
     #
-    # @param credentials
-    #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+    # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
     #   Provides the means for authenticating requests made by the client. This parameter can
     #   be many types.
     #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -237,15 +237,32 @@ module Library
     # @param scopes [Array<String>]
     #   The OAuth scopes for this service. This parameter is ignored if
     #   an updater_proc is supplied.
-    # @param client_config[Hash]
+    # @param client_config [Hash]
     #   A Hash for call options for each method. See
     #   Google::Gax#construct_settings for the structure of
     #   this data. Falls back to the default config if not specified
     #   or the specified config is missing data points.
     # @param timeout [Numeric]
     #   The default timeout, in seconds, for calls made through this client.
-    def self.new(*args, **kwargs)
-      Library::V1::LibraryServiceClient.new(*args, **kwargs)
+    def self.new
+        service_path: nil,
+        port: nil,
+        channel: nil,
+        chan_creds: nil,
+        updater_proc: nil,
+        credentials: nil,
+        scopes: nil,
+        client_config: nil,
+        timeout: nil,
+        lib_name: nil,
+        lib_version: nil
+      kwargs = Hash[
+        *method(__method__).parameters
+          .select { |_, param| binding.local_variable_get(param) != nil }
+          .map { |_, param| [param, binding.local_variable_get(param)] }
+          .flatten(1)
+        ]
+      Library::V1::LibraryServiceClient.new(**kwargs)
     end
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_longrunning.baseline
@@ -86,8 +86,7 @@ module Google
     # returns long-running operations should implement the +Operations+ interface
     # so developers can have a consistent client experience.
     #
-    # @param credentials
-    #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+    # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
     #   Provides the means for authenticating requests made by the client. This parameter can
     #   be many types.
     #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -104,15 +103,32 @@ module Google
     # @param scopes [Array<String>]
     #   The OAuth scopes for this service. This parameter is ignored if
     #   an updater_proc is supplied.
-    # @param client_config[Hash]
+    # @param client_config [Hash]
     #   A Hash for call options for each method. See
     #   Google::Gax#construct_settings for the structure of
     #   this data. Falls back to the default config if not specified
     #   or the specified config is missing data points.
     # @param timeout [Numeric]
     #   The default timeout, in seconds, for calls made through this client.
-    def self.new(*args, **kwargs)
-      Google::Longrunning::OperationsClient.new(*args, **kwargs)
+    def self.new
+        service_path: nil,
+        port: nil,
+        channel: nil,
+        chan_creds: nil,
+        updater_proc: nil,
+        credentials: nil,
+        scopes: nil,
+        client_config: nil,
+        timeout: nil,
+        lib_name: nil,
+        lib_version: nil
+      kwargs = Hash[
+        *method(__method__).parameters
+          .select { |_, param| binding.local_variable_get(param) != nil }
+          .map { |_, param| [param, binding.local_variable_get(param)] }
+          .flatten(1)
+        ]
+      Google::Longrunning::OperationsClient.new(**kwargs)
     end
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
@@ -62,10 +62,10 @@ module Google
 
     module Incrementer
       ##
+      # @param version [Symbol, String]
+      #   The major version of the service to be used. By default :v1
+      #   is used.
       # @overload
-      #   @param version [Symbol, String]
-      #     The major version of the service to be used. By default :v1
-      #     is used.
       #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #     Provides the means for authenticating requests made by the client. This parameter can
       #     be many types.
@@ -107,10 +107,10 @@ module Google
 
     module Decrementer
       ##
+      # @param version [Symbol, String]
+      #   The major version of the service to be used. By default :v1
+      #   is used.
       # @overload
-      #   @param version [Symbol, String]
-      #     The major version of the service to be used. By default :v1
-      #     is used.
       #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #     Provides the means for authenticating requests made by the client. This parameter can
       #     be many types.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
@@ -55,41 +55,41 @@ module Google
     FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("example"))
 
     AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
-      .select {|file| File.directory?(file)}
-      .select {|dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir))}
-      .select {|dir| File.exist?(dir + ".rb")}
-      .map {|dir| File.basename(dir)}
+      .select { |file| File.directory?(file) }
+      .select { |dir| Google::Gax::VERSION_MATCHER.match(File.basename(dir)) }
+      .select { |dir| File.exist?(dir + ".rb") }
+      .map { |dir| File.basename(dir) }
 
     module Incrementer
       ##
-      # @param version [Symbol, String]
-      #   The major version of the service to be used. By default :v1
-      #   is used.
-      # @param credentials
-      #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-      #   Provides the means for authenticating requests made by the client. This parameter can
-      #   be many types.
-      #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
-      #   authenticating requests made by this client.
-      #   A `String` will be treated as the path to the keyfile to be used for the construction of
-      #   credentials for this client.
-      #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-      #   credentials for this client.
-      #   A `GRPC::Core::Channel` will be used to make calls through.
-      #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-      #   should already be composed with a `GRPC::Core::CallCredentials` object.
-      #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-      #   metadata for requests, generally, to give OAuth credentials.
-      # @param scopes [Array<String>]
-      #   The OAuth scopes for this service. This parameter is ignored if
-      #   an updater_proc is supplied.
-      # @param client_config[Hash]
-      #   A Hash for call options for each method. See
-      #   Google::Gax#construct_settings for the structure of
-      #   this data. Falls back to the default config if not specified
-      #   or the specified config is missing data points.
-      # @param timeout [Numeric]
-      #   The default timeout, in seconds, for calls made through this client.
+      # @overload
+      #   @param version [Symbol, String]
+      #     The major version of the service to be used. By default :v1
+      #     is used.
+      #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+      #     Provides the means for authenticating requests made by the client. This parameter can
+      #     be many types.
+      #     A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
+      #     authenticating requests made by this client.
+      #     A `String` will be treated as the path to the keyfile to be used for the construction of
+      #     credentials for this client.
+      #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+      #     credentials for this client.
+      #     A `GRPC::Core::Channel` will be used to make calls through.
+      #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+      #     should already be composed with a `GRPC::Core::CallCredentials` object.
+      #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+      #     metadata for requests, generally, to give OAuth credentials.
+      #   @param scopes [Array<String>]
+      #     The OAuth scopes for this service. This parameter is ignored if
+      #     an updater_proc is supplied.
+      #   @param client_config [Hash]
+      #     A Hash for call options for each method. See
+      #     Google::Gax#construct_settings for the structure of
+      #     this data. Falls back to the default config if not specified
+      #     or the specified config is missing data points.
+      #   @param timeout [Numeric]
+      #     The default timeout, in seconds, for calls made through this client.
       def self.new(*args, version: :v1, **kwargs)
         unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
           raise "The version: #{version} is not available. The available versions " \
@@ -107,34 +107,34 @@ module Google
 
     module Decrementer
       ##
-      # @param version [Symbol, String]
-      #   The major version of the service to be used. By default :v1
-      #   is used.
-      # @param credentials
-      #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
-      #   Provides the means for authenticating requests made by the client. This parameter can
-      #   be many types.
-      #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
-      #   authenticating requests made by this client.
-      #   A `String` will be treated as the path to the keyfile to be used for the construction of
-      #   credentials for this client.
-      #   A `Hash` will be treated as the contents of a keyfile to be used for the construction of
-      #   credentials for this client.
-      #   A `GRPC::Core::Channel` will be used to make calls through.
-      #   A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
-      #   should already be composed with a `GRPC::Core::CallCredentials` object.
-      #   A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
-      #   metadata for requests, generally, to give OAuth credentials.
-      # @param scopes [Array<String>]
-      #   The OAuth scopes for this service. This parameter is ignored if
-      #   an updater_proc is supplied.
-      # @param client_config[Hash]
-      #   A Hash for call options for each method. See
-      #   Google::Gax#construct_settings for the structure of
-      #   this data. Falls back to the default config if not specified
-      #   or the specified config is missing data points.
-      # @param timeout [Numeric]
-      #   The default timeout, in seconds, for calls made through this client.
+      # @overload
+      #   @param version [Symbol, String]
+      #     The major version of the service to be used. By default :v1
+      #     is used.
+      #   @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+      #     Provides the means for authenticating requests made by the client. This parameter can
+      #     be many types.
+      #     A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
+      #     authenticating requests made by this client.
+      #     A `String` will be treated as the path to the keyfile to be used for the construction of
+      #     credentials for this client.
+      #     A `Hash` will be treated as the contents of a keyfile to be used for the construction of
+      #     credentials for this client.
+      #     A `GRPC::Core::Channel` will be used to make calls through.
+      #     A `GRPC::Core::ChannelCredentials` for the setting up the RPC client. The channel credentials
+      #     should already be composed with a `GRPC::Core::CallCredentials` object.
+      #     A `Proc` will be used as an updater_proc for the Grpc channel. The proc transforms the
+      #     metadata for requests, generally, to give OAuth credentials.
+      #   @param scopes [Array<String>]
+      #     The OAuth scopes for this service. This parameter is ignored if
+      #     an updater_proc is supplied.
+      #   @param client_config [Hash]
+      #     A Hash for call options for each method. See
+      #     Google::Gax#construct_settings for the structure of
+      #     this data. Falls back to the default config if not specified
+      #     or the specified config is missing data points.
+      #   @param timeout [Numeric]
+      #     The default timeout, in seconds, for calls made through this client.
       def self.new(*args, version: :v1, **kwargs)
         unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
           raise "The version: #{version} is not available. The available versions " \
@@ -151,6 +151,7 @@ module Google
     end
   end
 end
+
 ============== file: lib/google/example/v1.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
@@ -221,8 +222,7 @@ module Google
 
       module Incrementer
         ##
-        # @param credentials
-        #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
         #   Provides the means for authenticating requests made by the client. This parameter can
         #   be many types.
         #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -239,22 +239,38 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if
         #   an updater_proc is supplied.
-        # @param client_config[Hash]
+        # @param client_config [Hash]
         #   A Hash for call options for each method. See
         #   Google::Gax#construct_settings for the structure of
         #   this data. Falls back to the default config if not specified
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
-        def self.new(*args, **kwargs)
-          Google::Example::V1::IncrementerServiceClient.new(*args, **kwargs)
+        def self.new
+            service_path: nil,
+            port: nil,
+            channel: nil,
+            chan_creds: nil,
+            updater_proc: nil,
+            credentials: nil,
+            scopes: nil,
+            client_config: nil,
+            timeout: nil,
+            lib_name: nil,
+            lib_version: nil
+          kwargs = Hash[
+            *method(__method__).parameters
+              .select { |_, param| binding.local_variable_get(param) != nil }
+              .map { |_, param| [param, binding.local_variable_get(param)] }
+              .flatten(1)
+            ]
+          Google::Example::V1::IncrementerServiceClient.new(**kwargs)
         end
       end
 
       module Decrementer
         ##
-        # @param credentials
-        #   [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
+        # @param credentials [Google::Gax::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
         #   Provides the means for authenticating requests made by the client. This parameter can
         #   be many types.
         #   A `Google::Gax::Credentials` uses a the properties of its represented keyfile for
@@ -271,15 +287,32 @@ module Google
         # @param scopes [Array<String>]
         #   The OAuth scopes for this service. This parameter is ignored if
         #   an updater_proc is supplied.
-        # @param client_config[Hash]
+        # @param client_config [Hash]
         #   A Hash for call options for each method. See
         #   Google::Gax#construct_settings for the structure of
         #   this data. Falls back to the default config if not specified
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
-        def self.new(*args, **kwargs)
-          Google::Example::V1::DecrementerServiceClient.new(*args, **kwargs)
+        def self.new
+            service_path: nil,
+            port: nil,
+            channel: nil,
+            chan_creds: nil,
+            updater_proc: nil,
+            credentials: nil,
+            scopes: nil,
+            client_config: nil,
+            timeout: nil,
+            lib_name: nil,
+            lib_version: nil
+          kwargs = Hash[
+            *method(__method__).parameters
+              .select { |_, param| binding.local_variable_get(param) != nil }
+              .map { |_, param| [param, binding.local_variable_get(param)] }
+              .flatten(1)
+            ]
+          Google::Example::V1::DecrementerServiceClient.new(**kwargs)
         end
       end
     end


### PR DESCRIPTION
Based on feedback from
  https://github.com/GoogleCloudPlatform/google-cloud-ruby/pull/1702

- Use `@overload` to prevent YARD from being confused when `@param` docs
  do not match the *args, **kwargs method signature
- Do not use *args, **kwargs when the true method signature is known
- End version index files in newline, per convention