### PR TITLE
Deprecate defaultBuilder in GAPIC java surface

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -506,8 +506,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     stubClass.doc(serviceTransformer.generateServiceDoc(context, null));
 
     String name = namer.getApiGrpcStubClassName(interfaceConfig);
-    stubClass.releaseLevelAnnotation(
-        namer.getReleaseAnnotation(packageMetadataConfig.releaseLevel(TargetLanguage.JAVA)));
+    // TODO: Remove hardcoded BETA release level after gRPC stub class is GA.
+    stubClass.releaseLevelAnnotation(namer.getReleaseAnnotation(ReleaseLevel.BETA));
     stubClass.name(name);
     stubClass.parentName(namer.getApiStubInterfaceName(interfaceConfig));
     stubClass.settingsClassName(

--- a/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
@@ -111,7 +111,7 @@
   }
 
   public static final {@stubClass.name} create(ClientContext clientContext) throws IOException {
-    return new {@stubClass.name}({@stubClass.settingsClassName}.defaultBuilder().build(), clientContext);
+    return new {@stubClass.name}({@stubClass.settingsClassName}.newBuilder().build(), clientContext);
   }
 
   /**

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -112,7 +112,7 @@
    * <pre>
    * <code>
    * {@xapiClassDoc.settingsClassName} {@xapiClassDoc.settingsVarName} =
-   *     {@xapiClassDoc.settingsClassName}.defaultBuilder()
+   *     {@xapiClassDoc.settingsClassName}.newBuilder()
    *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
    *         .build();
    * {@xapiClassDoc.apiClassName} {@xapiClassDoc.apiVarName} =
@@ -125,7 +125,7 @@
    * <pre>
    * <code>
    * {@xapiClassDoc.settingsClassName} {@xapiClassDoc.settingsVarName} =
-   *     {@xapiClassDoc.settingsClassName}.defaultBuilder()
+   *     {@xapiClassDoc.settingsClassName}.newBuilder()
    *         .setTransportProvider({@xapiClassDoc.settingsClassName}.defaultGrpcTransportProviderBuilder()
    *             .setChannelProvider({@xapiClassDoc.settingsClassName}.defaultGrpcChannelProviderBuilder()
    *                 .setEndpoint(myEndpoint)
@@ -209,7 +209,7 @@
      * Constructs an instance of {@xapiClass.name} with default settings.
      */
     public static final {@xapiClass.name} create() throws IOException {
-      return create({@xapiClass.settingsClassName}.defaultBuilder().build());
+      return create({@xapiClass.settingsClassName}.newBuilder().build());
     }
     {@""}
   @end

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -259,6 +259,7 @@
     return settings;
   }
 
+  @@BetaApi
   public {@xapiClass.stubInterfaceName} getStub() {
     return stub;
   }

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -47,7 +47,7 @@
      * <pre>
      * <code>
      * {@doc.settingsClassName}.Builder {@doc.settingsBuilderVarName} =
-     *     {@doc.settingsClassName}.defaultBuilder();
+     *     {@doc.settingsClassName}.newBuilder();
      * {@doc.settingsBuilderVarName}.{@doc.exampleApiMethodSettingsGetter}().getRetrySettingsBuilder()
      *     .setTotalTimeout(Duration.ofSeconds(30));
      * {@doc.settingsClassName} {@doc.settingsVarName} = {@doc.settingsBuilderVarName}.build();
@@ -164,6 +164,7 @@
   /**
    * Returns a builder for this class with recommended defaults.
    */
+  @@Deprecated
   public static Builder defaultBuilder() {
     return Builder.createDefault();
   }
@@ -172,6 +173,7 @@
    * Returns a builder for this class with recommended defaults for API methods, and the given
    * ClientContext used for executor/transport/credentials.
    */
+  @@Deprecated
   public static Builder defaultBuilder(ClientContext clientContext) {
     return new Builder(clientContext);
   }
@@ -180,7 +182,7 @@
    * Returns a new builder for this class.
    */
   public static Builder newBuilder() {
-    return new Builder();
+    return Builder.createDefault();
   }
 
   /**

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -29,7 +29,7 @@
     @@Before
     public void setUp() throws IOException {
       serviceHelper.reset();
-      {@xapiTest.testClass.apiSettingsClassName} settings = {@xapiTest.testClass.apiSettingsClassName}.defaultBuilder()
+      {@xapiTest.testClass.apiSettingsClassName} settings = {@xapiTest.testClass.apiSettingsClassName}.newBuilder()
           .setTransportProvider(
                 GrpcTransportProvider.newBuilder()
                     .setChannelProvider(serviceHelper.createChannelProvider())

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -414,6 +414,7 @@ public class LibraryClient implements BackgroundResource {
     return settings;
   }
 
+  @BetaApi
   public LibraryServiceStub getStub() {
     return stub;
   }
@@ -5116,6 +5117,7 @@ import javax.annotation.Generated;
  * <p>This class is for advanced usage and reflects the underlying API directly.
  */
 @Generated("by GAPIC v0.0.5")
+@BetaApi
 public class GrpcLibraryServiceStub extends LibraryServiceStub {
   private static final UnaryCallable<CreateShelfRequest, Shelf> directCreateShelfCallable =
       GrpcCallableFactory.createDirectCallable(

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -336,7 +336,7 @@ import javax.annotation.Generated;
  * <pre>
  * <code>
  * LibrarySettings librarySettings =
- *     LibrarySettings.defaultBuilder()
+ *     LibrarySettings.newBuilder()
  *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
  *         .build();
  * LibraryClient libraryClient =
@@ -349,7 +349,7 @@ import javax.annotation.Generated;
  * <pre>
  * <code>
  * LibrarySettings librarySettings =
- *     LibrarySettings.defaultBuilder()
+ *     LibrarySettings.newBuilder()
  *         .setTransportProvider(LibrarySettings.defaultGrpcTransportProviderBuilder()
  *             .setChannelProvider(LibrarySettings.defaultGrpcChannelProviderBuilder()
  *                 .setEndpoint(myEndpoint)
@@ -373,7 +373,7 @@ public class LibraryClient implements BackgroundResource {
    * Constructs an instance of LibraryClient with default settings.
    */
   public static final LibraryClient create() throws IOException {
-    return create(LibrarySettings.defaultBuilder().build());
+    return create(LibrarySettings.newBuilder().build());
   }
 
   /**
@@ -3090,7 +3090,7 @@ import org.threeten.bp.Duration;
  * <pre>
  * <code>
  * LibrarySettings.Builder librarySettingsBuilder =
- *     LibrarySettings.defaultBuilder();
+ *     LibrarySettings.newBuilder();
  * librarySettingsBuilder.createShelfSettings().getRetrySettingsBuilder()
  *     .setTotalTimeout(Duration.ofSeconds(30));
  * LibrarySettings librarySettings = librarySettingsBuilder.build();
@@ -3411,6 +3411,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns a builder for this class with recommended defaults.
    */
+  @Deprecated
   public static Builder defaultBuilder() {
     return Builder.createDefault();
   }
@@ -3419,6 +3420,7 @@ public class LibrarySettings extends ClientSettings {
    * Returns a builder for this class with recommended defaults for API methods, and the given
    * ClientContext used for executor/transport/credentials.
    */
+  @Deprecated
   public static Builder defaultBuilder(ClientContext clientContext) {
     return new Builder(clientContext);
   }
@@ -3427,7 +3429,7 @@ public class LibrarySettings extends ClientSettings {
    * Returns a new builder for this class.
    */
   public static Builder newBuilder() {
-    return new Builder();
+    return Builder.createDefault();
   }
 
   /**
@@ -5355,7 +5357,7 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
   }
 
   public static final GrpcLibraryServiceStub create(ClientContext clientContext) throws IOException {
-    return new GrpcLibraryServiceStub(LibrarySettings.defaultBuilder().build(), clientContext);
+    return new GrpcLibraryServiceStub(LibrarySettings.newBuilder().build(), clientContext);
   }
 
   /**
@@ -5950,7 +5952,7 @@ public class LibraryClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
-    LibrarySettings settings = LibrarySettings.defaultBuilder()
+    LibrarySettings settings = LibrarySettings.newBuilder()
         .setTransportProvider(
               GrpcTransportProvider.newBuilder()
                   .setChannelProvider(serviceHelper.createChannelProvider())

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -77,7 +77,7 @@ import javax.annotation.Generated;
  * <pre>
  * <code>
  * NoTemplatesApiServiceSettings noTemplatesApiServiceSettings =
- *     NoTemplatesApiServiceSettings.defaultBuilder()
+ *     NoTemplatesApiServiceSettings.newBuilder()
  *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
  *         .build();
  * NoTemplatesApiServiceClient noTemplatesApiServiceClient =
@@ -90,7 +90,7 @@ import javax.annotation.Generated;
  * <pre>
  * <code>
  * NoTemplatesApiServiceSettings noTemplatesApiServiceSettings =
- *     NoTemplatesApiServiceSettings.defaultBuilder()
+ *     NoTemplatesApiServiceSettings.newBuilder()
  *         .setTransportProvider(NoTemplatesApiServiceSettings.defaultGrpcTransportProviderBuilder()
  *             .setChannelProvider(NoTemplatesApiServiceSettings.defaultGrpcChannelProviderBuilder()
  *                 .setEndpoint(myEndpoint)
@@ -357,6 +357,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
   /**
    * Returns a builder for this class with recommended defaults.
    */
+  @Deprecated
   public static Builder defaultBuilder() {
     return Builder.createDefault();
   }
@@ -365,6 +366,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
    * Returns a builder for this class with recommended defaults for API methods, and the given
    * ClientContext used for executor/transport/credentials.
    */
+  @Deprecated
   public static Builder defaultBuilder(ClientContext clientContext) {
     return new Builder(clientContext);
   }
@@ -373,7 +375,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
    * Returns a new builder for this class.
    */
   public static Builder newBuilder() {
-    return new Builder();
+    return Builder.createDefault();
   }
 
   /**
@@ -596,7 +598,7 @@ public class GrpcNoTemplatesApiServiceStub extends NoTemplatesApiServiceStub {
   }
 
   public static final GrpcNoTemplatesApiServiceStub create(ClientContext clientContext) throws IOException {
-    return new GrpcNoTemplatesApiServiceStub(NoTemplatesApiServiceSettings.defaultBuilder().build(), clientContext);
+    return new GrpcNoTemplatesApiServiceStub(NoTemplatesApiServiceSettings.newBuilder().build(), clientContext);
   }
 
   /**
@@ -882,7 +884,7 @@ public class NoTemplatesApiServiceClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
-    NoTemplatesApiServiceSettings settings = NoTemplatesApiServiceSettings.defaultBuilder()
+    NoTemplatesApiServiceSettings settings = NoTemplatesApiServiceSettings.newBuilder()
         .setTransportProvider(
               GrpcTransportProvider.newBuilder()
                   .setChannelProvider(serviceHelper.createChannelProvider())

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -147,6 +147,7 @@ public class NoTemplatesApiServiceClient implements BackgroundResource {
     return settings;
   }
 
+  @BetaApi
   public NoTemplatesApiServiceStub getStub() {
     return stub;
   }


### PR DESCRIPTION
This PR also marks `stub` classes and `getStub()` method as `@BetaApi`. The beta release level for stub is now hardcoded since it will stay beta even after the surface is switched to GA.