### PR TITLE
Remove reflection for version index

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -140,12 +140,19 @@
       timeout: nil,
       lib_name: nil,
       lib_version: nil
-    kwargs = Hash[
-      *method(__method__).parameters
-        .select { |_, param| binding.local_variable_get(param) != nil }
-        .map { |_, param| [param, binding.local_variable_get(param)] }
-        .flatten(1)
-      ]
+    kwargs = {
+      service_path: service_path,
+      port: port,
+      channel: channel,
+      chan_creds: chan_creds,
+      updater_proc: updater_proc,
+      credentials: credentials,
+      scopes: scopes,
+      client_config: client_config,
+      timeout: timeout,
+      lib_name: lib_name,
+      lib_version: lib_version
+    }.select { |_, v| v != nil }
     {@requireView.clientName}.new(**kwargs)
   end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
@@ -245,12 +245,19 @@ module Library
         timeout: nil,
         lib_name: nil,
         lib_version: nil
-      kwargs = Hash[
-        *method(__method__).parameters
-          .select { |_, param| binding.local_variable_get(param) != nil }
-          .map { |_, param| [param, binding.local_variable_get(param)] }
-          .flatten(1)
-        ]
+      kwargs = {
+        service_path: service_path,
+        port: port,
+        channel: channel,
+        chan_creds: chan_creds,
+        updater_proc: updater_proc,
+        credentials: credentials,
+        scopes: scopes,
+        client_config: client_config,
+        timeout: timeout,
+        lib_name: lib_name,
+        lib_version: lib_version
+      }.select { |_, v| v != nil }
       Library::V1::LibraryServiceClient.new(**kwargs)
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
@@ -245,12 +245,19 @@ module Library
         timeout: nil,
         lib_name: nil,
         lib_version: nil
-      kwargs = Hash[
-        *method(__method__).parameters
-          .select { |_, param| binding.local_variable_get(param) != nil }
-          .map { |_, param| [param, binding.local_variable_get(param)] }
-          .flatten(1)
-        ]
+      kwargs = {
+        service_path: service_path,
+        port: port,
+        channel: channel,
+        chan_creds: chan_creds,
+        updater_proc: updater_proc,
+        credentials: credentials,
+        scopes: scopes,
+        client_config: client_config,
+        timeout: timeout,
+        lib_name: lib_name,
+        lib_version: lib_version
+      }.select { |_, v| v != nil }
       Library::V1::LibraryServiceClient.new(**kwargs)
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_longrunning.baseline
@@ -111,12 +111,19 @@ module Google
         timeout: nil,
         lib_name: nil,
         lib_version: nil
-      kwargs = Hash[
-        *method(__method__).parameters
-          .select { |_, param| binding.local_variable_get(param) != nil }
-          .map { |_, param| [param, binding.local_variable_get(param)] }
-          .flatten(1)
-        ]
+      kwargs = {
+        service_path: service_path,
+        port: port,
+        channel: channel,
+        chan_creds: chan_creds,
+        updater_proc: updater_proc,
+        credentials: credentials,
+        scopes: scopes,
+        client_config: client_config,
+        timeout: timeout,
+        lib_name: lib_name,
+        lib_version: lib_version
+      }.select { |_, v| v != nil }
       Google::Longrunning::OperationsClient.new(**kwargs)
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
@@ -245,12 +245,19 @@ module Google
             timeout: nil,
             lib_name: nil,
             lib_version: nil
-          kwargs = Hash[
-            *method(__method__).parameters
-              .select { |_, param| binding.local_variable_get(param) != nil }
-              .map { |_, param| [param, binding.local_variable_get(param)] }
-              .flatten(1)
-            ]
+          kwargs = {
+            service_path: service_path,
+            port: port,
+            channel: channel,
+            chan_creds: chan_creds,
+            updater_proc: updater_proc,
+            credentials: credentials,
+            scopes: scopes,
+            client_config: client_config,
+            timeout: timeout,
+            lib_name: lib_name,
+            lib_version: lib_version
+          }.select { |_, v| v != nil }
           Google::Example::V1::IncrementerServiceClient.new(**kwargs)
         end
       end
@@ -293,12 +300,19 @@ module Google
             timeout: nil,
             lib_name: nil,
             lib_version: nil
-          kwargs = Hash[
-            *method(__method__).parameters
-              .select { |_, param| binding.local_variable_get(param) != nil }
-              .map { |_, param| [param, binding.local_variable_get(param)] }
-              .flatten(1)
-            ]
+          kwargs = {
+            service_path: service_path,
+            port: port,
+            channel: channel,
+            chan_creds: chan_creds,
+            updater_proc: updater_proc,
+            credentials: credentials,
+            scopes: scopes,
+            client_config: client_config,
+            timeout: timeout,
+            lib_name: lib_name,
+            lib_version: lib_version
+          }.select { |_, v| v != nil }
           Google::Example::V1::DecrementerServiceClient.new(**kwargs)
         end
       end


### PR DESCRIPTION
The reflective `local_variable_get` method was only added in Ruby
2.1, whereas google-cloud-ruby continues to support Ruby 2.0.