### PR TITLE
Remove a one-character indentation error.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -120,7 +120,7 @@
                 which to make calls.
             credentials (~google.auth.credentials.Credentials): The authorization
                 credentials to attach to requests. These credentials identify this
-                 application to the service.
+                application to the service.
             ssl_credentials (~grpc.ChannelCredentials): A
                 ``ChannelCredentials`` instance for use with an SSL-enabled
                 channel.
@@ -140,8 +140,6 @@
                 client library metrics. Ultimately serializes to a string
                 (e.g. 'foo/1.2.3 bar/3.14.1'). This argument should be
                 considered private.
-
-        Returns: {@xapiClass.name}
         """
         @# Unless the calling application specifically requested
         @# OAuth scopes, request everything.

--- a/src/test/java/com/google/api/codegen/testdata/py/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_main_library.baseline
@@ -228,7 +228,7 @@ class LibraryServiceClient(object):
                 which to make calls.
             credentials (~google.auth.credentials.Credentials): The authorization
                 credentials to attach to requests. These credentials identify this
-                 application to the service.
+                application to the service.
             ssl_credentials (~grpc.ChannelCredentials): A
                 ``ChannelCredentials`` instance for use with an SSL-enabled
                 channel.
@@ -248,8 +248,6 @@ class LibraryServiceClient(object):
                 client library metrics. Ultimately serializes to a string
                 (e.g. 'foo/1.2.3 bar/3.14.1'). This argument should be
                 considered private.
-
-        Returns: LibraryServiceClient
         """
         # Unless the calling application specifically requested
         # OAuth scopes, request everything.
@@ -1696,4 +1694,3 @@ class LibraryServiceClient(object):
             optional_repeated_fixed64=optional_repeated_fixed64,
             optional_map=optional_map)
         return self._test_optional_required_flattening_params(request, options)
-

--- a/src/test/java/com/google/api/codegen/testdata/py/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_main_library.baseline
@@ -1694,3 +1694,4 @@ class LibraryServiceClient(object):
             optional_repeated_fixed64=optional_repeated_fixed64,
             optional_map=optional_map)
         return self._test_optional_required_flattening_params(request, options)
+

--- a/src/test/java/com/google/api/codegen/testdata/py/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_main_no_path_templates.baseline
@@ -67,7 +67,7 @@ class NoTemplatesAPIServiceClient(object):
                 which to make calls.
             credentials (~google.auth.credentials.Credentials): The authorization
                 credentials to attach to requests. These credentials identify this
-                 application to the service.
+                application to the service.
             ssl_credentials (~grpc.ChannelCredentials): A
                 ``ChannelCredentials`` instance for use with an SSL-enabled
                 channel.
@@ -87,8 +87,6 @@ class NoTemplatesAPIServiceClient(object):
                 client library metrics. Ultimately serializes to a string
                 (e.g. 'foo/1.2.3 bar/3.14.1'). This argument should be
                 considered private.
-
-        Returns: NoTemplatesAPIServiceClient
         """
         # Unless the calling application specifically requested
         # OAuth scopes, request everything.
@@ -164,4 +162,3 @@ class NoTemplatesAPIServiceClient(object):
         """
         request = no_path_templates_pb2.IncrementRequest()
         self._increment(request, options)
-

--- a/src/test/java/com/google/api/codegen/testdata/py/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_main_no_path_templates.baseline
@@ -162,3 +162,4 @@ class NoTemplatesAPIServiceClient(object):
         """
         request = no_path_templates_pb2.IncrementRequest()
         self._increment(request, options)
+


### PR DESCRIPTION
Yes, Sphinx is _that_ pedantic.

P. S. Also removes an inaccurate `Returns:` clause, since this is an `__init__` function (constructors in Python always return `None`).