### PR TITLE
Python: Make top level entrypoint file not depend on the shortname (which could be a hyphenated)

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/py/python_top_level_entry_point_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/python_top_level_entry_point_no_path_templates.baseline
@@ -1,4 +1,4 @@
-============== file: library.py ==============
+============== file: example.py ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
### What
I was generating the video-intelligence gapic and the shortname was hyphenated causing an error.

