### PR TITLE
Fix Ruby LRO endpoint

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -169,6 +169,7 @@
 
     @if xapiClass.hasLongRunningOperations
       @@operations_client = Google::Longrunning::OperationsClient.new(
+        service_path: service_path,
         credentials: credentials,
         scopes: scopes,
         client_config: client_config,

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_main_library.baseline
@@ -219,6 +219,7 @@ module Library
         credentials ||= Library::Credentials.default
 
         @operations_client = Google::Longrunning::OperationsClient.new(
+          service_path: service_path,
           credentials: credentials,
           scopes: scopes,
           client_config: client_config,

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_main_library.baseline
@@ -219,6 +219,7 @@ module Library
         credentials ||= Library::Credentials.default
 
         @operations_client = Google::Longrunning::OperationsClient.new(
+          service_path: service_path,
           credentials: credentials,
           scopes: scopes,
           client_config: client_config,


### PR DESCRIPTION
Same as https://github.com/googleapis/toolkit/pull/1571, but for
Ruby. Previously, calling a LRO method resulted in 404.