### PR TITLE
Add overview.rb file to Ruby docs

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceDocTransformer.java
@@ -76,8 +76,6 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
             new RubyTypeTable(productConfig.getPackageName()),
             new RubyModelTypeNameConverter(productConfig.getPackageName()));
     // Use file path for package name to get file-specific package instead of package for the API.
-    // TODO(jgeiger): switch to use productConfig.getPackageName() instead of
-    // typeTable.getFullNameFor(file)
     SurfaceNamer namer = new RubySurfaceNamer(typeTable.getFullNameFor(file));
     String subPath = pathMapper.getOutputPath(file, productConfig);
     String baseFilename = namer.getProtoFileName(file);
@@ -95,8 +93,6 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
   }
 
   private ViewModel generateOverview(Model model, GapicProductConfig productConfig) {
-    // TODO(jgeiger): switch to use productConfig.getPackageName() instead of
-    // typeTable.getFullNameFor(file)
     SurfaceNamer namer = new RubySurfaceNamer(productConfig.getPackageName());
     GrpcDocView.Builder doc = GrpcDocView.newBuilder();
     doc.templateFileName(DOC_TEMPLATE_FILENAME);

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceDocTransformer.java
@@ -27,6 +27,7 @@ import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.ruby.RubyTypeTable;
 import com.google.api.codegen.viewmodel.GrpcDocView;
+import com.google.api.codegen.viewmodel.GrpcElementDocView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.metadata.ModuleView;
@@ -65,6 +66,7 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
     for (ProtoFile file : new ProtoFileView().getElementIterable(model)) {
       surfaceDocs.add(generateDoc(file, productConfig));
     }
+    surfaceDocs.add(generateOverview(model, productConfig));
     return surfaceDocs.build();
   }
 
@@ -74,6 +76,8 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
             new RubyTypeTable(productConfig.getPackageName()),
             new RubyModelTypeNameConverter(productConfig.getPackageName()));
     // Use file path for package name to get file-specific package instead of package for the API.
+    // TODO(jgeiger): switch to use productConfig.getPackageName() instead of
+    // typeTable.getFullNameFor(file)
     SurfaceNamer namer = new RubySurfaceNamer(typeTable.getFullNameFor(file));
     String subPath = pathMapper.getOutputPath(file, productConfig);
     String baseFilename = namer.getProtoFileName(file);
@@ -85,7 +89,23 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
             productConfig, ImportSectionView.newBuilder().build(), namer));
     doc.elementDocs(elementDocTransformer.generateElementDocs(typeTable, namer, file));
     doc.modules(
-        generateModuleViews(file.getModel(), productConfig, namer, isSourceApiInterfaceFile(file)));
+        generateModuleViews(
+            file.getModel(), productConfig, namer, isSourceApiInterfaceFile(file), false));
+    return doc.build();
+  }
+
+  private ViewModel generateOverview(Model model, GapicProductConfig productConfig) {
+    // TODO(jgeiger): switch to use productConfig.getPackageName() instead of
+    // typeTable.getFullNameFor(file)
+    SurfaceNamer namer = new RubySurfaceNamer(productConfig.getPackageName());
+    GrpcDocView.Builder doc = GrpcDocView.newBuilder();
+    doc.templateFileName(DOC_TEMPLATE_FILENAME);
+    doc.outputPath(pathMapper.getOutputPath(null, productConfig) + "/doc/overview.rb");
+    doc.fileHeader(
+        fileHeaderTransformer.generateFileHeader(
+            productConfig, ImportSectionView.newBuilder().build(), namer));
+    doc.elementDocs(ImmutableList.<GrpcElementDocView>of());
+    doc.modules(generateModuleViews(model, productConfig, namer, false, true));
     return doc.build();
   }
 
@@ -102,11 +122,17 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
   }
 
   private List<ModuleView> generateModuleViews(
-      Model model, GapicProductConfig productConfig, SurfaceNamer namer, boolean hasToc) {
+      Model model,
+      GapicProductConfig productConfig,
+      SurfaceNamer namer,
+      boolean hasToc,
+      boolean hasOverview) {
     ImmutableList.Builder<ModuleView> moduleViews = ImmutableList.builder();
     for (String moduleName : namer.getApiModules()) {
-      if (hasToc && moduleName.equals(namer.getModuleVersionName())) {
+      if (moduleName.equals(namer.getModuleVersionName()) && hasToc) {
         moduleViews.add(generateTocModuleView(model, productConfig, namer, moduleName));
+      } else if (moduleName.equals(namer.getModuleServiceName()) && hasOverview) {
+        moduleViews.add(generateOverviewView(model, productConfig));
       } else {
         moduleViews.add(SimpleModuleView.newBuilder().moduleName(moduleName).build());
       }
@@ -137,6 +163,18 @@ public class RubyGapicSurfaceDocTransformer implements ModelToViewTransformer {
         .moduleName(moduleName)
         .fullName(model.getServiceConfig().getTitle())
         .contents(tocContents.build())
+        .build();
+  }
+
+  private ModuleView generateOverviewView(Model model, GapicProductConfig productConfig) {
+    SurfaceNamer namer = new RubySurfaceNamer(productConfig.getPackageName());
+    RubyPackageMetadataTransformer metadataTransformer =
+        new RubyPackageMetadataTransformer(packageConfig);
+    RubyPackageMetadataNamer packageNamer =
+        new RubyPackageMetadataNamer(productConfig.getPackageName());
+    return metadataTransformer
+        .generateReadmeMetadataView(model, productConfig, packageNamer)
+        .moduleName(namer.getModuleServiceName())
         .build();
   }
 }

--- a/src/main/resources/com/google/api/codegen/ruby/common.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/common.snip
@@ -64,3 +64,7 @@
   @@param timeout [Numeric]
     The default timeout, in seconds, for calls made through this client.
 @end
+
+@snippet installationLines(metadata)
+  $ gem install {@metadata.identifier}
+@end

--- a/src/main/resources/com/google/api/codegen/ruby/message.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/message.snip
@@ -1,4 +1,6 @@
+@extends "readme.snip"
 @extends "ruby/common.snip"
+@extends "ruby/method_sample.snip"
 
 @snippet generate(doc)
   @let body = documentChildren(doc)
@@ -14,6 +16,8 @@
     @switch module.type
     @case "TocModuleView"
       {@tocModule(module, iterator, content)}
+    @case "ReadmeMetadataView"
+      {@readmeModule(module, iterator, content)}
     @case "SimpleModuleView"
       {@simpleModule(module, iterator, content)}
     @end
@@ -35,6 +39,29 @@
   @end
   @#
   {@simpleModule(module, iterator, content)}
+@end
+
+@private readmeModule(module, iterator, content)
+  @# rubocop:disable LineLength
+
+  @##
+  {@toComments(util.getDocLines(generateReadme(module)))}
+  @#
+  @#
+  {@simpleModule(module, iterator, content)}
+@end
+
+@private generateReadme(metadata)
+  {@readme(metadata, exampleMethods(metadata.exampleMethods), installationLines(metadata))}
+@end
+
+@private exampleMethods(methods)
+  @join method : methods on BREAK
+    @#### {@method.apiClassName}
+    ```rb
+    {@sampleCodeWithTopLevelImport(method)}
+    ```
+  @end
 @end
 
 @private simpleModule(module, iterator, content)

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -58,7 +58,7 @@
 @end
 
 @private generateReadme(indexType, metadata)
-  {@readme(metadata, exampleMethods(indexType, metadata.exampleMethods), installationLines(metadata))}
+  {@readme(metadata, exampleMethods(indexType, metadata.exampleMethods), "")}
 @end
 
 @private exampleMethods(indexType, methods)
@@ -74,10 +74,6 @@
     @end
     ```
   @end
-@end
-
-@private installationLines(metadata)
-  $ gem install {@metadata.identifier}
 @end
 
 @private body(index)

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_message_library.baseline
@@ -1442,6 +1442,68 @@ module Google
     end
   end
 end
+============== file: lib/library/v1/doc/overview.rb ==============
+# Copyright 2017, Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# rubocop:disable LineLength
+
+##
+# # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+#
+# [Google Example Library API][Product Documentation]:
+# A simple Google Example Library API.
+# - [Product Documentation][]
+#
+# ## Quick Start
+# In order to use this library, you first need to go through the following
+# steps:
+#
+# 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
+# 2. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
+# 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
+#
+# ### Installation
+# ```
+# $ gem install library
+# ```
+#
+# ### Preview
+# #### LibraryServiceClient
+# ```rb
+# require "library"
+#
+# library_service_client = Library.new
+# formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
+# rating = :GOOD
+# book = { rating: rating }
+# response = library_service_client.update_book(formatted_name, book)
+# ```
+#
+# ### Next Steps
+# - Read the [Google Example Library API Product documentation][Product Documentation]
+#   to learn more about the product and see How-to Guides.
+# - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md)
+#   to see the full list of Cloud APIs that we cover.
+#
+# [Product Documentation]: https://cloud.google.com/library
+#
+#
+module Library
+  module V1
+  end
+end
 ============== file: lib/library/v1/doc/shared_type.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_version_index_library.baseline
@@ -33,11 +33,6 @@ require "pathname"
 # 2. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
 # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
-# ### Installation
-# ```
-# $ gem install library
-# ```
-#
 # ### Preview
 # #### LibraryServiceClient
 # ```rb
@@ -162,11 +157,6 @@ require "library/v1/library_service_client"
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
 # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
-#
-# ### Installation
-# ```
-# $ gem install library
-# ```
 #
 # ### Preview
 # #### LibraryServiceClient

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_library.baseline
@@ -33,11 +33,6 @@ require "pathname"
 # 2. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
 # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
-# ### Installation
-# ```
-# $ gem install library
-# ```
-#
 # ### Preview
 # #### LibraryServiceClient
 # ```rb
@@ -162,11 +157,6 @@ require "library/v1/library_service_client"
 # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
 # 2. [Enable the Google Example Library API.](https://console.cloud.google.com/apis/api/library)
 # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
-#
-# ### Installation
-# ```
-# $ gem install library
-# ```
 #
 # ### Preview
 # #### LibraryServiceClient

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_longrunning.baseline
@@ -46,11 +46,6 @@ require "google/longrunning/operations_client"
 # 2. [Enable the Google Long Running Operations API.](https://console.cloud.google.com/apis/api/longrunning)
 # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
 #
-# ### Installation
-# ```
-# $ gem install google
-# ```
-#
 # ### Next Steps
 # - Read the [Google Long Running Operations API Product documentation][Product Documentation]
 #   to learn more about the product and see How-to Guides.

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_version_index_multiple_services.baseline
@@ -35,11 +35,6 @@ module Google
   # 2. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
   # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
   #
-  # ### Installation
-  # ```
-  # $ gem install google-example
-  # ```
-  #
   # ### Next Steps
   # - Read the [Google Example API Product documentation][Product Documentation]
   #   to learn more about the product and see How-to Guides.
@@ -188,11 +183,6 @@ module Google
   # 1. [Select or create a Cloud Platform project.](https://console.cloud.google.com/project)
   # 2. [Enable the Google Example API.](https://console.cloud.google.com/apis/api/multiple_services)
   # 3. [Setup Authentication.](https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-cloud/master/guides/authentication)
-  #
-  # ### Installation
-  # ```
-  # $ gem install google-example
-  # ```
   #
   # ### Next Steps
   # - Read the [Google Example API Product documentation][Product Documentation]


### PR DESCRIPTION
This overview serves as the landing page for documentation for
GAPIC-only APIs. Previously, it was not rendered due to the same
feature shortcoming in the jsondoc tool that motivated

  https://github.com/googleapis/toolkit/pull/1544

Retain readme text in the version index to serve as a per-version
code level example, but remove installation instructions, since
installation is not API version-dependent.