### PR TITLE
NodeJS: Hand-edit fixes.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -49,12 +49,13 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
     imports.add(createImport("configData", "./" + configModule));
     imports.add(createImport("extend", "extend"));
     imports.add(createImport("gax", "google-gax"));
-    imports.add(createImport("googleProtoFiles", "google-proto-files"));
     if (new GrpcStubTransformer().generateGrpcStubs(context).size() > 1) {
       imports.add(createImport("merge", "lodash.merge"));
     }
     imports.add(createImport("path", "path"));
-    imports.add(createImport("protobuf", "protobufjs"));
+    if (context.getInterfaceConfig().hasLongRunningOperations()) {
+      imports.add(createImport("protobuf", "protobufjs"));
+    }
     return imports.build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -218,8 +218,20 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
       dependencies.add(
           PackageDependencyView.create("lodash.merge", VersionBound.create("4.6.0", "")));
     }
-    dependencies.add(PackageDependencyView.create("protobufjs", VersionBound.create("6.8.0", "")));
+    if (hasLongrunning(model, productConfig)) {
+      dependencies.add(
+          PackageDependencyView.create("protobufjs", VersionBound.create("6.8.0", "")));
+    }
     return dependencies.build();
+  }
+
+  private boolean hasLongrunning(Model model, GapicProductConfig productConfig) {
+    for (Interface apiInterface : new InterfaceView().getElementIterable(model)) {
+      if (productConfig.getInterfaceConfig(apiInterface).hasLongRunningOperations()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private boolean hasMixinApis(Model model, GapicProductConfig productConfig) {

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -33,7 +33,6 @@
     @end
   }
 
-  {@index.apiVersion}.GAPIC_VERSION = '{@index.toolkitVersion}';
   {@index.apiVersion}.SERVICE_ADDRESS = {@index.primaryService.clientName}.SERVICE_ADDRESS;
   @if index.hasMultipleServices
     {@index.apiVersion}.ALL_SCOPES = union(

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -14,7 +14,6 @@
    {@comments(fileHeader.licenseLines)}
    {@editingInstructions(protoFilename)}
    */
-  /* jscs: disable maximumLineLength */
   'use strict';
 
   {@importSection(fileHeader.importSection)}

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -14,7 +14,6 @@
    {@comments(fileHeader.licenseLines)}
    {@editingInstructions(protoFilename)}
    */
-  /* TODO: introduce line-wrapping so that it never exceeds the limit. */
   /* jscs: disable maximumLineLength */
   'use strict';
 

--- a/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
@@ -30,7 +30,6 @@
     {@index.apiVersion}: require('./{@index.apiVersion}')
   };
   var gaxGrpc = require('google-gax').grpc();
-  var googleProtoFiles = require('google-proto-files');
   var path = require('path');
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_index_library.baseline
@@ -28,7 +28,6 @@ function v1(options) {
   return libraryServiceClient(gaxGrpc);
 }
 
-v1.GAPIC_VERSION = '0.0.5';
 v1.SERVICE_ADDRESS = libraryServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = libraryServiceClient.ALL_SCOPES;
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
@@ -24,7 +24,6 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./library_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
@@ -24,14 +24,12 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* TODO: introduce line-wrapping so that it never exceeds the limit. */
 /* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./library_service_client_config');
 var extend = require('extend');
 var gax = require('google-gax');
-var googleProtoFiles = require('google-proto-files');
 var merge = require('lodash.merge');
 var path = require('path');
 var protobuf = require('protobufjs');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_package_library.baseline
@@ -28,7 +28,6 @@
   "dependencies": {
     "extend": "^3.0",
     "google-gax": "^0.14.0",
-    "google-proto-files": "^0.8.2",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_version_index_library.baseline
@@ -21,7 +21,6 @@ var gapic = {
   v1: require('./v1')
 };
 var gaxGrpc = require('google-gax').grpc();
-var googleProtoFiles = require('google-proto-files');
 var path = require('path');
 
 const VERSION = require('../package.json').version;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_index_library.baseline
@@ -28,7 +28,6 @@ function v1(options) {
   return libraryServiceClient(gaxGrpc);
 }
 
-v1.GAPIC_VERSION = '0.0.5';
 v1.SERVICE_ADDRESS = libraryServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = libraryServiceClient.ALL_SCOPES;
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_index_multiple_services.baseline
@@ -33,7 +33,6 @@ function v1(options) {
   return result;
 }
 
-v1.GAPIC_VERSION = '0.0.5';
 v1.SERVICE_ADDRESS = incrementerServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = union(
   incrementerServiceClient.ALL_SCOPES,

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_index_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_index_no_path_templates.baseline
@@ -28,7 +28,6 @@ function v1(options) {
   return noTemplatesApiServiceClient(gaxGrpc);
 }
 
-v1.GAPIC_VERSION = '0.0.5';
 v1.SERVICE_ADDRESS = noTemplatesApiServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = noTemplatesApiServiceClient.ALL_SCOPES;
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
@@ -24,7 +24,6 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./library_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
@@ -24,14 +24,12 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* TODO: introduce line-wrapping so that it never exceeds the limit. */
 /* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./library_service_client_config');
 var extend = require('extend');
 var gax = require('google-gax');
-var googleProtoFiles = require('google-proto-files');
 var merge = require('lodash.merge');
 var path = require('path');
 var protobuf = require('protobufjs');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_multiple_services.baseline
@@ -24,16 +24,13 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* TODO: introduce line-wrapping so that it never exceeds the limit. */
 /* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./decrementer_service_client_config');
 var extend = require('extend');
 var gax = require('google-gax');
-var googleProtoFiles = require('google-proto-files');
 var path = require('path');
-var protobuf = require('protobufjs');
 
 var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
 
@@ -209,16 +206,13 @@ module.exports.ALL_SCOPES = ALL_SCOPES;
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* TODO: introduce line-wrapping so that it never exceeds the limit. */
 /* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./incrementer_service_client_config');
 var extend = require('extend');
 var gax = require('google-gax');
-var googleProtoFiles = require('google-proto-files');
 var path = require('path');
-var protobuf = require('protobufjs');
 
 var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_multiple_services.baseline
@@ -24,7 +24,6 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./decrementer_service_client_config');
@@ -206,7 +205,6 @@ module.exports.ALL_SCOPES = ALL_SCOPES;
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./incrementer_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_no_path_templates.baseline
@@ -24,16 +24,13 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* TODO: introduce line-wrapping so that it never exceeds the limit. */
 /* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./no_templates_api_service_client_config');
 var extend = require('extend');
 var gax = require('google-gax');
-var googleProtoFiles = require('google-proto-files');
 var path = require('path');
-var protobuf = require('protobufjs');
 
 var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_no_path_templates.baseline
@@ -24,7 +24,6 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
-/* jscs: disable maximumLineLength */
 'use strict';
 
 var configData = require('./no_templates_api_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_package_library.baseline
@@ -28,7 +28,6 @@
   "dependencies": {
     "extend": "^3.0",
     "google-gax": "^0.14.0",
-    "google-proto-files": "^0.8.2",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
     "protobufjs": "^6.8.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_package_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_package_multiple_services.baseline
@@ -28,10 +28,8 @@
   "dependencies": {
     "extend": "^3.0",
     "google-gax": "^0.14.0",
-    "google-proto-files": "^0.8.2",
     "google-some-other-package-v1": "^0.2.1",
-    "lodash.union": "^4.6.0",
-    "protobufjs": "^6.8.0"
+    "lodash.union": "^4.6.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0",

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_package_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_package_no_path_templates.baseline
@@ -28,9 +28,7 @@
   "dependencies": {
     "extend": "^3.0",
     "google-gax": "^0.14.0",
-    "google-proto-files": "^0.8.2",
-    "google-some-other-package-v1": "^0.2.1",
-    "protobufjs": "^6.8.0"
+    "google-some-other-package-v1": "^0.2.1"
   },
   "devDependencies": {
     "mocha": "^3.2.0",

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_version_index_library.baseline
@@ -21,7 +21,6 @@ var gapic = {
   v1: require('./v1')
 };
 var gaxGrpc = require('google-gax').grpc();
-var googleProtoFiles = require('google-proto-files');
 var path = require('path');
 
 const VERSION = require('../package.json').version;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_version_index_multiple_services.baseline
@@ -21,7 +21,6 @@ var gapic = {
   v1: require('./v1')
 };
 var gaxGrpc = require('google-gax').grpc();
-var googleProtoFiles = require('google-proto-files');
 var path = require('path');
 
 const VERSION = require('../package.json').version;

--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
@@ -95,9 +95,6 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.5.0'
     upper: '2.0dev'
-  nodejs:
-    name_override: google-proto-files
-    lower: '0.8.2'
   ruby:
     name_override: googleapis-common-protos
     lower: '1.3.1'

--- a/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/longrunning_pkg.yaml
@@ -92,9 +92,6 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.5.0'
     upper: '2.0dev'
-  nodejs:
-    name_override: google-proto-files
-    lower: '0.8.2'
   ruby:
     name_override: googleapis-common-protos
     lower: '1.3.1'

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
@@ -95,9 +95,6 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.5.0'
     upper: '2.0dev'
-  nodejs:
-    name_override: google-proto-files
-    lower: '0.8.2'
   ruby:
     name_override: googleapis-common-protos
     lower: '1.3.1'

--- a/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
@@ -91,9 +91,6 @@ google-common-protos_version:
     name_override: googleapis-common-protos
     lower: '1.5.0'
     upper: '2.0dev'
-  nodejs:
-    name_override: google-proto-files
-    lower: '0.8.2'
   ruby:
     name_override: googleapis-common-protos
     lower: '1.3.1'


### PR DESCRIPTION
Removes usage of protobufjs since thats in gax now and that line of code exporting toolkit version.