### PR TITLE
NodeJS: Docs. Update to add member tags and remove external semantics.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
@@ -54,6 +54,7 @@ public class GrpcElementDocTransformer {
       doc.lines(namer.getDocLines(message));
       doc.properties(generateMessagePropertyDocs(typeTable, namer, message.getFields()));
       doc.elementDocs(generateElementDocs(typeTable, namer, message));
+      doc.packageName(message.getFile().getFullName());
       messageDocs.add(doc.build());
     }
     return messageDocs.build();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceDocTransformer.java
@@ -29,6 +29,7 @@ import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoFile;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
@@ -77,6 +78,12 @@ public class NodeJSGapicSurfaceDocTransformer implements ModelToViewTransformer 
     String version = namer.getApiWrapperModuleVersion();
     boolean hasVersion = version != null && !version.isEmpty();
     String path = hasVersion ? "src/" + version + "/doc/" : "src/doc/";
-    return path + "doc_" + namer.getProtoFileName(file);
+    String packageDirPath = file.getFullName().replace('.', '/');
+    if (!Strings.isNullOrEmpty(packageDirPath)) {
+      packageDirPath += "/";
+    } else {
+      packageDirPath = "";
+    }
+    return path + packageDirPath + "doc_" + namer.getProtoFileName(file);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceDocTransformer.java
@@ -70,7 +70,6 @@ public class NodeJSGapicSurfaceDocTransformer implements ModelToViewTransformer 
         fileHeaderTransformer.generateFileHeader(
             productConfig, ImportSectionView.newBuilder().build(), namer));
     doc.elementDocs(grpcElementDocTransformer.generateElementDocs(typeTable, namer, file));
-    doc.isExternalFile(commentReformatter.isExternalFile(file));
     return doc.build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -365,13 +365,9 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   @Override
   public String getProtoFileName(ProtoFile file) {
     String filePath = file.getSimpleName().replace(".proto", ".js");
-    if (commentReformatter.isExternalFile(file)) {
-      filePath = filePath.replaceAll("/", "_");
-    } else {
-      int lastSlash = filePath.lastIndexOf('/');
-      if (lastSlash >= 0) {
-        filePath = filePath.substring(lastSlash + 1);
-      }
+    int lastSlash = filePath.lastIndexOf('/');
+    if (lastSlash >= 0) {
+      filePath = filePath.substring(lastSlash + 1);
     }
     return filePath;
   }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -278,6 +278,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
         messageView.lines(namer.getDocLines(message));
         messageView.properties(ImmutableList.<ParamDocView>of());
         messageView.elementDocs(elementDocs);
+        messageView.packageName(message.getFile().getFullName());
         elements.add(messageView.build());
       }
     }

--- a/src/main/java/com/google/api/codegen/util/js/JSCommentReformatter.java
+++ b/src/main/java/com/google/api/codegen/util/js/JSCommentReformatter.java
@@ -37,6 +37,7 @@ public class JSCommentReformatter implements CommentReformatter {
 
   public String getLinkedElementName(ProtoElement element) {
     String simpleName = element.getSimpleName();
-    return String.format("[%s]{@link %s}", simpleName, simpleName);
+    String packageName = element.getFile().getFullName();
+    return String.format("[%s]{@link %s.%s}", simpleName, packageName, simpleName);
   }
 }

--- a/src/main/java/com/google/api/codegen/util/js/JSCommentReformatter.java
+++ b/src/main/java/com/google/api/codegen/util/js/JSCommentReformatter.java
@@ -18,8 +18,6 @@ import com.google.api.codegen.util.CommentReformatter;
 import com.google.api.codegen.util.CommentTransformer;
 import com.google.api.codegen.util.LinkPattern;
 import com.google.api.tools.framework.model.ProtoElement;
-import com.google.api.tools.framework.model.ProtoFile;
-import com.google.common.collect.ImmutableSet;
 
 public class JSCommentReformatter implements CommentReformatter {
 
@@ -38,32 +36,7 @@ public class JSCommentReformatter implements CommentReformatter {
   }
 
   public String getLinkedElementName(ProtoElement element) {
-    if (isExternalFile(element.getFile())) {
-      String fullName = element.getFullName();
-      return String.format("[%s]{@link external:\"%s\"}", fullName, fullName);
-    } else {
-      String simpleName = element.getSimpleName();
-      return String.format("[%s]{@link %s}", simpleName, simpleName);
-    }
+    String simpleName = element.getSimpleName();
+    return String.format("[%s]{@link %s}", simpleName, simpleName);
   }
-
-  public boolean isExternalFile(ProtoFile file) {
-    String filePath = file.getSimpleName();
-    for (String commonPath : COMMON_PROTO_PATHS) {
-      if (filePath.startsWith(commonPath)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static final ImmutableSet<String> COMMON_PROTO_PATHS =
-      ImmutableSet.of(
-          "google/api",
-          "google/bytestream",
-          "google/logging/type",
-          "google/longrunning",
-          "google/protobuf",
-          "google/rpc",
-          "google/type");
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/GrpcDocView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/GrpcDocView.java
@@ -30,13 +30,11 @@ public abstract class GrpcDocView implements ViewModel {
 
   public abstract List<GrpcElementDocView> elementDocs();
 
-  public abstract boolean isExternalFile();
-
   @Nullable
   public abstract List<ModuleView> modules();
 
   public static Builder newBuilder() {
-    return new AutoValue_GrpcDocView.Builder().isExternalFile(false);
+    return new AutoValue_GrpcDocView.Builder();
   }
 
   @Override
@@ -53,8 +51,6 @@ public abstract class GrpcDocView implements ViewModel {
     public abstract Builder fileHeader(FileHeaderView val);
 
     public abstract Builder elementDocs(List<GrpcElementDocView> val);
-
-    public abstract Builder isExternalFile(boolean externalFile);
 
     public abstract Builder modules(List<ModuleView> val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/GrpcMessageDocView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/GrpcMessageDocView.java
@@ -31,6 +31,8 @@ public abstract class GrpcMessageDocView implements GrpcElementDocView {
 
   public abstract String fileUrl();
 
+  public abstract String packageName();
+
   public static Builder newBuilder() {
     return new AutoValue_GrpcMessageDocView.Builder();
   }
@@ -52,6 +54,8 @@ public abstract class GrpcMessageDocView implements GrpcElementDocView {
     public abstract Builder elementDocs(List<GrpcElementDocView> val);
 
     public abstract Builder fileUrl(String val);
+
+    public abstract Builder packageName(String val);
 
     public abstract GrpcMessageDocView build();
   }

--- a/src/main/resources/com/google/api/codegen/nodejs/message.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/message.snip
@@ -4,11 +4,7 @@
   {@licenseSection(doc.fileHeader)}
 
   @join elementDoc : doc.elementDocs on BREAK.add(BREAK)
-    @if doc.isExternalFile
-      {@documentExternalElement(elementDoc)}
-    @else
-      {@documentElement(elementDoc, toplevelHeader(elementDoc), semicolon())}
-    @end
+    {@documentElement(elementDoc, toplevelHeader(elementDoc), semicolon())}
   @end
 @end
 
@@ -53,6 +49,7 @@
      {@properties(message)}
    @end
    * @@typedef {@message.name}
+   * @@member {@message.packageName}
    * @@see [{@message.fullName} definition in proto format]{@@link {@message.fileUrl}}
    */
   {@header}
@@ -87,20 +84,6 @@
   }{@footer}
 @end
 
-@private documentExternalMessage(message)
-  /**
-   @if message.lines
-     {@comments(message.lines)}
-     *
-   @end
-   * @@external "{@message.fullName}"
-   @if properties(message)
-     {@properties(message)}
-   @end
-   * @@see [{@message.fullName} definition in proto format]{@@link {@message.fileUrl}}
-   */
-@end
-
 @private properties(message)
   @join property : message.properties
     * @@property {{@property.typeName}} {@property.paramName}
@@ -128,12 +111,3 @@
   @end
 @end
 
-@private documentExternalElement(doc)
-  @switch doc.type
-  @case "GrpcMessageDocView"
-    {@documentExternalMessage(doc)}
-  @case "GrpcEnumDocView"
-  @default
-    {@unhandledCase()}
-  @end
-@end

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
@@ -1070,7 +1070,7 @@ LibraryServiceClient.prototype.deleteBook = function(request, options, callback)
  * @param {Object=} request.updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
  *
- *   This object should have the same structure as [google.protobuf.FieldMask]{@link external:"google.protobuf.FieldMask"}
+ *   This object should have the same structure as [FieldMask]{@link FieldMask}
  * @param {Object=} request.physicalMask
  *   To test Python import clash resolution.
  *

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_main_library.baseline
@@ -361,16 +361,16 @@ LibraryServiceClient.prototype.getProjectId = function(callback) {
  * @param {Object} request.shelf
  *   The shelf to create.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link Shelf}.
+ *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -414,18 +414,18 @@ LibraryServiceClient.prototype.createShelf = function(request, options, callback
  * @param {Object=} request.message
  *   Field to verify that message-type query parameter gets flattened.
  *
- *   This object should have the same structure as [SomeMessage]{@link SomeMessage}
+ *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
  * @param {Object=} request.stringBuilder
- *   This object should have the same structure as [StringBuilder]{@link StringBuilder}
+ *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link Shelf}.
+ *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -473,20 +473,20 @@ LibraryServiceClient.prototype.getShelf = function(request, options, callback) {
  * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is Array of [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is Array of [Shelf]{@link google.example.library.v1.Shelf}.
  *
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListShelvesResponse]{@link ListShelvesResponse}.
+ *   the raw response object of an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Shelf]{@link Shelf}.
+ *   The first element of the array is Array of [Shelf]{@link google.example.library.v1.Shelf}.
  *
  *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Shelf]{@link Shelf} in a single response.
+ *   The first element is Array of [Shelf]{@link google.example.library.v1.Shelf} in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [ListShelvesResponse]{@link ListShelvesResponse}.
+ *   an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -566,7 +566,7 @@ LibraryServiceClient.prototype.listShelves = function(request, options, callback
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits an object representing [Shelf]{@link Shelf} on 'data' event.
+ *   An object stream which emits an object representing [Shelf]{@link google.example.library.v1.Shelf} on 'data' event.
  *
  * @example
  *
@@ -651,9 +651,9 @@ LibraryServiceClient.prototype.deleteShelf = function(request, options, callback
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link Shelf}.
+ *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -700,16 +700,16 @@ LibraryServiceClient.prototype.mergeShelves = function(request, options, callbac
  * @param {Object} request.book
  *   The book to create.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -754,15 +754,15 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  * @param {Object} request.shelf
  *   The shelf in which the series is created.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  * @param {Object[]} request.books
  *   The books to publish in the series.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  * @param {Object} request.seriesUuid
  *   Uniquely identifies the series to the publishing house.
  *
- *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
+ *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
  * @param {number=} request.edition
  *   The edition of the series
  * @param {boolean=} request.reviewCopy
@@ -773,9 +773,9 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link PublishSeriesResponse}.
+ *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [PublishSeriesResponse]{@link PublishSeriesResponse}.
+ *   The first element of the array is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -830,9 +830,9 @@ LibraryServiceClient.prototype.publishSeries = function(request, options, callba
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -885,20 +885,20 @@ LibraryServiceClient.prototype.getBook = function(request, options, callback) {
  * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is Array of [Book]{@link Book}.
+ *   The second parameter to the callback is Array of [Book]{@link google.example.library.v1.Book}.
  *
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListBooksResponse]{@link ListBooksResponse}.
+ *   the raw response object of an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Book]{@link Book}.
+ *   The first element of the array is Array of [Book]{@link google.example.library.v1.Book}.
  *
  *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Book]{@link Book} in a single response.
+ *   The first element is Array of [Book]{@link google.example.library.v1.Book} in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [ListBooksResponse]{@link ListBooksResponse}.
+ *   an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -990,7 +990,7 @@ LibraryServiceClient.prototype.listBooks = function(request, options, callback) 
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits an object representing [Book]{@link Book} on 'data' event.
+ *   An object stream which emits an object representing [Book]{@link google.example.library.v1.Book} on 'data' event.
  *
  * @example
  *
@@ -1066,24 +1066,24 @@ LibraryServiceClient.prototype.deleteBook = function(request, options, callback)
  * @param {Object} request.book
  *   The book to update with.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  * @param {Object=} request.updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
  *
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
  * @param {Object=} request.physicalMask
  *   To test Python import clash resolution.
  *
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1135,9 +1135,9 @@ LibraryServiceClient.prototype.updateBook = function(request, options, callback)
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1197,7 +1197,7 @@ LibraryServiceClient.prototype.moveBook = function(request, options, callback) {
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListStringsResponse]{@link ListStringsResponse}.
+ *   the raw response object of an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is Array of string.
  *
@@ -1205,7 +1205,7 @@ LibraryServiceClient.prototype.moveBook = function(request, options, callback) {
  *   The first element is Array of string in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [ListStringsResponse]{@link ListStringsResponse}.
+ *   an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -1323,7 +1323,7 @@ LibraryServiceClient.prototype.listStringsStream = function(request, options) {
  *   The request object that will be sent.
  * @param {string} request.name
  * @param {Object[]} request.comments
- *   This object should have the same structure as [Comment]{@link Comment}
+ *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
@@ -1383,9 +1383,9 @@ LibraryServiceClient.prototype.addComments = function(request, options, callback
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [BookFromArchive]{@link BookFromArchive}.
+ *   The second parameter to the callback is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromArchive]{@link BookFromArchive}.
+ *   The first element of the array is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1433,9 +1433,9 @@ LibraryServiceClient.prototype.getBookFromArchive = function(request, options, c
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1485,9 +1485,9 @@ LibraryServiceClient.prototype.getBookFromAnywhere = function(request, options, 
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1581,7 +1581,7 @@ LibraryServiceClient.prototype.updateBookIndex = function(request, options, call
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits [StreamShelvesResponse]{@link StreamShelvesResponse} on 'data' event.
+ *   An object stream which emits [StreamShelvesResponse]{@link google.example.library.v1.StreamShelvesResponse} on 'data' event.
  *
  * @example
  *
@@ -1618,7 +1618,7 @@ LibraryServiceClient.prototype.streamShelves = function(request, options) {
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits [Book]{@link Book} on 'data' event.
+ *   An object stream which emits [Book]{@link google.example.library.v1.Book} on 'data' event.
  *
  * @example
  *
@@ -1650,8 +1650,8 @@ LibraryServiceClient.prototype.streamBooks = function(request, options) {
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing [DiscussBookRequest]{@link DiscussBookRequest} for write() method, and
- *   will emit objects representing [Comment]{@link Comment} on 'data' event asynchronously.
+ *   representing [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method, and
+ *   will emit objects representing [Comment]{@link google.example.library.v1.Comment} on 'data' event asynchronously.
  *
  * @example
  *
@@ -1689,9 +1689,9 @@ LibraryServiceClient.prototype.discussBook = function(options) {
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Comment]{@link Comment}.
+ *   The second parameter to the callback is an object representing [Comment]{@link google.example.library.v1.Comment}.
  * @returns {Stream} - A writable stream which accepts objects representing
- *   [DiscussBookRequest]{@link DiscussBookRequest} for write() method.
+ *   [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method.
  *
  * @example
  *
@@ -1749,7 +1749,7 @@ LibraryServiceClient.prototype.monologAboutBook = function(options, callback) {
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [FindRelatedBooksResponse]{@link FindRelatedBooksResponse}.
+ *   the raw response object of an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is Array of string.
  *
@@ -1757,7 +1757,7 @@ LibraryServiceClient.prototype.monologAboutBook = function(options, callback) {
  *   The first element is Array of string in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [FindRelatedBooksResponse]{@link FindRelatedBooksResponse}.
+ *   an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -1908,9 +1908,9 @@ LibraryServiceClient.prototype.findRelatedBooksStream = function(request, option
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [AddTagResponse]{@link AddTagResponse}.
+ *   The second parameter to the callback is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddTagResponse]{@link AddTagResponse}.
+ *   The first element of the array is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1964,9 +1964,9 @@ LibraryServiceClient.prototype.addTag = function(request, options, callback) {
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [AddLabelResponse]{@link AddLabelResponse}.
+ *   The second parameter to the callback is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddLabelResponse]{@link AddLabelResponse}.
+ *   The first element of the array is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -2192,11 +2192,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number} request.requiredSingularDouble
  * @param {boolean} request.requiredSingularBool
  * @param {number} request.requiredSingularEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string} request.requiredSingularString
  * @param {string} request.requiredSingularBytes
  * @param {Object} request.requiredSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string} request.requiredSingularResourceName
  * @param {string} request.requiredSingularResourceNameOneof
  * @param {number} request.requiredSingularFixed32
@@ -2207,11 +2207,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number[]} request.requiredRepeatedDouble
  * @param {boolean[]} request.requiredRepeatedBool
  * @param {number[]} request.requiredRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string[]} request.requiredRepeatedString
  * @param {string[]} request.requiredRepeatedBytes
  * @param {Object[]} request.requiredRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string[]} request.requiredRepeatedResourceName
  * @param {string[]} request.requiredRepeatedResourceNameOneof
  * @param {number[]} request.requiredRepeatedFixed32
@@ -2223,11 +2223,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number=} request.optionalSingularDouble
  * @param {boolean=} request.optionalSingularBool
  * @param {number=} request.optionalSingularEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string=} request.optionalSingularString
  * @param {string=} request.optionalSingularBytes
  * @param {Object=} request.optionalSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string=} request.optionalSingularResourceName
  * @param {string=} request.optionalSingularResourceNameOneof
  * @param {number=} request.optionalSingularFixed32
@@ -2238,11 +2238,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number[]=} request.optionalRepeatedDouble
  * @param {boolean[]=} request.optionalRepeatedBool
  * @param {number[]=} request.optionalRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string[]=} request.optionalRepeatedString
  * @param {string[]=} request.optionalRepeatedBytes
  * @param {Object[]=} request.optionalRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string[]=} request.optionalRepeatedResourceName
  * @param {string[]=} request.optionalRepeatedResourceNameOneof
  * @param {number[]=} request.optionalRepeatedFixed32
@@ -2254,9 +2254,9 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link TestOptionalRequiredFlatteningParamsResponse}.
+ *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link TestOptionalRequiredFlatteningParamsResponse}.
+ *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_message_library.baseline
@@ -1,47 +1,4 @@
-============== file: src/v1/doc/doc_field_mask.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * @property {number[]} materials
- *   The number should be among the values of [Material]{@link Material}
- *
- * @typedef FieldMask
- * @see [google.example.library.v1.FieldMask definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/field_mask.proto}
- */
-var FieldMask = {
-  // This is for documentation. Actual contents will be loaded by gRPC.
-
-  /**
-   * @enum {number}
-   */
-  Material: {
-    PAPIER_MACHE: 0,
-    WOOD: 1,
-    PORCELAIN: 2,
-    SEQUINS: 3,
-    CARDBOARD: 4
-  }
-};
-============== file: src/v1/doc/doc_google_protobuf_any.js ==============
+============== file: src/v1/doc/doc_any.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -144,7 +101,6 @@ var FieldMask = {
  *       "value": "1.212s"
  *     }
  *
- * @external "google.protobuf.Any"
  * @property {string} typeUrl
  *   A URL/resource name whose content describes the type of the
  *   serialized protocol buffer message.
@@ -171,9 +127,14 @@ var FieldMask = {
  * @property {string} value
  *   Must be a valid serialized protocol buffer of the above specified type.
  *
+ * @typedef Any
+ * @member google.protobuf
  * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
  */
-============== file: src/v1/doc/doc_google_protobuf_duration.js ==============
+var Any = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/doc_duration.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -255,7 +216,6 @@ var FieldMask = {
  * be expressed in JSON format as "3.000000001s", and 3 seconds and 1
  * microsecond should be expressed in JSON format as "3.000001s".
  *
- * @external "google.protobuf.Duration"
  * @property {number} seconds
  *   Signed seconds of the span of time. Must be from -315,576,000,000
  *   to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -269,9 +229,14 @@ var FieldMask = {
  *   of the same sign as the `seconds` field. Must be from -999,999,999
  *   to +999,999,999 inclusive.
  *
+ * @typedef Duration
+ * @member google.protobuf
  * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
  */
-============== file: src/v1/doc/doc_google_protobuf_field_mask.js ==============
+var Duration = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/doc_field_mask.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -496,438 +461,16 @@ var FieldMask = {
  * Note that oneof type names ("test_oneof" in this case) cannot be used in
  * paths.
  *
- * @external "google.protobuf.FieldMask"
  * @property {string[]} paths
  *   The set of field mask paths.
  *
+ * @typedef FieldMask
+ * @member google.protobuf
  * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
  */
-============== file: src/v1/doc/doc_google_protobuf_struct.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * `Struct` represents a structured data value, consisting of fields
- * which map to dynamically typed values. In some languages, `Struct`
- * might be supported by a native representation. For example, in
- * scripting languages like JS a struct is represented as an
- * object. The details of that representation are described together
- * with the proto support for the language.
- *
- * The JSON representation for `Struct` is JSON object.
- *
- * @external "google.protobuf.Struct"
- * @property {Object.<string, Object>} fields
- *   Unordered map of dynamically typed values.
- *
- * @see [google.protobuf.Struct definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
- */
-
-/**
- * `Value` represents a dynamically typed value which can be either
- * null, a number, a string, a boolean, a recursive struct value, or a
- * list of values. A producer of value is expected to set one of that
- * variants, absence of any variant indicates an error.
- *
- * The JSON representation for `Value` is JSON value.
- *
- * @external "google.protobuf.Value"
- * @property {number} nullValue
- *   Represents a null value.
- *
- *   The number should be among the values of [google.protobuf.NullValue]{@link external:"google.protobuf.NullValue"}
- *
- * @property {number} numberValue
- *   Represents a double value.
- *
- * @property {string} stringValue
- *   Represents a string value.
- *
- * @property {boolean} boolValue
- *   Represents a boolean value.
- *
- * @property {Object} structValue
- *   Represents a structured value.
- *
- *   This object should have the same structure as [google.protobuf.Struct]{@link external:"google.protobuf.Struct"}
- *
- * @property {Object} listValue
- *   Represents a repeated `Value`.
- *
- *   This object should have the same structure as [google.protobuf.ListValue]{@link external:"google.protobuf.ListValue"}
- *
- * @see [google.protobuf.Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
- */
-
-/**
- * `ListValue` is a wrapper around a repeated field of values.
- *
- * The JSON representation for `ListValue` is JSON array.
- *
- * @external "google.protobuf.ListValue"
- * @property {Object[]} values
- *   Repeated field of dynamically typed values.
- *
- *   This object should have the same structure as [google.protobuf.Value]{@link external:"google.protobuf.Value"}
- *
- * @see [google.protobuf.ListValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
- */
-
-
-============== file: src/v1/doc/doc_google_protobuf_timestamp.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * A Timestamp represents a point in time independent of any time zone
- * or calendar, represented as seconds and fractions of seconds at
- * nanosecond resolution in UTC Epoch time. It is encoded using the
- * Proleptic Gregorian Calendar which extends the Gregorian calendar
- * backwards to year one. It is encoded assuming all minutes are 60
- * seconds long, i.e. leap seconds are "smeared" so that no leap second
- * table is needed for interpretation. Range is from
- * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
- * By restricting to that range, we ensure that we can convert to
- * and from  RFC 3339 date strings.
- * See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
- *
- * # Examples
- *
- * Example 1: Compute Timestamp from POSIX `time()`.
- *
- *     Timestamp timestamp;
- *     timestamp.set_seconds(time(NULL));
- *     timestamp.set_nanos(0);
- *
- * Example 2: Compute Timestamp from POSIX `gettimeofday()`.
- *
- *     struct timeval tv;
- *     gettimeofday(&tv, NULL);
- *
- *     Timestamp timestamp;
- *     timestamp.set_seconds(tv.tv_sec);
- *     timestamp.set_nanos(tv.tv_usec * 1000);
- *
- * Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
- *
- *     FILETIME ft;
- *     GetSystemTimeAsFileTime(&ft);
- *     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
- *
- *     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
- *     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
- *     Timestamp timestamp;
- *     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
- *     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
- *
- * Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
- *
- *     long millis = System.currentTimeMillis();
- *
- *     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
- *         .setNanos((int) ((millis % 1000) * 1000000)).build();
- *
- *
- * Example 5: Compute Timestamp from current time in Python.
- *
- *     timestamp = Timestamp()
- *     timestamp.GetCurrentTime()
- *
- * # JSON Mapping
- *
- * In JSON format, the Timestamp type is encoded as a string in the
- * [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
- * format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
- * where {year} is always expressed using four digits while {month}, {day},
- * {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
- * seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
- * are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
- * is required, though only UTC (as indicated by "Z") is presently supported.
- *
- * For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
- * 01:30 UTC on January 15, 2017.
- *
- * In JavaScript, one can convert a Date object to this format using the
- * standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
- * method. In Python, a standard `datetime.datetime` object can be converted
- * to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
- * with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
- * can use the Joda Time's [`ISODateTimeFormat.dateTime()`](https://cloud.google.com
- * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime())
- * to obtain a formatter capable of generating timestamps in this format.
- *
- * @external "google.protobuf.Timestamp"
- * @property {number} seconds
- *   Represents seconds of UTC time since Unix epoch
- *   1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
- *   9999-12-31T23:59:59Z inclusive.
- *
- * @property {number} nanos
- *   Non-negative fractions of a second at nanosecond resolution. Negative
- *   second values with fractions must still have non-negative nanos values
- *   that count forward in time. Must be from 0 to 999,999,999
- *   inclusive.
- *
- * @see [google.protobuf.Timestamp definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto}
- */
-============== file: src/v1/doc/doc_google_protobuf_wrappers.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * Wrapper message for `double`.
- *
- * The JSON representation for `DoubleValue` is JSON number.
- *
- * @external "google.protobuf.DoubleValue"
- * @property {number} value
- *   The double value.
- *
- * @see [google.protobuf.DoubleValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `float`.
- *
- * The JSON representation for `FloatValue` is JSON number.
- *
- * @external "google.protobuf.FloatValue"
- * @property {number} value
- *   The float value.
- *
- * @see [google.protobuf.FloatValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `int64`.
- *
- * The JSON representation for `Int64Value` is JSON string.
- *
- * @external "google.protobuf.Int64Value"
- * @property {number} value
- *   The int64 value.
- *
- * @see [google.protobuf.Int64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `uint64`.
- *
- * The JSON representation for `UInt64Value` is JSON string.
- *
- * @external "google.protobuf.UInt64Value"
- * @property {number} value
- *   The uint64 value.
- *
- * @see [google.protobuf.UInt64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `int32`.
- *
- * The JSON representation for `Int32Value` is JSON number.
- *
- * @external "google.protobuf.Int32Value"
- * @property {number} value
- *   The int32 value.
- *
- * @see [google.protobuf.Int32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `uint32`.
- *
- * The JSON representation for `UInt32Value` is JSON number.
- *
- * @external "google.protobuf.UInt32Value"
- * @property {number} value
- *   The uint32 value.
- *
- * @see [google.protobuf.UInt32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `bool`.
- *
- * The JSON representation for `BoolValue` is JSON `true` and `false`.
- *
- * @external "google.protobuf.BoolValue"
- * @property {boolean} value
- *   The bool value.
- *
- * @see [google.protobuf.BoolValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `string`.
- *
- * The JSON representation for `StringValue` is JSON string.
- *
- * @external "google.protobuf.StringValue"
- * @property {string} value
- *   The string value.
- *
- * @see [google.protobuf.StringValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-
-/**
- * Wrapper message for `bytes`.
- *
- * The JSON representation for `BytesValue` is JSON string.
- *
- * @external "google.protobuf.BytesValue"
- * @property {string} value
- *   The bytes value.
- *
- * @see [google.protobuf.BytesValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
- */
-============== file: src/v1/doc/doc_google_rpc_status.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * The `Status` type defines a logical error model that is suitable for different
- * programming environments, including REST APIs and RPC APIs. It is used by
- * [gRPC](https://github.com/grpc). The error model is designed to be:
- *
- * - Simple to use and understand for most users
- * - Flexible enough to meet unexpected needs
- *
- * # Overview
- *
- * The `Status` message contains three pieces of data: error code, error message,
- * and error details. The error code should be an enum value of
- * {@link google.rpc.Code}, but it may accept additional error codes if needed.  The
- * error message should be a developer-facing English message that helps
- * developers *understand* and *resolve* the error. If a localized user-facing
- * error message is needed, put the localized message in the error details or
- * localize it in the client. The optional error details may contain arbitrary
- * information about the error. There is a predefined set of error detail types
- * in the package `google.rpc` which can be used for common error conditions.
- *
- * # Language mapping
- *
- * The `Status` message is the logical representation of the error model, but it
- * is not necessarily the actual wire format. When the `Status` message is
- * exposed in different client libraries and different wire protocols, it can be
- * mapped differently. For example, it will likely be mapped to some exceptions
- * in Java, but more likely mapped to some error codes in C.
- *
- * # Other uses
- *
- * The error model and the `Status` message can be used in a variety of
- * environments, either with or without APIs, to provide a
- * consistent developer experience across different environments.
- *
- * Example uses of this error model include:
- *
- * - Partial errors. If a service needs to return partial errors to the client,
- *     it may embed the `Status` in the normal response to indicate the partial
- *     errors.
- *
- * - Workflow errors. A typical workflow has multiple steps. Each step may
- *     have a `Status` message for error reporting purpose.
- *
- * - Batch operations. If a client uses batch request and batch response, the
- *     `Status` message should be used directly inside batch response, one for
- *     each error sub-response.
- *
- * - Asynchronous operations. If an API call embeds asynchronous operation
- *     results in its response, the status of those operations should be
- *     represented directly using the `Status` message.
- *
- * - Logging. If some API errors are stored in logs, the message `Status` could
- *     be used directly after any stripping needed for security/privacy reasons.
- *
- * @external "google.rpc.Status"
- * @property {number} code
- *   The status code, which should be an enum value of {@link google.rpc.Code}.
- *
- * @property {string} message
- *   A developer-facing error message, which should be in English. Any
- *   user-facing error message should be localized and sent in the
- *   {@link google.rpc.Status.details} field, or localized by the client.
- *
- * @property {Object[]} details
- *   A list of messages that carry the error details.  There will be a
- *   common set of message types for APIs to use.
- *
- *   This object should have the same structure as [google.protobuf.Any]{@link external:"google.protobuf.Any"}
- *
- * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
- */
+var FieldMask = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
 ============== file: src/v1/doc/doc_library.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -976,54 +519,54 @@ var FieldMask = {
  * @property {Object} anyValue
  *   For testing all well-known types.
  *
- *   This object should have the same structure as [google.protobuf.Any]{@link external:"google.protobuf.Any"}
+ *   This object should have the same structure as [Any]{@link Any}
  *
  * @property {Object} structValue
- *   This object should have the same structure as [google.protobuf.Struct]{@link external:"google.protobuf.Struct"}
+ *   This object should have the same structure as [Struct]{@link Struct}
  *
  * @property {Object} valueValue
- *   This object should have the same structure as [google.protobuf.Value]{@link external:"google.protobuf.Value"}
+ *   This object should have the same structure as [Value]{@link Value}
  *
  * @property {Object} listValueValue
- *   This object should have the same structure as [google.protobuf.ListValue]{@link external:"google.protobuf.ListValue"}
+ *   This object should have the same structure as [ListValue]{@link ListValue}
  *
  * @property {Object.<string, Object>} mapListValueValue
  *
  * @property {Object} timeValue
- *   This object should have the same structure as [google.protobuf.Timestamp]{@link external:"google.protobuf.Timestamp"}
+ *   This object should have the same structure as [Timestamp]{@link Timestamp}
  *
  * @property {Object} durationValue
- *   This object should have the same structure as [google.protobuf.Duration]{@link external:"google.protobuf.Duration"}
+ *   This object should have the same structure as [Duration]{@link Duration}
  *
  * @property {Object} fieldMaskValue
- *   This object should have the same structure as [google.protobuf.FieldMask]{@link external:"google.protobuf.FieldMask"}
+ *   This object should have the same structure as [FieldMask]{@link FieldMask}
  *
  * @property {Object} int32Value
- *   This object should have the same structure as [google.protobuf.Int32Value]{@link external:"google.protobuf.Int32Value"}
+ *   This object should have the same structure as [Int32Value]{@link Int32Value}
  *
  * @property {Object} uint32Value
- *   This object should have the same structure as [google.protobuf.UInt32Value]{@link external:"google.protobuf.UInt32Value"}
+ *   This object should have the same structure as [UInt32Value]{@link UInt32Value}
  *
  * @property {Object} int64Value
- *   This object should have the same structure as [google.protobuf.Int64Value]{@link external:"google.protobuf.Int64Value"}
+ *   This object should have the same structure as [Int64Value]{@link Int64Value}
  *
  * @property {Object} uint64Value
- *   This object should have the same structure as [google.protobuf.UInt64Value]{@link external:"google.protobuf.UInt64Value"}
+ *   This object should have the same structure as [UInt64Value]{@link UInt64Value}
  *
  * @property {Object} floatValue
- *   This object should have the same structure as [google.protobuf.FloatValue]{@link external:"google.protobuf.FloatValue"}
+ *   This object should have the same structure as [FloatValue]{@link FloatValue}
  *
  * @property {Object} doubleValue
- *   This object should have the same structure as [google.protobuf.DoubleValue]{@link external:"google.protobuf.DoubleValue"}
+ *   This object should have the same structure as [DoubleValue]{@link DoubleValue}
  *
  * @property {Object} stringValue
- *   This object should have the same structure as [google.protobuf.StringValue]{@link external:"google.protobuf.StringValue"}
+ *   This object should have the same structure as [StringValue]{@link StringValue}
  *
  * @property {Object} boolValue
- *   This object should have the same structure as [google.protobuf.BoolValue]{@link external:"google.protobuf.BoolValue"}
+ *   This object should have the same structure as [BoolValue]{@link BoolValue}
  *
  * @property {Object} bytesValue
- *   This object should have the same structure as [google.protobuf.BytesValue]{@link external:"google.protobuf.BytesValue"}
+ *   This object should have the same structure as [BytesValue]{@link BytesValue}
  *
  * @property {Object.<number, string>} mapStringValue
  *   Test doc generation of lists:
@@ -1046,6 +589,7 @@ var FieldMask = {
  *   This object should have the same structure as [Used]{@link Used}
  *
  * @typedef Book
+ * @member google.example.library.v1
  * @see [google.example.library.v1.Book definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var Book = {
@@ -1085,6 +629,7 @@ var Book = {
  *   Value indicating whether the book has been read.
  *
  * @typedef BookFromArchive
+ * @member google.example.library.v1
  * @see [google.example.library.v1.BookFromArchive definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var BookFromArchive = {
@@ -1101,6 +646,7 @@ var BookFromArchive = {
  *   The number should be among the values of [Alignment]{@link Alignment}
  *
  * @typedef SomeMessage
+ * @member google.example.library.v1
  * @see [google.example.library.v1.SomeMessage definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SomeMessage = {
@@ -1125,6 +671,7 @@ var SomeMessage = {
  *   The number should be among the values of [Alignment]{@link Alignment}
  *
  * @typedef SomeMessage2
+ * @member google.example.library.v1
  * @see [google.example.library.v1.SomeMessage2 definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SomeMessage2 = {
@@ -1132,6 +679,7 @@ var SomeMessage2 = {
 
   /**
    * @typedef SomeMessage3
+   * @member google.example.library.v1
    * @see [google.example.library.v1.SomeMessage2.SomeMessage3 definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
    */
   SomeMessage3: {
@@ -1188,6 +736,7 @@ var SomeMessage2 = {
  *   Internal theme that is visible to trusted testers only.
  *
  * @typedef Shelf
+ * @member google.example.library.v1
  * @see [google.example.library.v1.Shelf definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var Shelf = {
@@ -1203,6 +752,7 @@ var Shelf = {
  *   This object should have the same structure as [Shelf]{@link Shelf}
  *
  * @typedef CreateShelfRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.CreateShelfRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var CreateShelfRequest = {
@@ -1227,6 +777,7 @@ var CreateShelfRequest = {
  *   To test 'options' parameter name conflict.
  *
  * @typedef GetShelfRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.GetShelfRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetShelfRequest = {
@@ -1239,6 +790,7 @@ var GetShelfRequest = {
  * @property {string} name
  *
  * @typedef StringBuilder
+ * @member google.example.library.v1
  * @see [google.example.library.v1.StringBuilder definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StringBuilder = {
@@ -1255,6 +807,7 @@ var StringBuilder = {
  *   returned from the previous call to `ListShelves` method.
  *
  * @typedef ListShelvesRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.ListShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListShelvesRequest = {
@@ -1277,6 +830,7 @@ var ListShelvesRequest = {
  *   page of results.
  *
  * @typedef ListShelvesResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.ListShelvesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListShelvesResponse = {
@@ -1286,6 +840,7 @@ var ListShelvesResponse = {
 /**
  * Request message for LibraryService.StreamShelves.
  * @typedef StreamShelvesRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.StreamShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StreamShelvesRequest = {
@@ -1301,6 +856,7 @@ var StreamShelvesRequest = {
  *   This object should have the same structure as [Shelf]{@link Shelf}
  *
  * @typedef StreamShelvesResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.StreamShelvesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StreamShelvesResponse = {
@@ -1314,6 +870,7 @@ var StreamShelvesResponse = {
  *   The name of the shelf to delete.
  *
  * @typedef DeleteShelfRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.DeleteShelfRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var DeleteShelfRequest = {
@@ -1331,6 +888,7 @@ var DeleteShelfRequest = {
  *   The name of the shelf we're removing books from and deleting.
  *
  * @typedef MergeShelvesRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.MergeShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var MergeShelvesRequest = {
@@ -1349,6 +907,7 @@ var MergeShelvesRequest = {
  *   This object should have the same structure as [Book]{@link Book}
  *
  * @typedef CreateBookRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.CreateBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var CreateBookRequest = {
@@ -1380,6 +939,7 @@ var CreateBookRequest = {
  *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  *
  * @typedef PublishSeriesRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.PublishSeriesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var PublishSeriesRequest = {
@@ -1392,6 +952,7 @@ var PublishSeriesRequest = {
  * @property {string} seriesString
  *
  * @typedef SeriesUuid
+ * @member google.example.library.v1
  * @see [google.example.library.v1.SeriesUuid definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SeriesUuid = {
@@ -1405,6 +966,7 @@ var SeriesUuid = {
  *   The names of the books in the series that were published
  *
  * @typedef PublishSeriesResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.PublishSeriesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var PublishSeriesResponse = {
@@ -1418,6 +980,7 @@ var PublishSeriesResponse = {
  *   The name of the book to retrieve.
  *
  * @typedef GetBookRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.GetBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookRequest = {
@@ -1444,6 +1007,7 @@ var GetBookRequest = {
  *   To test python built-in wrapping.
  *
  * @typedef ListBooksRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.ListBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListBooksRequest = {
@@ -1466,6 +1030,7 @@ var ListBooksRequest = {
  *   page of results.
  *
  * @typedef ListBooksResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.ListBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListBooksResponse = {
@@ -1479,6 +1044,7 @@ var ListBooksResponse = {
  *   The name of the shelf whose books we'd like to list.
  *
  * @typedef StreamBooksRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.StreamBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StreamBooksRequest = {
@@ -1499,7 +1065,7 @@ var StreamBooksRequest = {
  * @property {Object} updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
  *
- *   This object should have the same structure as [google.protobuf.FieldMask]{@link external:"google.protobuf.FieldMask"}
+ *   This object should have the same structure as [FieldMask]{@link FieldMask}
  *
  * @property {Object} physicalMask
  *   To test Python import clash resolution.
@@ -1507,6 +1073,7 @@ var StreamBooksRequest = {
  *   This object should have the same structure as [FieldMask]{@link FieldMask}
  *
  * @typedef UpdateBookRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.UpdateBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var UpdateBookRequest = {
@@ -1520,6 +1087,7 @@ var UpdateBookRequest = {
  *   The name of the book to delete.
  *
  * @typedef DeleteBookRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.DeleteBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var DeleteBookRequest = {
@@ -1537,6 +1105,7 @@ var DeleteBookRequest = {
  *   The name of the destination shelf.
  *
  * @typedef MoveBookRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.MoveBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var MoveBookRequest = {
@@ -1551,6 +1120,7 @@ var MoveBookRequest = {
  * @property {string} pageToken
  *
  * @typedef ListStringsRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.ListStringsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListStringsRequest = {
@@ -1563,6 +1133,7 @@ var ListStringsRequest = {
  * @property {string} nextPageToken
  *
  * @typedef ListStringsResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.ListStringsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListStringsResponse = {
@@ -1576,6 +1147,7 @@ var ListStringsResponse = {
  *   This object should have the same structure as [Comment]{@link Comment}
  *
  * @typedef AddCommentsRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.AddCommentsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var AddCommentsRequest = {
@@ -1600,6 +1172,7 @@ var AddCommentsRequest = {
  *   The number should be among the values of [Alignment]{@link Alignment}
  *
  * @typedef Comment
+ * @member google.example.library.v1
  * @see [google.example.library.v1.Comment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var Comment = {
@@ -1623,6 +1196,7 @@ var Comment = {
  *   The name of the book to retrieve.
  *
  * @typedef GetBookFromArchiveRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.GetBookFromArchiveRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookFromArchiveRequest = {
@@ -1640,6 +1214,7 @@ var GetBookFromArchiveRequest = {
  *   single resource name type in a oneof.
  *
  * @typedef GetBookFromAnywhereRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.GetBookFromAnywhereRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookFromAnywhereRequest = {
@@ -1653,6 +1228,7 @@ var GetBookFromAnywhereRequest = {
  *   The name of the book to retrieve.
  *
  * @typedef GetBookFromAbsolutelyAnywhereRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookFromAbsolutelyAnywhereRequest = {
@@ -1672,6 +1248,7 @@ var GetBookFromAbsolutelyAnywhereRequest = {
  *   The index to update the book with
  *
  * @typedef UpdateBookIndexRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.UpdateBookIndexRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var UpdateBookIndexRequest = {
@@ -1690,6 +1267,7 @@ var UpdateBookIndexRequest = {
  *   This object should have the same structure as [Comment]{@link Comment}
  *
  * @typedef DiscussBookRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.DiscussBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var DiscussBookRequest = {
@@ -1708,6 +1286,7 @@ var DiscussBookRequest = {
  * @property {string} pageToken
  *
  * @typedef FindRelatedBooksRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.FindRelatedBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var FindRelatedBooksRequest = {
@@ -1722,6 +1301,7 @@ var FindRelatedBooksRequest = {
  * @property {string} nextPageToken
  *
  * @typedef FindRelatedBooksResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.FindRelatedBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var FindRelatedBooksResponse = {
@@ -1735,6 +1315,7 @@ var FindRelatedBooksResponse = {
  *   Approximate percentage of the book processed thus far.
  *
  * @typedef GetBigBookMetadata
+ * @member google.example.library.v1
  * @see [google.example.library.v1.GetBigBookMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBigBookMetadata = {
@@ -1859,6 +1440,7 @@ var GetBigBookMetadata = {
  * @property {Object.<number, string>} optionalMap
  *
  * @typedef TestOptionalRequiredFlatteningParamsRequest
+ * @member google.example.library.v1
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var TestOptionalRequiredFlatteningParamsRequest = {
@@ -1866,6 +1448,7 @@ var TestOptionalRequiredFlatteningParamsRequest = {
 
   /**
    * @typedef InnerMessage
+   * @member google.example.library.v1
    * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
    */
   InnerMessage: {
@@ -1885,6 +1468,7 @@ var TestOptionalRequiredFlatteningParamsRequest = {
 
 /**
  * @typedef TestOptionalRequiredFlatteningParamsResponse
+ * @member google.example.library.v1
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var TestOptionalRequiredFlatteningParamsResponse = {
@@ -1919,6 +1503,7 @@ var TestOptionalRequiredFlatteningParamsResponse = {
  * @property {number} timesUsed
  *
  * @typedef Used
+ * @member google.test.shared.data
  * @see [google.test.shared.data.Used definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
  */
 var Used = {
@@ -1933,8 +1518,505 @@ var Used = {
  *   This object should have the same structure as [OtherType]{@link OtherType}
  *
  * @typedef Unused
+ * @member google.test.shared.data
  * @see [google.test.shared.data.Unused definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
  */
 var Unused = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/doc_status.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * The `Status` type defines a logical error model that is suitable for different
+ * programming environments, including REST APIs and RPC APIs. It is used by
+ * [gRPC](https://github.com/grpc). The error model is designed to be:
+ *
+ * - Simple to use and understand for most users
+ * - Flexible enough to meet unexpected needs
+ *
+ * # Overview
+ *
+ * The `Status` message contains three pieces of data: error code, error message,
+ * and error details. The error code should be an enum value of
+ * {@link google.rpc.Code}, but it may accept additional error codes if needed.  The
+ * error message should be a developer-facing English message that helps
+ * developers *understand* and *resolve* the error. If a localized user-facing
+ * error message is needed, put the localized message in the error details or
+ * localize it in the client. The optional error details may contain arbitrary
+ * information about the error. There is a predefined set of error detail types
+ * in the package `google.rpc` which can be used for common error conditions.
+ *
+ * # Language mapping
+ *
+ * The `Status` message is the logical representation of the error model, but it
+ * is not necessarily the actual wire format. When the `Status` message is
+ * exposed in different client libraries and different wire protocols, it can be
+ * mapped differently. For example, it will likely be mapped to some exceptions
+ * in Java, but more likely mapped to some error codes in C.
+ *
+ * # Other uses
+ *
+ * The error model and the `Status` message can be used in a variety of
+ * environments, either with or without APIs, to provide a
+ * consistent developer experience across different environments.
+ *
+ * Example uses of this error model include:
+ *
+ * - Partial errors. If a service needs to return partial errors to the client,
+ *     it may embed the `Status` in the normal response to indicate the partial
+ *     errors.
+ *
+ * - Workflow errors. A typical workflow has multiple steps. Each step may
+ *     have a `Status` message for error reporting purpose.
+ *
+ * - Batch operations. If a client uses batch request and batch response, the
+ *     `Status` message should be used directly inside batch response, one for
+ *     each error sub-response.
+ *
+ * - Asynchronous operations. If an API call embeds asynchronous operation
+ *     results in its response, the status of those operations should be
+ *     represented directly using the `Status` message.
+ *
+ * - Logging. If some API errors are stored in logs, the message `Status` could
+ *     be used directly after any stripping needed for security/privacy reasons.
+ *
+ * @property {number} code
+ *   The status code, which should be an enum value of {@link google.rpc.Code}.
+ *
+ * @property {string} message
+ *   A developer-facing error message, which should be in English. Any
+ *   user-facing error message should be localized and sent in the
+ *   {@link google.rpc.Status.details} field, or localized by the client.
+ *
+ * @property {Object[]} details
+ *   A list of messages that carry the error details.  There will be a
+ *   common set of message types for APIs to use.
+ *
+ *   This object should have the same structure as [Any]{@link Any}
+ *
+ * @typedef Status
+ * @member google.rpc
+ * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ */
+var Status = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/doc_struct.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * `Struct` represents a structured data value, consisting of fields
+ * which map to dynamically typed values. In some languages, `Struct`
+ * might be supported by a native representation. For example, in
+ * scripting languages like JS a struct is represented as an
+ * object. The details of that representation are described together
+ * with the proto support for the language.
+ *
+ * The JSON representation for `Struct` is JSON object.
+ *
+ * @property {Object.<string, Object>} fields
+ *   Unordered map of dynamically typed values.
+ *
+ * @typedef Struct
+ * @member google.protobuf
+ * @see [google.protobuf.Struct definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
+var Struct = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `Value` represents a dynamically typed value which can be either
+ * null, a number, a string, a boolean, a recursive struct value, or a
+ * list of values. A producer of value is expected to set one of that
+ * variants, absence of any variant indicates an error.
+ *
+ * The JSON representation for `Value` is JSON value.
+ *
+ * @property {number} nullValue
+ *   Represents a null value.
+ *
+ *   The number should be among the values of [NullValue]{@link NullValue}
+ *
+ * @property {number} numberValue
+ *   Represents a double value.
+ *
+ * @property {string} stringValue
+ *   Represents a string value.
+ *
+ * @property {boolean} boolValue
+ *   Represents a boolean value.
+ *
+ * @property {Object} structValue
+ *   Represents a structured value.
+ *
+ *   This object should have the same structure as [Struct]{@link Struct}
+ *
+ * @property {Object} listValue
+ *   Represents a repeated `Value`.
+ *
+ *   This object should have the same structure as [ListValue]{@link ListValue}
+ *
+ * @typedef Value
+ * @member google.protobuf
+ * @see [google.protobuf.Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
+var Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `ListValue` is a wrapper around a repeated field of values.
+ *
+ * The JSON representation for `ListValue` is JSON array.
+ *
+ * @property {Object[]} values
+ *   Repeated field of dynamically typed values.
+ *
+ *   This object should have the same structure as [Value]{@link Value}
+ *
+ * @typedef ListValue
+ * @member google.protobuf
+ * @see [google.protobuf.ListValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
+var ListValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * `NullValue` is a singleton enumeration to represent the null value for the
+ * `Value` type union.
+ *
+ *  The JSON representation for `NullValue` is JSON `null`.
+ *
+ * @enum {number}
+ */
+var NullValue = {
+
+  /**
+   * Null value.
+   */
+  NULL_VALUE: 0
+};
+============== file: src/v1/doc/doc_timestamp.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * A Timestamp represents a point in time independent of any time zone
+ * or calendar, represented as seconds and fractions of seconds at
+ * nanosecond resolution in UTC Epoch time. It is encoded using the
+ * Proleptic Gregorian Calendar which extends the Gregorian calendar
+ * backwards to year one. It is encoded assuming all minutes are 60
+ * seconds long, i.e. leap seconds are "smeared" so that no leap second
+ * table is needed for interpretation. Range is from
+ * 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+ * By restricting to that range, we ensure that we can convert to
+ * and from  RFC 3339 date strings.
+ * See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+ *
+ * # Examples
+ *
+ * Example 1: Compute Timestamp from POSIX `time()`.
+ *
+ *     Timestamp timestamp;
+ *     timestamp.set_seconds(time(NULL));
+ *     timestamp.set_nanos(0);
+ *
+ * Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+ *
+ *     struct timeval tv;
+ *     gettimeofday(&tv, NULL);
+ *
+ *     Timestamp timestamp;
+ *     timestamp.set_seconds(tv.tv_sec);
+ *     timestamp.set_nanos(tv.tv_usec * 1000);
+ *
+ * Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+ *
+ *     FILETIME ft;
+ *     GetSystemTimeAsFileTime(&ft);
+ *     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+ *
+ *     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+ *     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+ *     Timestamp timestamp;
+ *     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+ *     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+ *
+ * Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+ *
+ *     long millis = System.currentTimeMillis();
+ *
+ *     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+ *         .setNanos((int) ((millis % 1000) * 1000000)).build();
+ *
+ *
+ * Example 5: Compute Timestamp from current time in Python.
+ *
+ *     timestamp = Timestamp()
+ *     timestamp.GetCurrentTime()
+ *
+ * # JSON Mapping
+ *
+ * In JSON format, the Timestamp type is encoded as a string in the
+ * [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+ * format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+ * where {year} is always expressed using four digits while {month}, {day},
+ * {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+ * seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+ * are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+ * is required, though only UTC (as indicated by "Z") is presently supported.
+ *
+ * For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+ * 01:30 UTC on January 15, 2017.
+ *
+ * In JavaScript, one can convert a Date object to this format using the
+ * standard [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString]
+ * method. In Python, a standard `datetime.datetime` object can be converted
+ * to this format using [`strftime`](https://docs.python.org/2/library/time.html#time.strftime)
+ * with the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one
+ * can use the Joda Time's [`ISODateTimeFormat.dateTime()`](https://cloud.google.com
+ * http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime())
+ * to obtain a formatter capable of generating timestamps in this format.
+ *
+ * @property {number} seconds
+ *   Represents seconds of UTC time since Unix epoch
+ *   1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+ *   9999-12-31T23:59:59Z inclusive.
+ *
+ * @property {number} nanos
+ *   Non-negative fractions of a second at nanosecond resolution. Negative
+ *   second values with fractions must still have non-negative nanos values
+ *   that count forward in time. Must be from 0 to 999,999,999
+ *   inclusive.
+ *
+ * @typedef Timestamp
+ * @member google.protobuf
+ * @see [google.protobuf.Timestamp definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto}
+ */
+var Timestamp = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/doc_wrappers.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * Wrapper message for `double`.
+ *
+ * The JSON representation for `DoubleValue` is JSON number.
+ *
+ * @property {number} value
+ *   The double value.
+ *
+ * @typedef DoubleValue
+ * @member google.protobuf
+ * @see [google.protobuf.DoubleValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var DoubleValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `float`.
+ *
+ * The JSON representation for `FloatValue` is JSON number.
+ *
+ * @property {number} value
+ *   The float value.
+ *
+ * @typedef FloatValue
+ * @member google.protobuf
+ * @see [google.protobuf.FloatValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var FloatValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `int64`.
+ *
+ * The JSON representation for `Int64Value` is JSON string.
+ *
+ * @property {number} value
+ *   The int64 value.
+ *
+ * @typedef Int64Value
+ * @member google.protobuf
+ * @see [google.protobuf.Int64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var Int64Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `uint64`.
+ *
+ * The JSON representation for `UInt64Value` is JSON string.
+ *
+ * @property {number} value
+ *   The uint64 value.
+ *
+ * @typedef UInt64Value
+ * @member google.protobuf
+ * @see [google.protobuf.UInt64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var UInt64Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `int32`.
+ *
+ * The JSON representation for `Int32Value` is JSON number.
+ *
+ * @property {number} value
+ *   The int32 value.
+ *
+ * @typedef Int32Value
+ * @member google.protobuf
+ * @see [google.protobuf.Int32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var Int32Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `uint32`.
+ *
+ * The JSON representation for `UInt32Value` is JSON number.
+ *
+ * @property {number} value
+ *   The uint32 value.
+ *
+ * @typedef UInt32Value
+ * @member google.protobuf
+ * @see [google.protobuf.UInt32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var UInt32Value = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `bool`.
+ *
+ * The JSON representation for `BoolValue` is JSON `true` and `false`.
+ *
+ * @property {boolean} value
+ *   The bool value.
+ *
+ * @typedef BoolValue
+ * @member google.protobuf
+ * @see [google.protobuf.BoolValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var BoolValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `string`.
+ *
+ * The JSON representation for `StringValue` is JSON string.
+ *
+ * @property {string} value
+ *   The string value.
+ *
+ * @typedef StringValue
+ * @member google.protobuf
+ * @see [google.protobuf.StringValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var StringValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Wrapper message for `bytes`.
+ *
+ * The JSON representation for `BytesValue` is JSON string.
+ *
+ * @property {string} value
+ *   The bytes value.
+ *
+ * @typedef BytesValue
+ * @member google.protobuf
+ * @see [google.protobuf.BytesValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
+ */
+var BytesValue = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_message_library.baseline
@@ -514,59 +514,59 @@ var FieldMask = {
  * @property {number} rating
  *   For testing enums.
  *
- *   The number should be among the values of [Rating]{@link Rating}
+ *   The number should be among the values of [Rating]{@link google.example.library.v1.Rating}
  *
  * @property {Object} anyValue
  *   For testing all well-known types.
  *
- *   This object should have the same structure as [Any]{@link Any}
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
  *
  * @property {Object} structValue
- *   This object should have the same structure as [Struct]{@link Struct}
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
  *
  * @property {Object} valueValue
- *   This object should have the same structure as [Value]{@link Value}
+ *   This object should have the same structure as [Value]{@link google.protobuf.Value}
  *
  * @property {Object} listValueValue
- *   This object should have the same structure as [ListValue]{@link ListValue}
+ *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
  *
  * @property {Object.<string, Object>} mapListValueValue
  *
  * @property {Object} timeValue
- *   This object should have the same structure as [Timestamp]{@link Timestamp}
+ *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
  * @property {Object} durationValue
- *   This object should have the same structure as [Duration]{@link Duration}
+ *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
  *
  * @property {Object} fieldMaskValue
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
  *
  * @property {Object} int32Value
- *   This object should have the same structure as [Int32Value]{@link Int32Value}
+ *   This object should have the same structure as [Int32Value]{@link google.protobuf.Int32Value}
  *
  * @property {Object} uint32Value
- *   This object should have the same structure as [UInt32Value]{@link UInt32Value}
+ *   This object should have the same structure as [UInt32Value]{@link google.protobuf.UInt32Value}
  *
  * @property {Object} int64Value
- *   This object should have the same structure as [Int64Value]{@link Int64Value}
+ *   This object should have the same structure as [Int64Value]{@link google.protobuf.Int64Value}
  *
  * @property {Object} uint64Value
- *   This object should have the same structure as [UInt64Value]{@link UInt64Value}
+ *   This object should have the same structure as [UInt64Value]{@link google.protobuf.UInt64Value}
  *
  * @property {Object} floatValue
- *   This object should have the same structure as [FloatValue]{@link FloatValue}
+ *   This object should have the same structure as [FloatValue]{@link google.protobuf.FloatValue}
  *
  * @property {Object} doubleValue
- *   This object should have the same structure as [DoubleValue]{@link DoubleValue}
+ *   This object should have the same structure as [DoubleValue]{@link google.protobuf.DoubleValue}
  *
  * @property {Object} stringValue
- *   This object should have the same structure as [StringValue]{@link StringValue}
+ *   This object should have the same structure as [StringValue]{@link google.protobuf.StringValue}
  *
  * @property {Object} boolValue
- *   This object should have the same structure as [BoolValue]{@link BoolValue}
+ *   This object should have the same structure as [BoolValue]{@link google.protobuf.BoolValue}
  *
  * @property {Object} bytesValue
- *   This object should have the same structure as [BytesValue]{@link BytesValue}
+ *   This object should have the same structure as [BytesValue]{@link google.protobuf.BytesValue}
  *
  * @property {Object.<number, string>} mapStringValue
  *   Test doc generation of lists:
@@ -586,7 +586,7 @@ var FieldMask = {
  *   Tests Python doc generation: should generate a dummy file for shared_type
  *   resource, but *not* its import, other_shared_type
  *
- *   This object should have the same structure as [Used]{@link Used}
+ *   This object should have the same structure as [Used]{@link google.test.shared.data.Used}
  *
  * @typedef Book
  * @member google.example.library.v1
@@ -640,10 +640,10 @@ var BookFromArchive = {
  * @property {number} field
  *
  * @property {Object} field2
- *   This object should have the same structure as [SomeMessage2]{@link SomeMessage2}
+ *   This object should have the same structure as [SomeMessage2]{@link google.example.library.v1.SomeMessage2}
  *
  * @property {number} alignment
- *   The number should be among the values of [Alignment]{@link Alignment}
+ *   The number should be among the values of [Alignment]{@link google.example.library.v1.Alignment}
  *
  * @typedef SomeMessage
  * @member google.example.library.v1
@@ -668,7 +668,7 @@ var SomeMessage = {
  * @property {number} field1
  *
  * @property {number} format
- *   The number should be among the values of [Alignment]{@link Alignment}
+ *   The number should be among the values of [Alignment]{@link google.example.library.v1.Alignment}
  *
  * @typedef SomeMessage2
  * @member google.example.library.v1
@@ -749,7 +749,7 @@ var Shelf = {
  * @property {Object} shelf
  *   The shelf to create.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @typedef CreateShelfRequest
  * @member google.example.library.v1
@@ -768,10 +768,10 @@ var CreateShelfRequest = {
  * @property {Object} message
  *   Field to verify that message-type query parameter gets flattened.
  *
- *   This object should have the same structure as [SomeMessage]{@link SomeMessage}
+ *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
  *
  * @property {Object} stringBuilder
- *   This object should have the same structure as [StringBuilder]{@link StringBuilder}
+ *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
  *
  * @property {string} options
  *   To test 'options' parameter name conflict.
@@ -820,7 +820,7 @@ var ListShelvesRequest = {
  * @property {Object[]} shelves
  *   The list of shelves.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
@@ -853,7 +853,7 @@ var StreamShelvesRequest = {
  * @property {Object[]} shelves
  *   The list of shelves.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @typedef StreamShelvesResponse
  * @member google.example.library.v1
@@ -904,7 +904,7 @@ var MergeShelvesRequest = {
  * @property {Object} book
  *   The book to create.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  *
  * @typedef CreateBookRequest
  * @member google.example.library.v1
@@ -920,12 +920,12 @@ var CreateBookRequest = {
  * @property {Object} shelf
  *   The shelf in which the series is created.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @property {Object[]} books
  *   The books to publish in the series.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  *
  * @property {number} edition
  *   The edition of the series
@@ -936,7 +936,7 @@ var CreateBookRequest = {
  * @property {Object} seriesUuid
  *   Uniquely identifies the series to the publishing house.
  *
- *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
+ *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
  *
  * @typedef PublishSeriesRequest
  * @member google.example.library.v1
@@ -1020,7 +1020,7 @@ var ListBooksRequest = {
  * @property {Object[]} books
  *   The list of books.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  *
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
@@ -1060,17 +1060,17 @@ var StreamBooksRequest = {
  * @property {Object} book
  *   The book to update with.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  *
  * @property {Object} updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
  *
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
  *
  * @property {Object} physicalMask
  *   To test Python import clash resolution.
  *
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
  *
  * @typedef UpdateBookRequest
  * @member google.example.library.v1
@@ -1144,7 +1144,7 @@ var ListStringsResponse = {
  * @property {string} name
  *
  * @property {Object[]} comments
- *   This object should have the same structure as [Comment]{@link Comment}
+ *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  *
  * @typedef AddCommentsRequest
  * @member google.example.library.v1
@@ -1164,12 +1164,12 @@ var AddCommentsRequest = {
  * @property {number} stage
  *   should be filled in by the sample generator
  *
- *   The number should be among the values of [Stage]{@link Stage}
+ *   The number should be among the values of [Stage]{@link google.example.library.v1.Stage}
  *
  * @property {number} alignment
  *   Tests Python nested enums
  *
- *   The number should be among the values of [Alignment]{@link Alignment}
+ *   The number should be among the values of [Alignment]{@link google.example.library.v1.Alignment}
  *
  * @typedef Comment
  * @member google.example.library.v1
@@ -1264,7 +1264,7 @@ var UpdateBookIndexRequest = {
  * @property {Object} comment
  *   The new comment.
  *
- *   This object should have the same structure as [Comment]{@link Comment}
+ *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  *
  * @typedef DiscussBookRequest
  * @member google.example.library.v1
@@ -1334,14 +1334,14 @@ var GetBigBookMetadata = {
  * @property {boolean} requiredSingularBool
  *
  * @property {number} requiredSingularEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  *
  * @property {string} requiredSingularString
  *
  * @property {string} requiredSingularBytes
  *
  * @property {Object} requiredSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  *
  * @property {string} requiredSingularResourceName
  *
@@ -1362,14 +1362,14 @@ var GetBigBookMetadata = {
  * @property {boolean[]} requiredRepeatedBool
  *
  * @property {number[]} requiredRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  *
  * @property {string[]} requiredRepeatedString
  *
  * @property {string[]} requiredRepeatedBytes
  *
  * @property {Object[]} requiredRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  *
  * @property {string[]} requiredRepeatedResourceName
  *
@@ -1392,14 +1392,14 @@ var GetBigBookMetadata = {
  * @property {boolean} optionalSingularBool
  *
  * @property {number} optionalSingularEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  *
  * @property {string} optionalSingularString
  *
  * @property {string} optionalSingularBytes
  *
  * @property {Object} optionalSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  *
  * @property {string} optionalSingularResourceName
  *
@@ -1420,14 +1420,14 @@ var GetBigBookMetadata = {
  * @property {boolean[]} optionalRepeatedBool
  *
  * @property {number[]} optionalRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  *
  * @property {string[]} optionalRepeatedString
  *
  * @property {string[]} optionalRepeatedBytes
  *
  * @property {Object[]} optionalRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  *
  * @property {string[]} optionalRepeatedResourceName
  *
@@ -1515,7 +1515,7 @@ var Used = {
  * other_shared_type.proto.
  *
  * @property {Object} other
- *   This object should have the same structure as [OtherType]{@link OtherType}
+ *   This object should have the same structure as [OtherType]{@link google.test.shared.data.OtherType}
  *
  * @typedef Unused
  * @member google.test.shared.data
@@ -1612,7 +1612,7 @@ var Unused = {
  *   A list of messages that carry the error details.  There will be a
  *   common set of message types for APIs to use.
  *
- *   This object should have the same structure as [Any]{@link Any}
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
  *
  * @typedef Status
  * @member google.rpc
@@ -1675,7 +1675,7 @@ var Struct = {
  * @property {number} nullValue
  *   Represents a null value.
  *
- *   The number should be among the values of [NullValue]{@link NullValue}
+ *   The number should be among the values of [NullValue]{@link google.protobuf.NullValue}
  *
  * @property {number} numberValue
  *   Represents a double value.
@@ -1689,12 +1689,12 @@ var Struct = {
  * @property {Object} structValue
  *   Represents a structured value.
  *
- *   This object should have the same structure as [Struct]{@link Struct}
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
  *
  * @property {Object} listValue
  *   Represents a repeated `Value`.
  *
- *   This object should have the same structure as [ListValue]{@link ListValue}
+ *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
  *
  * @typedef Value
  * @member google.protobuf
@@ -1712,7 +1712,7 @@ var Value = {
  * @property {Object[]} values
  *   Repeated field of dynamically typed values.
  *
- *   This object should have the same structure as [Value]{@link Value}
+ *   This object should have the same structure as [Value]{@link google.protobuf.Value}
  *
  * @typedef ListValue
  * @member google.protobuf

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_message_library.baseline
@@ -1,4 +1,4 @@
-============== file: src/v1/doc/doc_any.js ==============
+============== file: src/v1/doc/google/example/library/v1/doc_field_mask.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -21,457 +21,28 @@
  */
 
 /**
- * `Any` contains an arbitrary serialized protocol buffer message along with a
- * URL that describes the type of the serialized message.
- *
- * Protobuf library provides support to pack/unpack Any values in the form
- * of utility functions or additional generated methods of the Any type.
- *
- * Example 1: Pack and unpack a message in C++.
- *
- *     Foo foo = ...;
- *     Any any;
- *     any.PackFrom(foo);
- *     ...
- *     if (any.UnpackTo(&foo)) {
- *       ...
- *     }
- *
- * Example 2: Pack and unpack a message in Java.
- *
- *     Foo foo = ...;
- *     Any any = Any.pack(foo);
- *     ...
- *     if (any.is(Foo.class)) {
- *       foo = any.unpack(Foo.class);
- *     }
- *
- *  Example 3: Pack and unpack a message in Python.
- *
- *     foo = Foo(...)
- *     any = Any()
- *     any.Pack(foo)
- *     ...
- *     if any.Is(Foo.DESCRIPTOR):
- *       any.Unpack(foo)
- *       ...
- *
- *  Example 4: Pack and unpack a message in Go
- *
- *      foo := &pb.Foo{...}
- *      any, err := ptypes.MarshalAny(foo)
- *      ...
- *      foo := &pb.Foo{}
- *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
- *        ...
- *      }
- *
- * The pack methods provided by protobuf library will by default use
- * 'type.googleapis.com/full.type.name' as the type URL and the unpack
- * methods only use the fully qualified type name after the last '/'
- * in the type URL, for example "foo.bar.com/x/y.z" will yield type
- * name "y.z".
- *
- *
- * # JSON
- *
- * The JSON representation of an `Any` value uses the regular
- * representation of the deserialized, embedded message, with an
- * additional field `@type` which contains the type URL. Example:
- *
- *     package google.profile;
- *     message Person {
- *       string first_name = 1;
- *       string last_name = 2;
- *     }
- *
- *     {
- *       "@type": "type.googleapis.com/google.profile.Person",
- *       "firstName": <string>,
- *       "lastName": <string>
- *     }
- *
- * If the embedded message type is well-known and has a custom JSON
- * representation, that representation will be embedded adding a field
- * `value` which holds the custom JSON in addition to the `@type`
- * field. Example (for message {@link google.protobuf.Duration}):
- *
- *     {
- *       "@type": "type.googleapis.com/google.protobuf.Duration",
- *       "value": "1.212s"
- *     }
- *
- * @property {string} typeUrl
- *   A URL/resource name whose content describes the type of the
- *   serialized protocol buffer message.
- *
- *   For URLs which use the scheme `http`, `https`, or no scheme, the
- *   following restrictions and interpretations apply:
- *
- *   * If no scheme is provided, `https` is assumed.
- *   * The last segment of the URL's path must represent the fully
- *     qualified name of the type (as in `path/google.protobuf.Duration`).
- *     The name should be in a canonical form (e.g., leading "." is
- *     not accepted).
- *   * An HTTP GET on the URL must yield a {@link google.protobuf.Type}
- *     value in binary format, or produce an error.
- *   * Applications are allowed to cache lookup results based on the
- *     URL, or have them precompiled into a binary to avoid any
- *     lookup. Therefore, binary compatibility needs to be preserved
- *     on changes to types. (Use versioned type names to manage
- *     breaking changes.)
- *
- *   Schemes other than `http`, `https` (or the empty scheme) might be
- *   used with implementation specific semantics.
- *
- * @property {string} value
- *   Must be a valid serialized protocol buffer of the above specified type.
- *
- * @typedef Any
- * @member google.protobuf
- * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
- */
-var Any = {
-  // This is for documentation. Actual contents will be loaded by gRPC.
-};
-============== file: src/v1/doc/doc_duration.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * A Duration represents a signed, fixed-length span of time represented
- * as a count of seconds and fractions of seconds at nanosecond
- * resolution. It is independent of any calendar and concepts like "day"
- * or "month". It is related to Timestamp in that the difference between
- * two Timestamp values is a Duration and it can be added or subtracted
- * from a Timestamp. Range is approximately +-10,000 years.
- *
- * # Examples
- *
- * Example 1: Compute Duration from two Timestamps in pseudo code.
- *
- *     Timestamp start = ...;
- *     Timestamp end = ...;
- *     Duration duration = ...;
- *
- *     duration.seconds = end.seconds - start.seconds;
- *     duration.nanos = end.nanos - start.nanos;
- *
- *     if (duration.seconds < 0 && duration.nanos > 0) {
- *       duration.seconds += 1;
- *       duration.nanos -= 1000000000;
- *     } else if (durations.seconds > 0 && duration.nanos < 0) {
- *       duration.seconds -= 1;
- *       duration.nanos += 1000000000;
- *     }
- *
- * Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
- *
- *     Timestamp start = ...;
- *     Duration duration = ...;
- *     Timestamp end = ...;
- *
- *     end.seconds = start.seconds + duration.seconds;
- *     end.nanos = start.nanos + duration.nanos;
- *
- *     if (end.nanos < 0) {
- *       end.seconds -= 1;
- *       end.nanos += 1000000000;
- *     } else if (end.nanos >= 1000000000) {
- *       end.seconds += 1;
- *       end.nanos -= 1000000000;
- *     }
- *
- * Example 3: Compute Duration from datetime.timedelta in Python.
- *
- *     td = datetime.timedelta(days=3, minutes=10)
- *     duration = Duration()
- *     duration.FromTimedelta(td)
- *
- * # JSON Mapping
- *
- * In JSON format, the Duration type is encoded as a string rather than an
- * object, where the string ends in the suffix "s" (indicating seconds) and
- * is preceded by the number of seconds, with nanoseconds expressed as
- * fractional seconds. For example, 3 seconds with 0 nanoseconds should be
- * encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
- * be expressed in JSON format as "3.000000001s", and 3 seconds and 1
- * microsecond should be expressed in JSON format as "3.000001s".
- *
- * @property {number} seconds
- *   Signed seconds of the span of time. Must be from -315,576,000,000
- *   to +315,576,000,000 inclusive. Note: these bounds are computed from:
- *   60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
- *
- * @property {number} nanos
- *   Signed fractions of a second at nanosecond resolution of the span
- *   of time. Durations less than one second are represented with a 0
- *   `seconds` field and a positive or negative `nanos` field. For durations
- *   of one second or more, a non-zero value for the `nanos` field must be
- *   of the same sign as the `seconds` field. Must be from -999,999,999
- *   to +999,999,999 inclusive.
- *
- * @typedef Duration
- * @member google.protobuf
- * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
- */
-var Duration = {
-  // This is for documentation. Actual contents will be loaded by gRPC.
-};
-============== file: src/v1/doc/doc_field_mask.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-/*
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
-
-/**
- * `FieldMask` represents a set of symbolic field paths, for example:
- *
- *     paths: "f.a"
- *     paths: "f.b.d"
- *
- * Here `f` represents a field in some root message, `a` and `b`
- * fields in the message found in `f`, and `d` a field found in the
- * message in `f.b`.
- *
- * Field masks are used to specify a subset of fields that should be
- * returned by a get operation or modified by an update operation.
- * Field masks also have a custom JSON encoding (see below).
- *
- * # Field Masks in Projections
- *
- * When used in the context of a projection, a response message or
- * sub-message is filtered by the API to only contain those fields as
- * specified in the mask. For example, if the mask in the previous
- * example is applied to a response message as follows:
- *
- *     f {
- *       a : 22
- *       b {
- *         d : 1
- *         x : 2
- *       }
- *       y : 13
- *     }
- *     z: 8
- *
- * The result will not contain specific values for fields x,y and z
- * (their value will be set to the default, and omitted in proto text
- * output):
- *
- *
- *     f {
- *       a : 22
- *       b {
- *         d : 1
- *       }
- *     }
- *
- * A repeated field is not allowed except at the last position of a
- * paths string.
- *
- * If a FieldMask object is not present in a get operation, the
- * operation applies to all fields (as if a FieldMask of all fields
- * had been specified).
- *
- * Note that a field mask does not necessarily apply to the
- * top-level response message. In case of a REST get operation, the
- * field mask applies directly to the response, but in case of a REST
- * list operation, the mask instead applies to each individual message
- * in the returned resource list. In case of a REST custom method,
- * other definitions may be used. Where the mask applies will be
- * clearly documented together with its declaration in the API.  In
- * any case, the effect on the returned resource/resources is required
- * behavior for APIs.
- *
- * # Field Masks in Update Operations
- *
- * A field mask in update operations specifies which fields of the
- * targeted resource are going to be updated. The API is required
- * to only change the values of the fields as specified in the mask
- * and leave the others untouched. If a resource is passed in to
- * describe the updated values, the API ignores the values of all
- * fields not covered by the mask.
- *
- * If a repeated field is specified for an update operation, the existing
- * repeated values in the target resource will be overwritten by the new values.
- * Note that a repeated field is only allowed in the last position of a `paths`
- * string.
- *
- * If a sub-message is specified in the last position of the field mask for an
- * update operation, then the existing sub-message in the target resource is
- * overwritten. Given the target message:
- *
- *     f {
- *       b {
- *         d : 1
- *         x : 2
- *       }
- *       c : 1
- *     }
- *
- * And an update message:
- *
- *     f {
- *       b {
- *         d : 10
- *       }
- *     }
- *
- * then if the field mask is:
- *
- *  paths: "f.b"
- *
- * then the result will be:
- *
- *     f {
- *       b {
- *         d : 10
- *       }
- *       c : 1
- *     }
- *
- * However, if the update mask was:
- *
- *  paths: "f.b.d"
- *
- * then the result would be:
- *
- *     f {
- *       b {
- *         d : 10
- *         x : 2
- *       }
- *       c : 1
- *     }
- *
- * In order to reset a field's value to the default, the field must
- * be in the mask and set to the default value in the provided resource.
- * Hence, in order to reset all fields of a resource, provide a default
- * instance of the resource and set all fields in the mask, or do
- * not provide a mask as described below.
- *
- * If a field mask is not present on update, the operation applies to
- * all fields (as if a field mask of all fields has been specified).
- * Note that in the presence of schema evolution, this may mean that
- * fields the client does not know and has therefore not filled into
- * the request will be reset to their default. If this is unwanted
- * behavior, a specific service may require a client to always specify
- * a field mask, producing an error if not.
- *
- * As with get operations, the location of the resource which
- * describes the updated values in the request message depends on the
- * operation kind. In any case, the effect of the field mask is
- * required to be honored by the API.
- *
- * ## Considerations for HTTP REST
- *
- * The HTTP kind of an update operation which uses a field mask must
- * be set to PATCH instead of PUT in order to satisfy HTTP semantics
- * (PUT must only be used for full updates).
- *
- * # JSON Encoding of Field Masks
- *
- * In JSON, a field mask is encoded as a single string where paths are
- * separated by a comma. Fields name in each path are converted
- * to/from lower-camel naming conventions.
- *
- * As an example, consider the following message declarations:
- *
- *     message Profile {
- *       User user = 1;
- *       Photo photo = 2;
- *     }
- *     message User {
- *       string display_name = 1;
- *       string address = 2;
- *     }
- *
- * In proto a field mask for `Profile` may look as such:
- *
- *     mask {
- *       paths: "user.display_name"
- *       paths: "photo"
- *     }
- *
- * In JSON, the same mask is represented as below:
- *
- *     {
- *       mask: "user.displayName,photo"
- *     }
- *
- * # Field Masks and Oneof Fields
- *
- * Field masks treat fields in oneofs just as regular fields. Consider the
- * following message:
- *
- *     message SampleMessage {
- *       oneof test_oneof {
- *         string name = 4;
- *         SubMessage sub_message = 9;
- *       }
- *     }
- *
- * The field mask can be:
- *
- *     mask {
- *       paths: "name"
- *     }
- *
- * Or:
- *
- *     mask {
- *       paths: "sub_message"
- *     }
- *
- * Note that oneof type names ("test_oneof" in this case) cannot be used in
- * paths.
- *
- * @property {string[]} paths
- *   The set of field mask paths.
+ * @property {number[]} materials
+ *   The number should be among the values of [Material]{@link google.example.library.v1.Material}
  *
  * @typedef FieldMask
- * @member google.protobuf
- * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
+ * @member google.example.library.v1
+ * @see [google.example.library.v1.FieldMask definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/field_mask.proto}
  */
 var FieldMask = {
   // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * @enum {number}
+   */
+  Material: {
+    PAPIER_MACHE: 0,
+    WOOD: 1,
+    PORCELAIN: 2,
+    SEQUINS: 3,
+    CARDBOARD: 4
+  }
 };
-============== file: src/v1/doc/doc_library.js ==============
+============== file: src/v1/doc/google/example/library/v1/doc_library.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -1474,7 +1045,7 @@ var TestOptionalRequiredFlatteningParamsRequest = {
 var TestOptionalRequiredFlatteningParamsResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
-============== file: src/v1/doc/doc_shared_type.js ==============
+============== file: src/v1/doc/google/protobuf/doc_any.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -1497,34 +1068,120 @@ var TestOptionalRequiredFlatteningParamsResponse = {
  */
 
 /**
- * This message is used by the library service and does not reference
- * other_shared_type.proto.
+ * `Any` contains an arbitrary serialized protocol buffer message along with a
+ * URL that describes the type of the serialized message.
  *
- * @property {number} timesUsed
+ * Protobuf library provides support to pack/unpack Any values in the form
+ * of utility functions or additional generated methods of the Any type.
  *
- * @typedef Used
- * @member google.test.shared.data
- * @see [google.test.shared.data.Used definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
+ * Example 1: Pack and unpack a message in C++.
+ *
+ *     Foo foo = ...;
+ *     Any any;
+ *     any.PackFrom(foo);
+ *     ...
+ *     if (any.UnpackTo(&foo)) {
+ *       ...
+ *     }
+ *
+ * Example 2: Pack and unpack a message in Java.
+ *
+ *     Foo foo = ...;
+ *     Any any = Any.pack(foo);
+ *     ...
+ *     if (any.is(Foo.class)) {
+ *       foo = any.unpack(Foo.class);
+ *     }
+ *
+ *  Example 3: Pack and unpack a message in Python.
+ *
+ *     foo = Foo(...)
+ *     any = Any()
+ *     any.Pack(foo)
+ *     ...
+ *     if any.Is(Foo.DESCRIPTOR):
+ *       any.Unpack(foo)
+ *       ...
+ *
+ *  Example 4: Pack and unpack a message in Go
+ *
+ *      foo := &pb.Foo{...}
+ *      any, err := ptypes.MarshalAny(foo)
+ *      ...
+ *      foo := &pb.Foo{}
+ *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *        ...
+ *      }
+ *
+ * The pack methods provided by protobuf library will by default use
+ * 'type.googleapis.com/full.type.name' as the type URL and the unpack
+ * methods only use the fully qualified type name after the last '/'
+ * in the type URL, for example "foo.bar.com/x/y.z" will yield type
+ * name "y.z".
+ *
+ *
+ * # JSON
+ *
+ * The JSON representation of an `Any` value uses the regular
+ * representation of the deserialized, embedded message, with an
+ * additional field `@type` which contains the type URL. Example:
+ *
+ *     package google.profile;
+ *     message Person {
+ *       string first_name = 1;
+ *       string last_name = 2;
+ *     }
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.profile.Person",
+ *       "firstName": <string>,
+ *       "lastName": <string>
+ *     }
+ *
+ * If the embedded message type is well-known and has a custom JSON
+ * representation, that representation will be embedded adding a field
+ * `value` which holds the custom JSON in addition to the `@type`
+ * field. Example (for message {@link google.protobuf.Duration}):
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.protobuf.Duration",
+ *       "value": "1.212s"
+ *     }
+ *
+ * @property {string} typeUrl
+ *   A URL/resource name whose content describes the type of the
+ *   serialized protocol buffer message.
+ *
+ *   For URLs which use the scheme `http`, `https`, or no scheme, the
+ *   following restrictions and interpretations apply:
+ *
+ *   * If no scheme is provided, `https` is assumed.
+ *   * The last segment of the URL's path must represent the fully
+ *     qualified name of the type (as in `path/google.protobuf.Duration`).
+ *     The name should be in a canonical form (e.g., leading "." is
+ *     not accepted).
+ *   * An HTTP GET on the URL must yield a {@link google.protobuf.Type}
+ *     value in binary format, or produce an error.
+ *   * Applications are allowed to cache lookup results based on the
+ *     URL, or have them precompiled into a binary to avoid any
+ *     lookup. Therefore, binary compatibility needs to be preserved
+ *     on changes to types. (Use versioned type names to manage
+ *     breaking changes.)
+ *
+ *   Schemes other than `http`, `https` (or the empty scheme) might be
+ *   used with implementation specific semantics.
+ *
+ * @property {string} value
+ *   Must be a valid serialized protocol buffer of the above specified type.
+ *
+ * @typedef Any
+ * @member google.protobuf
+ * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
  */
-var Used = {
+var Any = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
-
-/**
- * This message is not used by the library service but does reference
- * other_shared_type.proto.
- *
- * @property {Object} other
- *   This object should have the same structure as [OtherType]{@link google.test.shared.data.OtherType}
- *
- * @typedef Unused
- * @member google.test.shared.data
- * @see [google.test.shared.data.Unused definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
- */
-var Unused = {
-  // This is for documentation. Actual contents will be loaded by gRPC.
-};
-============== file: src/v1/doc/doc_status.js ==============
+============== file: src/v1/doc/google/protobuf/doc_duration.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -1547,81 +1204,321 @@ var Unused = {
  */
 
 /**
- * The `Status` type defines a logical error model that is suitable for different
- * programming environments, including REST APIs and RPC APIs. It is used by
- * [gRPC](https://github.com/grpc). The error model is designed to be:
+ * A Duration represents a signed, fixed-length span of time represented
+ * as a count of seconds and fractions of seconds at nanosecond
+ * resolution. It is independent of any calendar and concepts like "day"
+ * or "month". It is related to Timestamp in that the difference between
+ * two Timestamp values is a Duration and it can be added or subtracted
+ * from a Timestamp. Range is approximately +-10,000 years.
  *
- * - Simple to use and understand for most users
- * - Flexible enough to meet unexpected needs
+ * # Examples
  *
- * # Overview
+ * Example 1: Compute Duration from two Timestamps in pseudo code.
  *
- * The `Status` message contains three pieces of data: error code, error message,
- * and error details. The error code should be an enum value of
- * {@link google.rpc.Code}, but it may accept additional error codes if needed.  The
- * error message should be a developer-facing English message that helps
- * developers *understand* and *resolve* the error. If a localized user-facing
- * error message is needed, put the localized message in the error details or
- * localize it in the client. The optional error details may contain arbitrary
- * information about the error. There is a predefined set of error detail types
- * in the package `google.rpc` which can be used for common error conditions.
+ *     Timestamp start = ...;
+ *     Timestamp end = ...;
+ *     Duration duration = ...;
  *
- * # Language mapping
+ *     duration.seconds = end.seconds - start.seconds;
+ *     duration.nanos = end.nanos - start.nanos;
  *
- * The `Status` message is the logical representation of the error model, but it
- * is not necessarily the actual wire format. When the `Status` message is
- * exposed in different client libraries and different wire protocols, it can be
- * mapped differently. For example, it will likely be mapped to some exceptions
- * in Java, but more likely mapped to some error codes in C.
+ *     if (duration.seconds < 0 && duration.nanos > 0) {
+ *       duration.seconds += 1;
+ *       duration.nanos -= 1000000000;
+ *     } else if (durations.seconds > 0 && duration.nanos < 0) {
+ *       duration.seconds -= 1;
+ *       duration.nanos += 1000000000;
+ *     }
  *
- * # Other uses
+ * Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
  *
- * The error model and the `Status` message can be used in a variety of
- * environments, either with or without APIs, to provide a
- * consistent developer experience across different environments.
+ *     Timestamp start = ...;
+ *     Duration duration = ...;
+ *     Timestamp end = ...;
  *
- * Example uses of this error model include:
+ *     end.seconds = start.seconds + duration.seconds;
+ *     end.nanos = start.nanos + duration.nanos;
  *
- * - Partial errors. If a service needs to return partial errors to the client,
- *     it may embed the `Status` in the normal response to indicate the partial
- *     errors.
+ *     if (end.nanos < 0) {
+ *       end.seconds -= 1;
+ *       end.nanos += 1000000000;
+ *     } else if (end.nanos >= 1000000000) {
+ *       end.seconds += 1;
+ *       end.nanos -= 1000000000;
+ *     }
  *
- * - Workflow errors. A typical workflow has multiple steps. Each step may
- *     have a `Status` message for error reporting purpose.
+ * Example 3: Compute Duration from datetime.timedelta in Python.
  *
- * - Batch operations. If a client uses batch request and batch response, the
- *     `Status` message should be used directly inside batch response, one for
- *     each error sub-response.
+ *     td = datetime.timedelta(days=3, minutes=10)
+ *     duration = Duration()
+ *     duration.FromTimedelta(td)
  *
- * - Asynchronous operations. If an API call embeds asynchronous operation
- *     results in its response, the status of those operations should be
- *     represented directly using the `Status` message.
+ * # JSON Mapping
  *
- * - Logging. If some API errors are stored in logs, the message `Status` could
- *     be used directly after any stripping needed for security/privacy reasons.
+ * In JSON format, the Duration type is encoded as a string rather than an
+ * object, where the string ends in the suffix "s" (indicating seconds) and
+ * is preceded by the number of seconds, with nanoseconds expressed as
+ * fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+ * encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+ * be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+ * microsecond should be expressed in JSON format as "3.000001s".
  *
- * @property {number} code
- *   The status code, which should be an enum value of {@link google.rpc.Code}.
+ * @property {number} seconds
+ *   Signed seconds of the span of time. Must be from -315,576,000,000
+ *   to +315,576,000,000 inclusive. Note: these bounds are computed from:
+ *   60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
  *
- * @property {string} message
- *   A developer-facing error message, which should be in English. Any
- *   user-facing error message should be localized and sent in the
- *   {@link google.rpc.Status.details} field, or localized by the client.
+ * @property {number} nanos
+ *   Signed fractions of a second at nanosecond resolution of the span
+ *   of time. Durations less than one second are represented with a 0
+ *   `seconds` field and a positive or negative `nanos` field. For durations
+ *   of one second or more, a non-zero value for the `nanos` field must be
+ *   of the same sign as the `seconds` field. Must be from -999,999,999
+ *   to +999,999,999 inclusive.
  *
- * @property {Object[]} details
- *   A list of messages that carry the error details.  There will be a
- *   common set of message types for APIs to use.
- *
- *   This object should have the same structure as [Any]{@link google.protobuf.Any}
- *
- * @typedef Status
- * @member google.rpc
- * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ * @typedef Duration
+ * @member google.protobuf
+ * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
  */
-var Status = {
+var Duration = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
-============== file: src/v1/doc/doc_struct.js ==============
+============== file: src/v1/doc/google/protobuf/doc_field_mask.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * `FieldMask` represents a set of symbolic field paths, for example:
+ *
+ *     paths: "f.a"
+ *     paths: "f.b.d"
+ *
+ * Here `f` represents a field in some root message, `a` and `b`
+ * fields in the message found in `f`, and `d` a field found in the
+ * message in `f.b`.
+ *
+ * Field masks are used to specify a subset of fields that should be
+ * returned by a get operation or modified by an update operation.
+ * Field masks also have a custom JSON encoding (see below).
+ *
+ * # Field Masks in Projections
+ *
+ * When used in the context of a projection, a response message or
+ * sub-message is filtered by the API to only contain those fields as
+ * specified in the mask. For example, if the mask in the previous
+ * example is applied to a response message as follows:
+ *
+ *     f {
+ *       a : 22
+ *       b {
+ *         d : 1
+ *         x : 2
+ *       }
+ *       y : 13
+ *     }
+ *     z: 8
+ *
+ * The result will not contain specific values for fields x,y and z
+ * (their value will be set to the default, and omitted in proto text
+ * output):
+ *
+ *
+ *     f {
+ *       a : 22
+ *       b {
+ *         d : 1
+ *       }
+ *     }
+ *
+ * A repeated field is not allowed except at the last position of a
+ * paths string.
+ *
+ * If a FieldMask object is not present in a get operation, the
+ * operation applies to all fields (as if a FieldMask of all fields
+ * had been specified).
+ *
+ * Note that a field mask does not necessarily apply to the
+ * top-level response message. In case of a REST get operation, the
+ * field mask applies directly to the response, but in case of a REST
+ * list operation, the mask instead applies to each individual message
+ * in the returned resource list. In case of a REST custom method,
+ * other definitions may be used. Where the mask applies will be
+ * clearly documented together with its declaration in the API.  In
+ * any case, the effect on the returned resource/resources is required
+ * behavior for APIs.
+ *
+ * # Field Masks in Update Operations
+ *
+ * A field mask in update operations specifies which fields of the
+ * targeted resource are going to be updated. The API is required
+ * to only change the values of the fields as specified in the mask
+ * and leave the others untouched. If a resource is passed in to
+ * describe the updated values, the API ignores the values of all
+ * fields not covered by the mask.
+ *
+ * If a repeated field is specified for an update operation, the existing
+ * repeated values in the target resource will be overwritten by the new values.
+ * Note that a repeated field is only allowed in the last position of a `paths`
+ * string.
+ *
+ * If a sub-message is specified in the last position of the field mask for an
+ * update operation, then the existing sub-message in the target resource is
+ * overwritten. Given the target message:
+ *
+ *     f {
+ *       b {
+ *         d : 1
+ *         x : 2
+ *       }
+ *       c : 1
+ *     }
+ *
+ * And an update message:
+ *
+ *     f {
+ *       b {
+ *         d : 10
+ *       }
+ *     }
+ *
+ * then if the field mask is:
+ *
+ *  paths: "f.b"
+ *
+ * then the result will be:
+ *
+ *     f {
+ *       b {
+ *         d : 10
+ *       }
+ *       c : 1
+ *     }
+ *
+ * However, if the update mask was:
+ *
+ *  paths: "f.b.d"
+ *
+ * then the result would be:
+ *
+ *     f {
+ *       b {
+ *         d : 10
+ *         x : 2
+ *       }
+ *       c : 1
+ *     }
+ *
+ * In order to reset a field's value to the default, the field must
+ * be in the mask and set to the default value in the provided resource.
+ * Hence, in order to reset all fields of a resource, provide a default
+ * instance of the resource and set all fields in the mask, or do
+ * not provide a mask as described below.
+ *
+ * If a field mask is not present on update, the operation applies to
+ * all fields (as if a field mask of all fields has been specified).
+ * Note that in the presence of schema evolution, this may mean that
+ * fields the client does not know and has therefore not filled into
+ * the request will be reset to their default. If this is unwanted
+ * behavior, a specific service may require a client to always specify
+ * a field mask, producing an error if not.
+ *
+ * As with get operations, the location of the resource which
+ * describes the updated values in the request message depends on the
+ * operation kind. In any case, the effect of the field mask is
+ * required to be honored by the API.
+ *
+ * ## Considerations for HTTP REST
+ *
+ * The HTTP kind of an update operation which uses a field mask must
+ * be set to PATCH instead of PUT in order to satisfy HTTP semantics
+ * (PUT must only be used for full updates).
+ *
+ * # JSON Encoding of Field Masks
+ *
+ * In JSON, a field mask is encoded as a single string where paths are
+ * separated by a comma. Fields name in each path are converted
+ * to/from lower-camel naming conventions.
+ *
+ * As an example, consider the following message declarations:
+ *
+ *     message Profile {
+ *       User user = 1;
+ *       Photo photo = 2;
+ *     }
+ *     message User {
+ *       string display_name = 1;
+ *       string address = 2;
+ *     }
+ *
+ * In proto a field mask for `Profile` may look as such:
+ *
+ *     mask {
+ *       paths: "user.display_name"
+ *       paths: "photo"
+ *     }
+ *
+ * In JSON, the same mask is represented as below:
+ *
+ *     {
+ *       mask: "user.displayName,photo"
+ *     }
+ *
+ * # Field Masks and Oneof Fields
+ *
+ * Field masks treat fields in oneofs just as regular fields. Consider the
+ * following message:
+ *
+ *     message SampleMessage {
+ *       oneof test_oneof {
+ *         string name = 4;
+ *         SubMessage sub_message = 9;
+ *       }
+ *     }
+ *
+ * The field mask can be:
+ *
+ *     mask {
+ *       paths: "name"
+ *     }
+ *
+ * Or:
+ *
+ *     mask {
+ *       paths: "sub_message"
+ *     }
+ *
+ * Note that oneof type names ("test_oneof" in this case) cannot be used in
+ * paths.
+ *
+ * @property {string[]} paths
+ *   The set of field mask paths.
+ *
+ * @typedef FieldMask
+ * @member google.protobuf
+ * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
+ */
+var FieldMask = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/google/protobuf/doc_struct.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -1737,7 +1634,7 @@ var NullValue = {
    */
   NULL_VALUE: 0
 };
-============== file: src/v1/doc/doc_timestamp.js ==============
+============== file: src/v1/doc/google/protobuf/doc_timestamp.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -1855,7 +1752,7 @@ var NullValue = {
 var Timestamp = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
-============== file: src/v1/doc/doc_wrappers.js ==============
+============== file: src/v1/doc/google/protobuf/doc_wrappers.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
  *
@@ -2018,5 +1915,152 @@ var StringValue = {
  * @see [google.protobuf.BytesValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var BytesValue = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/google/rpc/doc_status.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * The `Status` type defines a logical error model that is suitable for different
+ * programming environments, including REST APIs and RPC APIs. It is used by
+ * [gRPC](https://github.com/grpc). The error model is designed to be:
+ *
+ * - Simple to use and understand for most users
+ * - Flexible enough to meet unexpected needs
+ *
+ * # Overview
+ *
+ * The `Status` message contains three pieces of data: error code, error message,
+ * and error details. The error code should be an enum value of
+ * {@link google.rpc.Code}, but it may accept additional error codes if needed.  The
+ * error message should be a developer-facing English message that helps
+ * developers *understand* and *resolve* the error. If a localized user-facing
+ * error message is needed, put the localized message in the error details or
+ * localize it in the client. The optional error details may contain arbitrary
+ * information about the error. There is a predefined set of error detail types
+ * in the package `google.rpc` which can be used for common error conditions.
+ *
+ * # Language mapping
+ *
+ * The `Status` message is the logical representation of the error model, but it
+ * is not necessarily the actual wire format. When the `Status` message is
+ * exposed in different client libraries and different wire protocols, it can be
+ * mapped differently. For example, it will likely be mapped to some exceptions
+ * in Java, but more likely mapped to some error codes in C.
+ *
+ * # Other uses
+ *
+ * The error model and the `Status` message can be used in a variety of
+ * environments, either with or without APIs, to provide a
+ * consistent developer experience across different environments.
+ *
+ * Example uses of this error model include:
+ *
+ * - Partial errors. If a service needs to return partial errors to the client,
+ *     it may embed the `Status` in the normal response to indicate the partial
+ *     errors.
+ *
+ * - Workflow errors. A typical workflow has multiple steps. Each step may
+ *     have a `Status` message for error reporting purpose.
+ *
+ * - Batch operations. If a client uses batch request and batch response, the
+ *     `Status` message should be used directly inside batch response, one for
+ *     each error sub-response.
+ *
+ * - Asynchronous operations. If an API call embeds asynchronous operation
+ *     results in its response, the status of those operations should be
+ *     represented directly using the `Status` message.
+ *
+ * - Logging. If some API errors are stored in logs, the message `Status` could
+ *     be used directly after any stripping needed for security/privacy reasons.
+ *
+ * @property {number} code
+ *   The status code, which should be an enum value of {@link google.rpc.Code}.
+ *
+ * @property {string} message
+ *   A developer-facing error message, which should be in English. Any
+ *   user-facing error message should be localized and sent in the
+ *   {@link google.rpc.Status.details} field, or localized by the client.
+ *
+ * @property {Object[]} details
+ *   A list of messages that carry the error details.  There will be a
+ *   common set of message types for APIs to use.
+ *
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+ *
+ * @typedef Status
+ * @member google.rpc
+ * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ */
+var Status = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+============== file: src/v1/doc/google/test/shared/data/doc_shared_type.js ==============
+/*
+ * Copyright 2017, Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * This message is used by the library service and does not reference
+ * other_shared_type.proto.
+ *
+ * @property {number} timesUsed
+ *
+ * @typedef Used
+ * @member google.test.shared.data
+ * @see [google.test.shared.data.Used definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
+ */
+var Used = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * This message is not used by the library service but does reference
+ * other_shared_type.proto.
+ *
+ * @property {Object} other
+ *   This object should have the same structure as [OtherType]{@link google.test.shared.data.OtherType}
+ *
+ * @typedef Unused
+ * @member google.test.shared.data
+ * @see [google.test.shared.data.Unused definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
+ */
+var Unused = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
@@ -1070,7 +1070,7 @@ LibraryServiceClient.prototype.deleteBook = function(request, options, callback)
  * @param {Object=} request.updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
  *
- *   This object should have the same structure as [google.protobuf.FieldMask]{@link external:"google.protobuf.FieldMask"}
+ *   This object should have the same structure as [FieldMask]{@link FieldMask}
  * @param {Object=} request.physicalMask
  *   To test Python import clash resolution.
  *

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_main_library.baseline
@@ -361,16 +361,16 @@ LibraryServiceClient.prototype.getProjectId = function(callback) {
  * @param {Object} request.shelf
  *   The shelf to create.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link Shelf}.
+ *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -414,18 +414,18 @@ LibraryServiceClient.prototype.createShelf = function(request, options, callback
  * @param {Object=} request.message
  *   Field to verify that message-type query parameter gets flattened.
  *
- *   This object should have the same structure as [SomeMessage]{@link SomeMessage}
+ *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
  * @param {Object=} request.stringBuilder
- *   This object should have the same structure as [StringBuilder]{@link StringBuilder}
+ *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link Shelf}.
+ *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -473,20 +473,20 @@ LibraryServiceClient.prototype.getShelf = function(request, options, callback) {
  * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is Array of [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is Array of [Shelf]{@link google.example.library.v1.Shelf}.
  *
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListShelvesResponse]{@link ListShelvesResponse}.
+ *   the raw response object of an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Shelf]{@link Shelf}.
+ *   The first element of the array is Array of [Shelf]{@link google.example.library.v1.Shelf}.
  *
  *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Shelf]{@link Shelf} in a single response.
+ *   The first element is Array of [Shelf]{@link google.example.library.v1.Shelf} in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [ListShelvesResponse]{@link ListShelvesResponse}.
+ *   an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -566,7 +566,7 @@ LibraryServiceClient.prototype.listShelves = function(request, options, callback
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits an object representing [Shelf]{@link Shelf} on 'data' event.
+ *   An object stream which emits an object representing [Shelf]{@link google.example.library.v1.Shelf} on 'data' event.
  *
  * @example
  *
@@ -651,9 +651,9 @@ LibraryServiceClient.prototype.deleteShelf = function(request, options, callback
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Shelf]{@link Shelf}.
+ *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link Shelf}.
+ *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -700,16 +700,16 @@ LibraryServiceClient.prototype.mergeShelves = function(request, options, callbac
  * @param {Object} request.book
  *   The book to create.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -754,15 +754,15 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  * @param {Object} request.shelf
  *   The shelf in which the series is created.
  *
- *   This object should have the same structure as [Shelf]{@link Shelf}
+ *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  * @param {Object[]} request.books
  *   The books to publish in the series.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  * @param {Object} request.seriesUuid
  *   Uniquely identifies the series to the publishing house.
  *
- *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
+ *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
  * @param {number=} request.edition
  *   The edition of the series
  * @param {boolean=} request.reviewCopy
@@ -773,9 +773,9 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link PublishSeriesResponse}.
+ *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [PublishSeriesResponse]{@link PublishSeriesResponse}.
+ *   The first element of the array is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -830,9 +830,9 @@ LibraryServiceClient.prototype.publishSeries = function(request, options, callba
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -885,20 +885,20 @@ LibraryServiceClient.prototype.getBook = function(request, options, callback) {
  * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is Array of [Book]{@link Book}.
+ *   The second parameter to the callback is Array of [Book]{@link google.example.library.v1.Book}.
  *
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListBooksResponse]{@link ListBooksResponse}.
+ *   the raw response object of an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Book]{@link Book}.
+ *   The first element of the array is Array of [Book]{@link google.example.library.v1.Book}.
  *
  *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Book]{@link Book} in a single response.
+ *   The first element is Array of [Book]{@link google.example.library.v1.Book} in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [ListBooksResponse]{@link ListBooksResponse}.
+ *   an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -990,7 +990,7 @@ LibraryServiceClient.prototype.listBooks = function(request, options, callback) 
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits an object representing [Book]{@link Book} on 'data' event.
+ *   An object stream which emits an object representing [Book]{@link google.example.library.v1.Book} on 'data' event.
  *
  * @example
  *
@@ -1066,24 +1066,24 @@ LibraryServiceClient.prototype.deleteBook = function(request, options, callback)
  * @param {Object} request.book
  *   The book to update with.
  *
- *   This object should have the same structure as [Book]{@link Book}
+ *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  * @param {Object=} request.updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
  *
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
  * @param {Object=} request.physicalMask
  *   To test Python import clash resolution.
  *
- *   This object should have the same structure as [FieldMask]{@link FieldMask}
+ *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1135,9 +1135,9 @@ LibraryServiceClient.prototype.updateBook = function(request, options, callback)
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Book]{@link Book}.
+ *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link Book}.
+ *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1197,7 +1197,7 @@ LibraryServiceClient.prototype.moveBook = function(request, options, callback) {
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListStringsResponse]{@link ListStringsResponse}.
+ *   the raw response object of an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is Array of string.
  *
@@ -1205,7 +1205,7 @@ LibraryServiceClient.prototype.moveBook = function(request, options, callback) {
  *   The first element is Array of string in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [ListStringsResponse]{@link ListStringsResponse}.
+ *   an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -1323,7 +1323,7 @@ LibraryServiceClient.prototype.listStringsStream = function(request, options) {
  *   The request object that will be sent.
  * @param {string} request.name
  * @param {Object[]} request.comments
- *   This object should have the same structure as [Comment]{@link Comment}
+ *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
@@ -1383,9 +1383,9 @@ LibraryServiceClient.prototype.addComments = function(request, options, callback
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [BookFromArchive]{@link BookFromArchive}.
+ *   The second parameter to the callback is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromArchive]{@link BookFromArchive}.
+ *   The first element of the array is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1433,9 +1433,9 @@ LibraryServiceClient.prototype.getBookFromArchive = function(request, options, c
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1485,9 +1485,9 @@ LibraryServiceClient.prototype.getBookFromAnywhere = function(request, options, 
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link BookFromAnywhere}.
+ *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1581,7 +1581,7 @@ LibraryServiceClient.prototype.updateBookIndex = function(request, options, call
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits [StreamShelvesResponse]{@link StreamShelvesResponse} on 'data' event.
+ *   An object stream which emits [StreamShelvesResponse]{@link google.example.library.v1.StreamShelvesResponse} on 'data' event.
  *
  * @example
  *
@@ -1618,7 +1618,7 @@ LibraryServiceClient.prototype.streamShelves = function(request, options) {
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
- *   An object stream which emits [Book]{@link Book} on 'data' event.
+ *   An object stream which emits [Book]{@link google.example.library.v1.Book} on 'data' event.
  *
  * @example
  *
@@ -1650,8 +1650,8 @@ LibraryServiceClient.prototype.streamBooks = function(request, options) {
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
  * @returns {Stream}
  *   An object stream which is both readable and writable. It accepts objects
- *   representing [DiscussBookRequest]{@link DiscussBookRequest} for write() method, and
- *   will emit objects representing [Comment]{@link Comment} on 'data' event asynchronously.
+ *   representing [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method, and
+ *   will emit objects representing [Comment]{@link google.example.library.v1.Comment} on 'data' event asynchronously.
  *
  * @example
  *
@@ -1689,9 +1689,9 @@ LibraryServiceClient.prototype.discussBook = function(options) {
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [Comment]{@link Comment}.
+ *   The second parameter to the callback is an object representing [Comment]{@link google.example.library.v1.Comment}.
  * @returns {Stream} - A writable stream which accepts objects representing
- *   [DiscussBookRequest]{@link DiscussBookRequest} for write() method.
+ *   [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method.
  *
  * @example
  *
@@ -1749,7 +1749,7 @@ LibraryServiceClient.prototype.monologAboutBook = function(options, callback) {
  *   When autoPaginate: false is specified through options, it contains the result
  *   in a single response. If the response indicates the next page exists, the third
  *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [FindRelatedBooksResponse]{@link FindRelatedBooksResponse}.
+ *   the raw response object of an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
  * @returns {Promise} - The promise which resolves to an array.
  *   The first element of the array is Array of string.
  *
@@ -1757,7 +1757,7 @@ LibraryServiceClient.prototype.monologAboutBook = function(options, callback) {
  *   The first element is Array of string in a single response.
  *   The second element is the next request object if the response
  *   indicates the next page exists, or null. The third element is
- *   an object representing [FindRelatedBooksResponse]{@link FindRelatedBooksResponse}.
+ *   an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
  *
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
@@ -1908,9 +1908,9 @@ LibraryServiceClient.prototype.findRelatedBooksStream = function(request, option
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [AddTagResponse]{@link AddTagResponse}.
+ *   The second parameter to the callback is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddTagResponse]{@link AddTagResponse}.
+ *   The first element of the array is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -1964,9 +1964,9 @@ LibraryServiceClient.prototype.addTag = function(request, options, callback) {
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [AddLabelResponse]{@link AddLabelResponse}.
+ *   The second parameter to the callback is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddLabelResponse]{@link AddLabelResponse}.
+ *   The first element of the array is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example
@@ -2192,11 +2192,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number} request.requiredSingularDouble
  * @param {boolean} request.requiredSingularBool
  * @param {number} request.requiredSingularEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string} request.requiredSingularString
  * @param {string} request.requiredSingularBytes
  * @param {Object} request.requiredSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string} request.requiredSingularResourceName
  * @param {string} request.requiredSingularResourceNameOneof
  * @param {number} request.requiredSingularFixed32
@@ -2207,11 +2207,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number[]} request.requiredRepeatedDouble
  * @param {boolean[]} request.requiredRepeatedBool
  * @param {number[]} request.requiredRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string[]} request.requiredRepeatedString
  * @param {string[]} request.requiredRepeatedBytes
  * @param {Object[]} request.requiredRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string[]} request.requiredRepeatedResourceName
  * @param {string[]} request.requiredRepeatedResourceNameOneof
  * @param {number[]} request.requiredRepeatedFixed32
@@ -2223,11 +2223,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number=} request.optionalSingularDouble
  * @param {boolean=} request.optionalSingularBool
  * @param {number=} request.optionalSingularEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string=} request.optionalSingularString
  * @param {string=} request.optionalSingularBytes
  * @param {Object=} request.optionalSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string=} request.optionalSingularResourceName
  * @param {string=} request.optionalSingularResourceNameOneof
  * @param {number=} request.optionalSingularFixed32
@@ -2238,11 +2238,11 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {number[]=} request.optionalRepeatedDouble
  * @param {boolean[]=} request.optionalRepeatedBool
  * @param {number[]=} request.optionalRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link InnerEnum}
+ *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
  * @param {string[]=} request.optionalRepeatedString
  * @param {string[]=} request.optionalRepeatedBytes
  * @param {Object[]=} request.optionalRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link InnerMessage}
+ *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
  * @param {string[]=} request.optionalRepeatedResourceName
  * @param {string[]=} request.optionalRepeatedResourceNameOneof
  * @param {number[]=} request.optionalRepeatedFixed32
@@ -2254,9 +2254,9 @@ LibraryServiceClient.prototype.getBigNothing = function(request, options, callba
  * @param {function(?Error, ?Object)=} callback
  *   The function which will be called with the result of the API call.
  *
- *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link TestOptionalRequiredFlatteningParamsResponse}.
+ *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
  * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link TestOptionalRequiredFlatteningParamsResponse}.
+ *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
  *   The promise has a method named "cancel" which cancels the ongoing API call.
  *
  * @example


### PR DESCRIPTION
### What

1. If there was name collisions between grpc types and manually written types, the the documentation for the manual type would get overwritten by the rpc type.
2. DPEs would like the common protos types to be treated the same as  the rest of the types since it makes the docsite flow better.

### Fixes.

1. Add `@member` tag to the type docs
2. Remove external semantics.