### PR TITLE
Node.js autogen refactor

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -180,16 +180,16 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<String> generateValidDescriptorsNames(GapicInterfaceContext context) {
     ImmutableList.Builder<String> validDescriptorsNames = ImmutableList.builder();
     if (context.getInterfaceConfig().hasPageStreamingMethods()) {
-      validDescriptorsNames.add("PAGE_DESCRIPTORS");
+      validDescriptorsNames.add("this._descriptors.page");
     }
     if (context.getInterfaceConfig().hasBatchingMethods()) {
-      validDescriptorsNames.add("bundleDescriptors");
+      validDescriptorsNames.add("this._descriptors.batching");
     }
     if (context.getInterfaceConfig().hasGrpcStreamingMethods()) {
-      validDescriptorsNames.add("STREAM_DESCRIPTORS");
+      validDescriptorsNames.add("this._descriptors.stream");
     }
     if (context.getInterfaceConfig().hasLongRunningOperations()) {
-      validDescriptorsNames.add("self.longrunningDescriptors");
+      validDescriptorsNames.add("this._descriptors.longrunning");
     }
     return validDescriptorsNames.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -278,7 +278,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
       VersionIndexRequireView require =
           VersionIndexRequireView.newBuilder()
               .clientName(
-                  namer.getApiWrapperVariableName(productConfig.getInterfaceConfig(apiInterface)))
+                  namer.getApiWrapperClassName(productConfig.getInterfaceConfig(apiInterface)))
               .serviceName(namer.getPackageServiceName(apiInterface))
               .localName(localName)
               .doc(

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -46,7 +46,7 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
     ImmutableList.Builder<ImportFileView> imports = ImmutableList.builder();
     Interface apiInterface = context.getInterface();
     String configModule = context.getNamer().getClientConfigPath(apiInterface);
-    imports.add(createImport("configData", "./" + configModule));
+    imports.add(createImport("gapicConfig", "./" + configModule));
     imports.add(createImport("gax", "google-gax"));
     if (new GrpcStubTransformer().generateGrpcStubs(context).size() > 1) {
       imports.add(createImport("merge", "lodash.merge"));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -48,9 +48,7 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
     String configModule = context.getNamer().getClientConfigPath(apiInterface);
     imports.add(createImport("gapicConfig", "./" + configModule));
     imports.add(createImport("gax", "google-gax"));
-    if (new GrpcStubTransformer().generateGrpcStubs(context).size() > 1) {
-      imports.add(createImport("merge", "lodash.merge"));
-    }
+    imports.add(createImport("merge", "lodash.merge"));
     imports.add(createImport("path", "path"));
     if (context.getInterfaceConfig().hasLongRunningOperations()) {
       imports.add(createImport("protobuf", "protobufjs"));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -47,7 +47,6 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
     Interface apiInterface = context.getInterface();
     String configModule = context.getNamer().getClientConfigPath(apiInterface);
     imports.add(createImport("configData", "./" + configModule));
-    imports.add(createImport("extend", "extend"));
     imports.add(createImport("gax", "google-gax"));
     if (new GrpcStubTransformer().generateGrpcStubs(context).size() > 1) {
       imports.add(createImport("merge", "lodash.merge"));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.transformer.nodejs;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
 import com.google.api.codegen.transformer.GapicMethodContext;
-import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.ImportSectionTransformer;
 import com.google.api.codegen.transformer.StandardImportSectionTransformer;
 import com.google.api.codegen.viewmodel.ImportFileView;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverter.java
@@ -184,6 +184,6 @@ public class NodeJSModelTypeNameConverter implements ModelTypeNameConverter {
 
   @Override
   public TypedValue getEnumValue(TypeRef type, EnumValue value) {
-    return TypedValue.create(getTypeName(type), "%s." + value.getSimpleName());
+    return TypedValue.create(getTypeName(type), String.format("'%s'", value.getSimpleName()));
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -213,10 +213,8 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
       dependencies.add(
           PackageDependencyView.create("lodash.union", VersionBound.create("4.6.0", "")));
     }
-    if (hasMixinApis(model, productConfig)) {
-      dependencies.add(
-          PackageDependencyView.create("lodash.merge", VersionBound.create("4.6.0", "")));
-    }
+    dependencies.add(
+        PackageDependencyView.create("lodash.merge", VersionBound.create("4.6.0", "")));
     if (hasLongrunning(model, productConfig)) {
       dependencies.add(
           PackageDependencyView.create("protobufjs", VersionBound.create("6.8.0", "")));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -209,7 +209,6 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
     dependencies.add(
         PackageDependencyView.create(
             "google-gax", packageConfig.gaxVersionBound(TargetLanguage.NODEJS)));
-    dependencies.add(PackageDependencyView.create("extend", VersionBound.create("3.0", "")));
     if (new InterfaceView().hasMultipleServices(model)) {
       dependencies.add(
           PackageDependencyView.create("lodash.union", VersionBound.create("4.6.0", "")));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -118,7 +118,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   @Override
   public String getPathTemplateName(
       Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
-    return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
+    return publicFieldName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -445,12 +445,12 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   public String getByteLengthFunctionName(TypeRef typeRef) {
     switch (typeRef.getKind()) {
       case TYPE_MESSAGE:
-        return "gax.createByteLengthFunction(loadedProtos."
+        return "gax.createByteLengthFunction(protos."
             + typeRef.getMessageType().getFullName()
             + ")";
       case TYPE_STRING:
       case TYPE_BYTES:
-        return "function(s) { return s.length; }";
+        return "s => s.length";
       default:
         // There is no easy way to say the actual length of the numeric fields.
         // For now throwing an exception.

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -8,12 +8,12 @@
    */
   'use strict';
 
-  @join require : index.requireViews
-    const {@require.clientName} = require('./{@require.fileName}');
+  @join client : index.requireViews
+    const {@client.clientName} = require('./{@client.fileName}');
   @end
 
   @join client : index.requireViews
-    module.exports.{@require.clientName} = {@require.clientName};
+    module.exports.{@client.clientName} = {@client.clientName};
   @end
 
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -11,38 +11,9 @@
   @join require : index.requireViews
     const {@require.clientName} = require('./{@require.fileName}');
   @end
-  const gax = require('google-gax');
-  const extend = require('extend');
-  @if index.hasMultipleServices
-    const union = require('lodash.union');
+
+  @join client : index.requireViews
+    module.exports.{@require.clientName} = {@require.clientName};
   @end
 
-  function {@index.apiVersion}(options) {
-    options = extend({
-      scopes: {@index.apiVersion}.ALL_SCOPES
-    }, options);
-    var gaxGrpc = gax.grpc(options);
-    @if index.hasMultipleServices
-      var result = {};
-      @join require : index.requireViews
-        extend(result, {@require.clientName}(gaxGrpc));
-      @end
-      return result;
-    @else
-      return {@index.primaryService.clientName}(gaxGrpc);
-    @end
-  }
-
-  {@index.apiVersion}.SERVICE_ADDRESS = {@index.primaryService.clientName}.SERVICE_ADDRESS;
-  @if index.hasMultipleServices
-    {@index.apiVersion}.ALL_SCOPES = union(
-      @join require : index.requireViews on ", ".add(BREAK)
-        {@require.clientName}.ALL_SCOPES
-      @end
-    );
-  @else
-    {@index.apiVersion}.ALL_SCOPES = {@index.primaryService.clientName}.ALL_SCOPES;
-  @end
-
-  module.exports = {@index.apiVersion};
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -9,12 +9,12 @@
   'use strict';
 
   @join require : index.requireViews
-    var {@require.clientName} = require('./{@require.fileName}');
+    const {@require.clientName} = require('./{@require.fileName}');
   @end
-  var gax = require('google-gax');
-  var extend = require('extend');
+  const gax = require('google-gax');
+  const extend = require('extend');
   @if index.hasMultipleServices
-    var union = require('lodash.union');
+    const union = require('lodash.union');
   @end
 
   function {@index.apiVersion}(options) {

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -54,7 +54,7 @@
 
       // Create a `gaxGrpc` object, with any grpc-specific options
       // sent to the client.
-      Object.assign(opts, {scopes: this.constructor.scopes});
+      opts.scopes = this.constructor.scopes;
       var gaxGrpc = gax.grpc(opts);
 
       // Save the auth object to the client, for use by other methods.

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -347,7 +347,7 @@
 @end
 
 @private createRenderDictionary(resourceIdParams)
-  @join param: resourceIdParams on BREAL
+  @join param: resourceIdParams on BREAK
     {@param.templateKey}: {@param.name},
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -169,7 +169,20 @@
         {'x-goog-api-client': clientHeader.join(' ')},
       );
 
-      // Save a dictionary of "inner API calls"; the core implementation
+      // Load the applicable protos.
+      var protos = merge({},
+        @join stub : xapi.stubs on BREAK.add(BREAK)
+          gaxGrpc.loadProto(
+            @if xapi.fileHeader.hasVersion
+              path.join(__dirname, '..', '..', 'protos'), '{@stub.protoFileName}')
+            @else
+              path.join(__dirname, '..', 'protos'), '{@stub.protoFileName}')
+            @end
+          ),
+        @end
+      );
+
+      // Set up a dictionary of "inner API calls"; the core implementation
       // of calling the API is handled in `google-gax`, with this code
       // merely providing the destination and request information.
       this._innerApiCalls = {};
@@ -178,7 +191,7 @@
         // Put together the "service stub" for
         // {@stub.fullyQualifiedType}.
         var {@stub.name} = gaxGrpc.createStub(
-          loadedProtos.{@stub.fullyQualifiedType},
+          protos.{@stub.fullyQualifiedType},
           opts
         );
 

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -175,7 +175,7 @@
           gaxGrpc.loadProto(
             @if xapi.fileHeader.hasVersion
               path.join(__dirname, '..', '..', 'protos'),
-              '{@stub.protoFileName}')
+              '{@stub.protoFileName}'
             @else
               path.join(__dirname, '..', 'protos'),
               '{@stub.protoFileName}'

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -347,7 +347,7 @@
 
 @private flattenedMethod(method)
   {@methodComments(method)}
-  {@method.apiClassName}.prototype.{@method.name} = function({@methodRequestParameters(method)}options{@callbackParams(method)}) {
+  {@method.name}({@methodRequestParameters(method)}options{@callbackParams(method)}) {
     @switch method.grpcStreamingType.toString
     @case "ClientStreaming"
       {@handleCallback()}
@@ -355,11 +355,9 @@
       {@handleCallback()}
     @default
     @end
-    if (options === undefined) {
-      options = {};
-    }
+    options = options || {};
     {@maybeHandleRequest(method)}
-    return this._{@method.name}({@requestObject(method)}options{@callbackParams(method)});
+    return this._innerApiCalls.{@method.name}({@requestObject(method)}options{@callbackParams(method)});
   };
   @switch method.type.toString
   @case "PagedOptionalArrayMethod"
@@ -427,12 +425,14 @@
    *
    {@comments(util.getDocLines(decorateSampleCode(method, sampleCodePageStreaming(method))))}
    */
-  {@method.apiClassName}.prototype.{@method.name}Stream = function({@methodRequestParameters(method)}options) {
-    if (options === undefined) {
-      options = {};
-    }
+  {@method.name}Stream({@methodRequestParameters(method)}options) {
+    options = options || {};
     {@maybeHandleRequest(method)}
-    return PAGE_DESCRIPTORS.{@method.name}.createStream(this._{@method.name}, {@requestObject(method)}options);
+    return this._pageDescriptors.{@method.name}.createStream(
+      this._innerApiCalls.{@method.name},
+      {@requestObject(method)}
+      options
+    );
   };
 @end
 

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -263,7 +263,7 @@
   }
 
 
-  module.exports = {@xapi.constructorName};
+  module.exports = {@xapi.name};
 
 @end
 

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -12,8 +12,8 @@
    {@comments(fileHeader.copyrightLines)}
    *
    {@comments(fileHeader.licenseLines)}
-   {@editingInstructions(protoFilename)}
    */
+
   'use strict';
 
   {@importSection(fileHeader.importSection)}
@@ -25,31 +25,209 @@
 
 @private importGroup(group)
   @join import : group
-    # Currently there is only one type per import. This will need to be refactored if changed.
+    # Currently there is only one type per import.
+    # This will need to be refactored if changed.
     @join type : import.types
-      var {@type.nickname} = require('{@import.moduleName}');
+      const {@type.nickname} = require('{@import.moduleName}');
     @end
   @end
 @end
 
-@private editingInstructions(protoFileName)
-   *
-   * EDITING INSTRUCTIONS
-   * This file was generated from the file
-   * https://github.com/googleapis/googleapis/blob/master/{@protoFileName},
-   * and updates to that file get reflected here through a refresh process.
-   * For the short term, the refresh process will only be runnable by Google
-   * engineers.
-   *
-   * The only allowed edits are to method and file documentation. A 3-way
-   * merge preserves those additions if the generated source changes.
-@end
-
 
 @private serviceClass(xapi)
-  {@constantSection(xapi)}
+  /**
+   @if xapi.doc.lines
+     {@comments(xapi.doc.lines)}
+     *
+   @end
+   *
+   * @@class
+   */
+  class {@xapi.name} {
+    constructor(opts) {
+      // Ensure that options include the service address and port.
+      opts = Object.assign({
+        clientConfig: {},
+        port: this.constructor.port,
+        servicePath: this.constructor.servicePath,
+      }, opts);
 
-  {@constructor(xapi)}
+      // Create a `gaxGrpc` object, with any grpc-specific options
+      // sent to the client.
+      Object.assign(opts, {scopes: this.constructor.scopes});
+      var gaxGrpc = gax.grpc(opts);
+
+      // Save the auth object to the client, for use by other methods.
+      this.auth = gaxGrpc.auth;
+
+      // Determine the client header string.
+      var clientHeader = [
+        `gl-node/${process.version.node}`,
+        `grpc/${gaxGrpc.grpcVersion}`,
+        `gax/${gax.version}`,
+        `gapic/${this.version}`,
+      ];
+      if (opts.libName && opts.libVersion) {
+        clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+      }
+
+      @if xapi.hasPageStreamingMethods
+
+        // Some of the methods on this service return "paged" results,
+        // (e.g. 50 results at a time, with tokens to get subsequent
+        // pages). Denote the keys used for pagination and results.
+        this._pageDescriptors = {
+          @join descriptor : xapi.pageStreamingDescriptors on BREAK.add(BREAK)
+            {@descriptor.methodName}: new gax.PageDescriptor(
+              '{@descriptor.requestTokenFieldName}',
+              '{@descriptor.responseTokenFieldName}',
+              '{@descriptor.resourcesFieldName}'
+            ),
+          @end
+        };
+      @end
+      @if xapi.hasGrpcStreamingMethods
+
+        // Some of the methods on this service provide streaming responses.
+        // Provide descriptors for these.
+        this._streamDescriptors = {
+          @join descriptor : xapi.grpcStreamingDescriptors on BREAK.add(BREAK)
+            {@descriptor.methodName}: new gax.StreamDescriptor({@descriptor.streamTypeName}),
+          @end
+        };
+      @end
+      @if xapi.hasBatchingMethods
+
+        // Some methods on this API support automatically batching
+        // requests; denote this.
+        var batchingDescriptors = {
+          @join descriptor : xapi.batchingDescriptors on BREAK.add(BREAK)
+            {@descriptor.methodName}: new gax.BundleDescriptor(
+              '{@descriptor.batchedFieldName}',
+              [
+                @join fieldName : descriptor.discriminatorFieldNames() on BREAK.add(BREAK)
+                  '{@fieldName}',
+                @end
+              ],
+              @if descriptor.hasSubresponseField()
+                '{@descriptor.subresponseFieldName}',
+              @else
+                null,
+              @end
+              {@descriptor.byteLengthFunctionName},
+            ),
+          @end
+        };
+      @end
+      @if xapi.hasLongRunningOperations
+
+        // This API contains "long-running operations", which return a
+        // an Operation object that allows for tracking of the operation,
+        // rather than holding a request open.
+        this.operationsClient = new gax.lro({
+          auth: gaxGrpc.auth,
+          grpc: gaxGrpc.grpc,
+        }).operationsClient(opts);
+
+        var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+        @join stub : xapi.stubs
+          protoFilesRoot = protobuf.loadSync(
+            @if xapi.fileHeader.hasVersion
+              path.join(__dirname, '..', '..', 'protos', '{@stub.protoFileName}'),
+            @else
+              path.join(__dirname, '..', 'protos', '{@stub.protoFileName}'),
+            @end
+            protoFilesRoot
+          );
+        @end
+
+        @join descriptor : xapi.longRunningDescriptors
+          var {@descriptor.methodName}Response = protoFilesRoot.lookup(
+            '{@descriptor.operationPayloadTypeName}'
+          );
+          var {@descriptor.methodName}Metadata = protoFilesRoot.lookup(
+            '{@descriptor.metadataTypeName}'
+          );
+        @end
+
+        this.longrunningDescriptors = {
+          @join descriptor : xapi.longRunningDescriptors on BREAK.add(BREAK)
+            {@descriptor.methodName}: new gax.LongrunningDescriptor(
+              this.operationsClient,
+              {@descriptor.methodName}Response.decode.bind({@descriptor.methodName}Response),
+              {@descriptor.methodName}Metadata.decode.bind({@descriptor.methodName}Metadata)
+            ),
+          @end
+        };
+      @end
+
+      // Put together the default options sent with requests.
+      var defaults = gaxGrpc.constructSettings(
+        '{@xapi.interfaceKey}',
+        gapicConfig,
+        opts.clientConfig,
+        {'x-goog-api-client': clientHeader.join(' ')},
+      );
+
+      // Save a dictionary of "inner API calls"; the core implementation
+      // of calling the API is handled in `google-gax`, with this code
+      // merely providing the destination and request information.
+      this._innerApiCalls = {};
+
+      @join stub : xapi.stubs on BREAK.add(BREAK)
+        // Put together the "service stub" for
+        // {@stub.fullyQualifiedType}.
+        var {@stub.name} = gaxGrpc.createStub(
+          loadedProtos.{@stub.fullyQualifiedType},
+          opts
+        );
+
+        // Iterate over each of the methods that the service provides
+        // and create an API call method for each.
+        var {@stub.stubMethodsArrayName} = [
+          @join method : {@stub.methodNames} on BREAK.add(BREAK)
+              '{@method}',
+          @end
+        ];
+        for (let methodName of {@stub.stubMethodsArrayName}) {
+          this._innerApiCalls[methodName] = gax.createApiCall(
+            {@stub.name}.then(stub => function() {
+              var args = Array.prototype.slice.call(arguments, 0);
+              return stub[methodName].apply(stub, args);
+            }),
+            defaults[methodName],
+            {@getDescriptors(xapi)}
+          );
+        }
+      @end
+    }
+
+    /**
+     * The DNS address for this API service.
+     */
+    static get servicePath() {
+      return '{@xapi.serviceAddress}';
+    }
+
+    /**
+     * The port for this API service.
+     */
+    static get port() {
+      return {@xapi.servicePort};
+    }
+
+    /**
+     * The scopes needed to make gRPC calls for every method defined
+     * in this service.
+     */
+    static get scopes() {
+      return [
+        @join auth_scope : xapi.authScopes on BREAK.add(BREAK)
+          '{@auth_scope}',
+        @end
+      ];
+    }
+
 
   @if xapi.pathTemplates
     // Path templates
@@ -57,70 +235,21 @@
     {@pathTemplateSection(xapi)}
   @end
 
-  /**
-   * Get the project ID used by this class.
-   * @@param {function(Error, string)} callback - the callback to be called with
-   *   the current project Id.
-   */
-  {@xapi.name}.prototype.getProjectId = function(callback) {
-    return this.auth.getProjectId(callback);
-  };
-
-  {@serviceMethodsSection(xapi)}
-
-  /**
-   * @@class
-   * @@param {*} gaxGrpc
-   */
-  function {@xapi.name}Builder(gaxGrpc) {
-    if (!(this instanceof {@xapi.name }Builder)) {
-      return new {@xapi.name}Builder(gaxGrpc);
+    /**
+     * Return the project ID used by this class.
+     * @@param {function(Error, string)} callback - the callback to
+     *   be called with the current project Id.
+     */
+    getProjectId(callback) {
+      return this.auth.getProjectId(callback);
     }
 
-    @join stub : xapi.stubs on BREAK.add(BREAK)
-      var {@stub.name}Protos = gaxGrpc.loadProto(
-        @if xapi.fileHeader.hasVersion
-          path.join(__dirname, '..', '..', 'protos'), '{@stub.protoFileName}');
-        @else
-          path.join(__dirname, '..', 'protos'), '{@stub.protoFileName}');
-        @end
-      extend(this, {@stub.name}Protos.{@stub.namespace});
-    @end
-
-    @switch xapi.stubs.size.toString
-    @case "1"
-    @default
-      var protos = merge(
-        {},
-        @join stub : xapi.stubs on ", ".add(BREAK)
-          {@stub.name}Protos
-        @end
-      );
-    @end
-
-    /**
-     * Build a new instance of {@@link {@xapi.name}}.
-     *
-     * @@method {@xapi.name}Builder#{@xapi.constructorName}
-     * @@param {Object=} opts - The optional parameters.
-     * @@param {String=} opts.servicePath
-     *   The domain name of the API remote host.
-     * @@param {number=} opts.port
-     *   The port on which to connect to the remote host.
-     * @@param {grpc.ClientCredentials=} opts.sslCreds
-     *   A ClientCredentials for use with an SSL-enabled channel.
-     * @@param {Object=} opts.clientConfig
-     *   The customized config to build the call settings. See
-     *   {@@link gax.constructSettings} for the format.
-     */
-    this.{@xapi.constructorName} = function(opts) {
-      return new {@xapi.name}(gaxGrpc, {@clientsParamName(xapi.stubs)}, opts);
-    };
-    extend(this.{@xapi.constructorName}, {@xapi.name});
+    {@serviceMethodsSection(xapi)}
   }
-  module.exports = {@xapi.name}Builder;
-  module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
-  module.exports.ALL_SCOPES = ALL_SCOPES;
+
+
+  module.exports = {@xapi.constructorName};
+
 @end
 
 @private clientsParamName(stubs)
@@ -130,168 +259,6 @@
     @default
       protos
     @end
-@end
-
-@private constantSection(xapi)
-  var SERVICE_ADDRESS = '{@xapi.serviceAddress}';
-
-  var DEFAULT_SERVICE_PORT = {@xapi.servicePort};
-
-  var CODE_GEN_NAME_VERSION = 'gapic/{@xapi.toolkitVersion}';
-  @if xapi.hasPageStreamingMethods
-
-    var PAGE_DESCRIPTORS = {
-      @join descriptor : xapi.pageStreamingDescriptors on {@", "}.add(BREAK)
-        {@descriptor.methodName}: new gax.PageDescriptor(
-            '{@descriptor.requestTokenFieldName}',
-            '{@descriptor.responseTokenFieldName}',
-            '{@descriptor.resourcesFieldName}')
-      @end
-    };
-  @end
-  @if xapi.hasGrpcStreamingMethods
-
-    var STREAM_DESCRIPTORS = {
-      @join descriptor : xapi.grpcStreamingDescriptors on {@", "}.add(BREAK)
-        {@descriptor.methodName}: new gax.StreamDescriptor({@descriptor.streamTypeName})
-      @end
-    };
-  @end
-
-  /*!
-   * The scopes needed to make gRPC calls to all of the methods defined in
-   * this service.
-   */
-  var ALL_SCOPES = [
-    @join auth_scope : xapi.authScopes on ",".add(BREAK)
-      '{@auth_scope}'
-    @end
-  ];
-@end
-
-@private constructor(xapi)
-  /**
-   @if xapi.doc.lines
-     {@comments(xapi.doc.lines)}
-     *
-   @end
-   *
-   * @@class
-   */
-  function {@xapi.name}(gaxGrpc, loadedProtos, opts) {
-    opts = extend({
-      servicePath: SERVICE_ADDRESS,
-      port: DEFAULT_SERVICE_PORT,
-      clientConfig: {}
-    }, opts);
-
-    var googleApiClient = [
-      'gl-node/' + process.versions.node
-    ];
-    if (opts.libName && opts.libVersion) {
-      googleApiClient.push(opts.libName + '/' + opts.libVersion);
-    }
-    googleApiClient.push(
-      CODE_GEN_NAME_VERSION,
-      'gax/' + gax.version,
-      'grpc/' + gaxGrpc.grpcVersion
-    );
-    @if xapi.hasBatchingMethods
-
-      {@batchingDescriptors(xapi.batchingDescriptors)}
-    @end
-    @if xapi.hasLongRunningOperations
-
-      {@longrunningSetup(xapi.longRunningDescriptors, xapi.stubs, xapi.fileHeader.hasVersion)}
-    @end
-
-    {@constructDefaults(xapi)}
-
-    var self = this;
-
-    this.auth = gaxGrpc.auth;
-    @join stub : xapi.stubs on BREAK.add(BREAK)
-      var {@stub.name} = gaxGrpc.createStub(
-          loadedProtos.{@stub.fullyQualifiedType},
-          opts);
-      var {@stub.stubMethodsArrayName} = [
-        @join method : {@stub.methodNames} on {@","}.add(BREAK)
-            '{@method}'
-        @end
-      ];
-      {@stub.stubMethodsArrayName}.forEach(function(methodName) {
-        self['_' + methodName] = gax.createApiCall(
-          {@stub.name}.then(function({@stub.name}) {
-            return function() {
-              var args = Array.prototype.slice.call(arguments, 0);
-              return {@stub.name}[methodName].apply({@stub.name}, args);
-            };
-          }),
-          defaults[methodName],
-          {@getDescriptors(xapi)});
-      });
-    @end
-  }
-@end
-
-@private batchingDescriptors(descriptors)
-  var bundleDescriptors = {
-    @join descriptor : descriptors on {@", "}.add(BREAK)
-      {@descriptor.methodName}: new gax.BundleDescriptor(
-        '{@descriptor.batchedFieldName}',
-        [
-          @join fieldName : descriptor.discriminatorFieldNames() on {@", "}.add(BREAK)
-            '{@fieldName}'
-          @end
-        ],
-        @if descriptor.hasSubresponseField()
-          '{@descriptor.subresponseFieldName}',
-        @else
-          null,
-        @end
-        {@descriptor.byteLengthFunctionName})
-    @end
-  };
-@end
-
-@private longrunningSetup(descriptors, stubs, hasVersion)
-  this.operationsClient = new gax.lro({
-    auth: gaxGrpc.auth,
-    grpc: gaxGrpc.grpc
-  }).operationsClient(opts);
-
-  var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
-  @join stub : stubs
-    protoFilesRoot = protobuf.loadSync(
-      @if hasVersion
-        path.join(__dirname, '..', '..', 'protos', '{@stub.protoFileName}'),
-      @else
-        path.join(__dirname, '..', 'protos', '{@stub.protoFileName}'),
-      @end
-      protoFilesRoot);
-  @end
-
-  @join descriptor : descriptors
-    var {@descriptor.methodName}Response = protoFilesRoot.lookup('{@descriptor.operationPayloadTypeName}');
-    var {@descriptor.methodName}Metadata = protoFilesRoot.lookup('{@descriptor.metadataTypeName}');
-  @end
-
-  this.longrunningDescriptors = {
-    @join descriptor : descriptors on {@", "}.add(BREAK)
-      {@descriptor.methodName}: new gax.LongrunningDescriptor(
-        this.operationsClient,
-        {@descriptor.methodName}Response.decode.bind({@descriptor.methodName}Response),
-        {@descriptor.methodName}Metadata.decode.bind({@descriptor.methodName}Metadata))
-    @end
-  };
-@end
-
-@private constructDefaults(xapi)
-  var defaults = gaxGrpc.constructSettings(
-      '{@xapi.interfaceKey}',
-      configData,
-      opts.clientConfig,
-      {'x-goog-api-client': googleApiClient.join(' ')});
 @end
 
 @private getDescriptors(xapi)

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -171,12 +171,14 @@
 
       // Load the applicable protos.
       var protos = merge({},
-        @join stub : xapi.stubs on BREAK.add(BREAK)
+        @join stub : xapi.stubs on @{","}.add(BREAK)
           gaxGrpc.loadProto(
             @if xapi.fileHeader.hasVersion
-              path.join(__dirname, '..', '..', 'protos'), '{@stub.protoFileName}')
+              path.join(__dirname, '..', '..', 'protos'),
+              '{@stub.protoFileName}')
             @else
-              path.join(__dirname, '..', 'protos'), '{@stub.protoFileName}')
+              path.join(__dirname, '..', 'protos'),
+              '{@stub.protoFileName}'
             @end
           ),
         @end
@@ -198,7 +200,7 @@
         // Iterate over each of the methods that the service provides
         // and create an API call method for each.
         var {@stub.stubMethodsArrayName} = [
-          @join method : {@stub.methodNames} on BREAK.add(BREAK)
+          @join method : {@stub.methodNames} on BREAK
               '{@method}',
           @end
         ];

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -45,6 +45,8 @@
    */
   class {@xapi.name} {
     constructor(opts) {
+      this._descriptors = {};
+
       // Ensure that options include the service address and port.
       opts = Object.assign({
         clientConfig: {},
@@ -71,6 +73,20 @@
         clientHeader.push(`${opts.libName}/${opts.libVersion}`);
       }
 
+      // Load the applicable protos.
+      var protos = merge({},
+        @join stub : xapi.stubs on BREAK
+          gaxGrpc.loadProto(
+            @if xapi.fileHeader.hasVersion
+              path.join(__dirname, '..', '..', 'protos'),
+              '{@stub.protoFileName}'
+            @else
+              path.join(__dirname, '..', 'protos'),
+              '{@stub.protoFileName}'
+            @end
+          ),
+        @end
+      );
       @if xapi.pathTemplates
 
         // This API contains "path templates"; forward-slash-separated
@@ -89,7 +105,7 @@
         // Some of the methods on this service return "paged" results,
         // (e.g. 50 results at a time, with tokens to get subsequent
         // pages). Denote the keys used for pagination and results.
-        this._pageDescriptors = {
+        this._descriptors.page = {
           @join descriptor : xapi.pageStreamingDescriptors on BREAK
             {@descriptor.methodName}: new gax.PageDescriptor(
               '{@descriptor.requestTokenFieldName}',
@@ -103,7 +119,7 @@
 
         // Some of the methods on this service provide streaming responses.
         // Provide descriptors for these.
-        this._streamDescriptors = {
+        this._descriptors.stream = {
           @join descriptor : xapi.grpcStreamingDescriptors on BREAK
             {@descriptor.methodName}: new gax.StreamDescriptor({@descriptor.streamTypeName}),
           @end
@@ -113,7 +129,7 @@
 
         // Some methods on this API support automatically batching
         // requests; denote this.
-        var batchingDescriptors = {
+        this._descriptors.batching = {
           @join descriptor : xapi.batchingDescriptors on BREAK
             {@descriptor.methodName}: new gax.BundleDescriptor(
               '{@descriptor.batchedFieldName}',
@@ -163,7 +179,7 @@
           );
         @end
 
-        this.longrunningDescriptors = {
+        this._descriptors.longrunning = {
           @join descriptor : xapi.longRunningDescriptors on BREAK
             {@descriptor.methodName}: new gax.LongrunningDescriptor(
               this.operationsClient,
@@ -180,21 +196,6 @@
         gapicConfig,
         opts.clientConfig,
         {'x-goog-api-client': clientHeader.join(' ')},
-      );
-
-      // Load the applicable protos.
-      var protos = merge({},
-        @join stub : xapi.stubs on BREAK
-          gaxGrpc.loadProto(
-            @if xapi.fileHeader.hasVersion
-              path.join(__dirname, '..', '..', 'protos'),
-              '{@stub.protoFileName}'
-            @else
-              path.join(__dirname, '..', 'protos'),
-              '{@stub.protoFileName}'
-            @end
-          ),
-        @end
       );
 
       // Set up a dictionary of "inner API calls"; the core implementation
@@ -214,7 +215,7 @@
         // and create an API call method for each.
         var {@stub.stubMethodsArrayName} = [
           @join method : {@stub.methodNames} on BREAK
-              '{@method}',
+            '{@method}',
           @end
         ];
         for (let methodName of {@stub.stubMethodsArrayName}) {

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -184,7 +184,7 @@
 
       // Load the applicable protos.
       var protos = merge({},
-        @join stub : xapi.stubs on @{","}.add(BREAK)
+        @join stub : xapi.stubs on BREAK
           gaxGrpc.loadProto(
             @if xapi.fileHeader.hasVersion
               path.join(__dirname, '..', '..', 'protos'),

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -71,13 +71,26 @@
         clientHeader.push(`${opts.libName}/${opts.libVersion}`);
       }
 
+      @if xapi.pathTemplates
+
+        // This API contains "path templates"; forward-slash-separated
+        // identifiers to uniquely identify resources within the API.
+        // Create useful helper objects for these.
+        this._pathTemplates = {
+          @join pathTemplate : xapi.pathTemplates on BREAK
+            {@pathTemplate.name}: new gax.PathTemplate(
+              '{@pathTemplate.pattern}'
+            ),
+          @end
+        };
+      @end
       @if xapi.hasPageStreamingMethods
 
         // Some of the methods on this service return "paged" results,
         // (e.g. 50 results at a time, with tokens to get subsequent
         // pages). Denote the keys used for pagination and results.
         this._pageDescriptors = {
-          @join descriptor : xapi.pageStreamingDescriptors on BREAK.add(BREAK)
+          @join descriptor : xapi.pageStreamingDescriptors on BREAK
             {@descriptor.methodName}: new gax.PageDescriptor(
               '{@descriptor.requestTokenFieldName}',
               '{@descriptor.responseTokenFieldName}',
@@ -91,7 +104,7 @@
         // Some of the methods on this service provide streaming responses.
         // Provide descriptors for these.
         this._streamDescriptors = {
-          @join descriptor : xapi.grpcStreamingDescriptors on BREAK.add(BREAK)
+          @join descriptor : xapi.grpcStreamingDescriptors on BREAK
             {@descriptor.methodName}: new gax.StreamDescriptor({@descriptor.streamTypeName}),
           @end
         };
@@ -101,11 +114,11 @@
         // Some methods on this API support automatically batching
         // requests; denote this.
         var batchingDescriptors = {
-          @join descriptor : xapi.batchingDescriptors on BREAK.add(BREAK)
+          @join descriptor : xapi.batchingDescriptors on BREAK
             {@descriptor.methodName}: new gax.BundleDescriptor(
               '{@descriptor.batchedFieldName}',
               [
-                @join fieldName : descriptor.discriminatorFieldNames() on BREAK.add(BREAK)
+                @join fieldName : descriptor.discriminatorFieldNames() on BREAK
                   '{@fieldName}',
                 @end
               ],
@@ -151,7 +164,7 @@
         @end
 
         this.longrunningDescriptors = {
-          @join descriptor : xapi.longRunningDescriptors on BREAK.add(BREAK)
+          @join descriptor : xapi.longRunningDescriptors on BREAK
             {@descriptor.methodName}: new gax.LongrunningDescriptor(
               this.operationsClient,
               {@descriptor.methodName}Response.decode.bind({@descriptor.methodName}Response),
@@ -188,8 +201,8 @@
       // of calling the API is handled in `google-gax`, with this code
       // merely providing the destination and request information.
       this._innerApiCalls = {};
+      @join stub : xapi.stubs on BREAK
 
-      @join stub : xapi.stubs on BREAK.add(BREAK)
         // Put together the "service stub" for
         // {@stub.fullyQualifiedType}.
         var {@stub.name} = gaxGrpc.createStub(
@@ -243,13 +256,6 @@
       ];
     }
 
-
-  @if xapi.pathTemplates
-    // Path templates
-
-    {@pathTemplateSection(xapi)}
-  @end
-
     /**
      * Return the project ID used by this class.
      * @@param {function(Error, string)} callback - the callback to
@@ -258,6 +264,10 @@
     getProjectId(callback) {
       return this.auth.getProjectId(callback);
     }
+    @if xapi.pathTemplates
+
+      {@pathTemplateSection(xapi)}
+    @end
 
     {@serviceMethodsSection(xapi)}
   }
@@ -287,11 +297,9 @@
 @end
 
 @private pathTemplateSection(xapi)
-  @join pathTemplate : xapi.pathTemplates on BREAK
-    var {@pathTemplate.name} = new gax.PathTemplate(
-        '{@pathTemplate.pattern}');
-
-  @end
+  // --------------------
+  // -- Path templates --
+  // --------------------
   @join function : xapi.formatResourceFunctions
 
     {@createResourceFunction(function, xapi.name)}
@@ -305,30 +313,31 @@
 
 @private createResourceFunction(function, apiName)
   /**
-   * Returns a fully-qualified {@function.entityName} resource name string.
+   * Return a fully-qualified {@function.entityName} resource name string.
+   *
    @join param : function.resourceIdParams
      * @@param {String} {@param.name}
    @end
    * @@returns {String}
    */
-  {@apiName}.prototype.{@function.name} = \
-  function({@createResourceFunctionParams(function.resourceIdParams)}) {
-    return {@function.pathTemplateName}.render({
+  {@function.name}({@createResourceFunctionParams(function.resourceIdParams)}) {
+    return this._pathTemplates.{@function.pathTemplateName}.render({
       {@createRenderDictionary(function.resourceIdParams)}
     });
-  };
+  }
 @end
 
 @private createMatchFunction(function, apiName)
   /**
-   * Parses the {@function.entityNameParamName} from a {@function.entityName} resource.
+   * Parse the {@function.entityNameParamName} from a {@function.entityName} resource.
+   *
    * @@param {String} {@function.entityNameParamName}
    *   A fully-qualified path representing a {@function.entityName} resources.
    * @@returns {String} - A string representing the {@function.outputResourceId}.
    */
-  {@apiName}.prototype.{@function.name} = function({@function.entityNameParamName}) {
+  {@function.name}({@function.entityNameParamName}) {
     return {@function.pathTemplateName}.match({@function.entityNameParamName}).{@function.outputResourceId};
-  };
+  }
 @end
 
 @private createResourceFunctionParams(resourceIdParams)
@@ -338,13 +347,15 @@
 @end
 
 @private createRenderDictionary(resourceIdParams)
-  @join param: resourceIdParams on {@","}.add(BREAK)
-    {@param.templateKey}: {@param.name}
+  @join param: resourceIdParams on BREAL
+    {@param.templateKey}: {@param.name},
   @end
 @end
 
 @private serviceMethodsSection(xapi)
-  // Service calls
+  // -------------------
+  // -- Service calls --
+  // -------------------
   @join method : xapi.apiMethods
 
     {@flattenedMethod(method)}

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -182,7 +182,7 @@
     @end
 
     var options = {autoPaginate: false};
-    var callbacl = responses => {
+    var callback = responses => {
       // The actual resources in a response.
       var resources = responses[0];
       // The next request if the response shows that there are more responses.

--- a/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/method_sample.snip
@@ -2,17 +2,11 @@
 
 @snippet decorateSampleCode(apiMethod, coreSampleCode)
     @if apiMethod.hasApiVersion
-        var {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
+        const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
 
-        @if apiMethod.packageHasMultipleServices
-          var client = {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.packageServiceName}({
-            // optional auth parameters.
-          });
-        @else
-          var client = {@apiMethod.localPackageName}.{@apiMethod.apiVersion}({
-            // optional auth parameters.
-          });
-        @end
+        var client = new {@apiMethod.localPackageName}.{@apiMethod.apiVersion}.{@apiMethod.apiClassName}({
+          // optional auth parameters.
+        });
 
         {@coreSampleCode}
     @else
@@ -21,17 +15,11 @@
 @end
 
 @snippet decorateSampleCodeUnversioned(apiMethod, coreSampleCode)
-    var {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
+    const {@apiMethod.localPackageName} = require('{@apiMethod.packageName}');
 
-    @if apiMethod.packageHasMultipleServices
-      var client = {@apiMethod.localPackageName}.{@apiMethod.packageServiceName}({
-        // optional auth parameters.
-      });
-    @else
-      var client = {@apiMethod.localPackageName}({
-        // optional auth parameters.
-      });
-    @end
+    var client = {@apiMethod.localPackageName}.{@apiMethod.apiClassName}({
+      // optional auth parameters.
+    });
 
     {@coreSampleCode}
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
@@ -16,7 +16,7 @@
 @end
 
 @private smokeTest(smokeTest)
-  describe('{@smokeTest.name}', function() {
+  describe('{@smokeTest.name}', () => {
     @if smokeTest.requireProjectId
       if (!process.env.SMOKE_TEST_PROJECT) {
         throw new Error("Usage: SMOKE_TEST_PROJECT=<project_id> node #{$0}");
@@ -60,7 +60,7 @@
 @end
 
 @private smokeTestBody(smokeTest, description, sampleCode)
- it('{@description}', function({@mochaCompletedCallback()}) {
+ it('{@description}', {@mochaCompletedCallback()} => {
    {@decorateSampleCode(smokeTest.apiMethod, {@sampleCode})}
  });
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -207,8 +207,8 @@
 
     it('has longrunning decoder functions', () => {
       {@clientInit(testClass, apiTest)}
-      assert(client.longrunningDescriptors.{@test.clientMethodName}.responseDecoder instanceof Function);
-      assert(client.longrunningDescriptors.{@test.clientMethodName}.metadataDecoder instanceof Function);
+      assert(client._descriptors.longrunning.{@test.clientMethodName}.responseDecoder instanceof Function);
+      assert(client._descriptors.longrunning.{@test.clientMethodName}.metadataDecoder instanceof Function);
     });
   });
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -353,17 +353,9 @@
 
 @private clientInit(testClass, apiTest)
   @if apiTest.fileHeader.hasVersion
-    var client = new {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}{@clientBuilderCall(testClass, apiTest)};
+    var client = new {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}();
   @else
-    var client = new {@apiTest.localPackageName}Module.{@testClass.apiClassName}{@clientBuilderCall(testClass, apiTest)};
-  @end
-@end
-
-@private clientBuilderCall(testClass, apiTest)
-  @if apiTest.packageHasMultipleServices
-    .{@testClass.packageServiceName}()
-  @else
-    ()
+    var client = new {@apiTest.localPackageName}Module.{@testClass.apiClassName}();
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -12,7 +12,7 @@
   {@header(apiTest)}
 
   @join testClass : apiTest.testClasses
-    describe('{@testClass.apiClassName}', function() {
+    describe('{@testClass.apiClassName}', () => {
       @join test : testClass.testCases
         {@testCase(test, testClass, apiTest)}
 
@@ -25,11 +25,12 @@
 @end
 
 @private header(apiTest)
-  var assert = require('assert');
-  var {@apiTest.localPackageName} = require('../src');
+  const assert = require('assert');
   @if apiTest.hasGrpcStreaming
-    var through2 = require('through2');
+    const through2 = require('through2');
   @end
+
+  const {@apiTest.localPackageName}Module = require('../src');
 
   var FAKE_STATUS_CODE = 1;
   var error = new Error();
@@ -42,9 +43,11 @@
       assert.deepStrictEqual(actualRequest, expectedRequest);
       if (error) {
         callback(error);
-      } else if (response) {
+      }
+      else if (response) {
         callback(null, response);
-      } else {
+      }
+      else {
         callback(null);
       }
     };
@@ -52,12 +55,13 @@
   @if apiTest.hasServerStreaming
 
     function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
-      return function(actualRequest) {
+      return actualRequest => {
         assert.deepStrictEqual(actualRequest, expectedRequest);
-        var mockStream = through2.obj(function (chunk, enc, callback) {
+        var mockStream = through2.obj((chunk, enc, callback) => {
           if (error) {
             callback(error);
-          } else {
+          }
+          else {
             callback(null, response);
           }
         });
@@ -68,12 +72,13 @@
   @if apiTest.hasBidiStreaming
 
     function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
-      return function() {
-        var mockStream = through2.obj(function (chunk, enc, callback) {
+      return () => {
+        var mockStream = through2.obj((chunk, enc, callback) => {
           assert.deepStrictEqual(chunk, expectedRequest);
           if (error) {
             callback(error);
-          } else {
+          }
+          else {
             callback(null, response);
           }
         });
@@ -84,14 +89,15 @@
   @if apiTest.hasLongRunning
 
     function mockLongRunningGrpcMethod(expectedRequest, response, error) {
-      return function(request) {
+      return request => {
         assert.deepStrictEqual(request, expectedRequest);
         var mockOperation = {
           promise: function() {
-            return new Promise(function(resolve, reject) {
+            return new Promise((resolve, reject) => {
               if (error) {
                 reject(error);
-              } else {
+              }
+              else {
                 resolve([response]);
               }
             });
@@ -126,8 +132,8 @@
 @end
 
 @private requestObjectTestCase(test, testClass, apiTest)
-  describe('{@test.clientMethodName}', function() {
-    it('invokes {@test.clientMethodName} without error', function(done) {
+  describe('{@test.clientMethodName}', () => {
+    it('invokes {@test.clientMethodName} without error', done => {
       {@commonInit(test, testClass, apiTest)}
 
       @if test.hasReturnValue
@@ -137,19 +143,19 @@
       @end
       // Mock Grpc layer
       @if test.hasReturnValue
-        client._{@test.clientMethodName} = mockSimpleGrpcMethod(request, expectedResponse);
+        client._innerApiCalls.{@test.clientMethodName} = mockSimpleGrpcMethod(request, expectedResponse);
       @else
-        client._{@test.clientMethodName} = mockSimpleGrpcMethod(request);
+        client._innerApiCalls.{@test.clientMethodName} = mockSimpleGrpcMethod(request);
       @end
 
       @if test.hasReturnValue
-        client.{@test.clientMethodName}(request, function(err, response) {
+        client.{@test.clientMethodName}(request, (err, response) => {
           assert.ifError(err);
           assert.deepStrictEqual(response, expectedResponse);
           done();
         });
       @else
-        client.{@test.clientMethodName}(request, function(err) {
+        client.{@test.clientMethodName}(request, err => {
           assert.ifError(err);
           done();
         });
@@ -162,44 +168,44 @@
 
 @private operationTestCase(test, testClass, apiTest)
   describe('{@test.clientMethodName}', function() {
-    it('invokes {@test.clientMethodName} without error', function(done) {
+    it('invokes {@test.clientMethodName} without error', done => {
       {@commonInit(test, testClass, apiTest)}
 
       // Mock response
       {@initCodeLines(test.mockResponse.initCode)}
 
       // Mock Grpc layer
-      client._{@test.clientMethodName} = mockLongRunningGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.{@test.clientMethodName} = mockLongRunningGrpcMethod(request, expectedResponse);
 
-      client.{@test.clientMethodName}(request).then(function(responses) {
+      client.{@test.clientMethodName}(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.deepStrictEqual(responses[0], expectedResponse);
         done();
-      }).catch(function(err) {
+      }).catch(err => {
         done(err);
       });
     });
 
-    it('invokes {@test.clientMethodName} with error', function(done) {
+    it('invokes {@test.clientMethodName} with error', done => {
       {@commonInit(test, testClass, apiTest)}
 
       // Mock Grpc layer
-      client._{@test.clientMethodName} = mockLongRunningGrpcMethod(request, null, error);
+      client._innerApiCalls.{@test.clientMethodName} = mockLongRunningGrpcMethod(request, null, error);
 
-      client.{@test.clientMethodName}(request).then(function(responses) {
+      client.{@test.clientMethodName}(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.fail();
-      }).catch(function(err) {
+      }).catch(err => {
         {@assertError()}
         done();
       });
     });
 
-    it('has longrunning decoder functions', function() {
+    it('has longrunning decoder functions', () => {
       {@clientInit(testClass, apiTest)}
       assert(client.longrunningDescriptors.{@test.clientMethodName}.responseDecoder instanceof Function);
       assert(client.longrunningDescriptors.{@test.clientMethodName}.metadataDecoder instanceof Function);
@@ -208,22 +214,22 @@
 @end
 
 @private pagedRequestObjectTestCase(test, testClass, apiTest)
-  describe('{@test.clientMethodName}', function() {
-    it('invokes {@test.clientMethodName} without error', function(done) {
+  describe('{@test.clientMethodName}', () => {
+    it('invokes {@test.clientMethodName} without error', done => {
       {@commonInit(test, testClass, apiTest)}
 
       // Mock response
       {@initCodeLines(test.mockResponse.initCode)}
 
       // Mock Grpc layer
-      client._{@test.clientMethodName} = function(actualRequest, options, callback) {
+      client._innerApiCalls.{@test.clientMethodName} = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         @join pagedResponse : test.pageStreamingResponseViews
           callback(null, expectedResponse.{@pagedResponse.resourcesFieldGetterName});
         @end
       };
 
-      client.{@test.clientMethodName}(request, function(err, response) {
+      client.{@test.clientMethodName}(request, (err, response) => {
         assert.ifError(err);
         @join pagedResponse : test.pageStreamingResponseViews
           assert.deepStrictEqual(response, expectedResponse.{@pagedResponse.resourcesFieldGetterName});
@@ -237,8 +243,8 @@
 @end
 
 @private streamingTestCase(test, testClass, apiTest)
-  describe('{@test.clientMethodName}', function() {
-    it('invokes {@test.clientMethodName} without error', function(done) {
+  describe('{@test.clientMethodName}', () => {
+    it('invokes {@test.clientMethodName} without error', done => {
       {@commonInit(test, testClass, apiTest)}
 
       // Mock response
@@ -247,28 +253,28 @@
       // Mock Grpc layer
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        client._{@test.clientMethodName} = mockServerStreamingGrpcMethod(request, expectedResponse);
+        client._innerApiCalls.{@test.clientMethodName} = mockServerStreamingGrpcMethod(request, expectedResponse);
       @case "BidiStreaming"
-        client._{@test.clientMethodName} = mockBidiStreamingGrpcMethod(request, expectedResponse);
+        client._innerApiCalls.{@test.clientMethodName} = mockBidiStreamingGrpcMethod(request, expectedResponse);
       @end
 
       @switch test.grpcStreamingType
       @case "ServerStreaming"
         var stream = client.{@test.clientMethodName}(request);
-        stream.on('data', function(response) {
+        stream.on('data', response => {
           assert.deepStrictEqual(response, expectedResponse);
-          done()
+          done();
         });
-        stream.on('error', function(err) {
+        stream.on('error', err => {
           done(err);
         });
 
         stream.write();
       @case "BidiStreaming"
-        var stream = client.{@test.clientMethodName}().on('data', function(response) {
+        var stream = client.{@test.clientMethodName}().on('data', response => {
           assert.deepStrictEqual(response, expectedResponse);
-          done()
-        }).on('error', function(err) {
+          done();
+        }).on('error', err => {
           done(err);
         });
 
@@ -278,33 +284,33 @@
       @end
     });
 
-    it('invokes {@test.clientMethodName} with error', function(done) {
+    it('invokes {@test.clientMethodName} with error', done => {
       {@commonInit(test, testClass, apiTest)}
 
       // Mock Grpc layer
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        client._{@test.clientMethodName} = mockServerStreamingGrpcMethod(request, null, error);
+        client._innerApiCalls.{@test.clientMethodName} = mockServerStreamingGrpcMethod(request, null, error);
       @case "BidiStreaming"
-        client._{@test.clientMethodName} = mockBidiStreamingGrpcMethod(request, null, error);
+        client._innerApiCalls.{@test.clientMethodName} = mockBidiStreamingGrpcMethod(request, null, error);
       @end
 
       @switch test.grpcStreamingType
       @case "ServerStreaming"
         var stream = client.{@test.clientMethodName}(request);
-        stream.on('data', function(response) {
+        stream.on('data', response => {
           assert.fail();
-        })
-        stream.on('error', function(err) {
+        });
+        stream.on('error', err =>){
           {@assertError()}
           done();
         });
 
         stream.write();
       @case "BidiStreaming"
-        var stream = client.{@test.clientMethodName}().on('data', function(response) {
+        var stream = client.{@test.clientMethodName}().on('data', response => {
           assert.fail();
-        }).on('error', function(err) {
+        }).on('error', err => {
           {@assertError()}
           done();
         });
@@ -318,19 +324,19 @@
 @end
 
 @private simpleTestWithError(test, testClass, apiTest)
-  it('invokes {@test.clientMethodName} with error', function(done) {
+  it('invokes {@test.clientMethodName} with error', done => {
     {@commonInit(test, testClass, apiTest)}
 
     // Mock Grpc layer
-    client._{@test.clientMethodName} = mockSimpleGrpcMethod(request, null, error);
+    client._innerApiCalls.{@test.clientMethodName} = mockSimpleGrpcMethod(request, null, error);
 
     @if test.hasReturnValue
-      client.{@test.clientMethodName}(request, function(err, response) {
+      client.{@test.clientMethodName}(request, (err, response) => {
         {@assertError()}
         done();
       });
     @else
-      client.{@test.clientMethodName}(request, function(err) {
+      client.{@test.clientMethodName}(request, err => {
         {@assertError()}
         done();
       });
@@ -347,9 +353,9 @@
 
 @private clientInit(testClass, apiTest)
   @if apiTest.fileHeader.hasVersion
-    var client = {@apiTest.localPackageName}.{@apiTest.fileHeader.version}{@clientBuilderCall(testClass, apiTest)};
+    var client = new {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}{@clientBuilderCall(testClass, apiTest)};
   @else
-    var client = {@apiTest.localPackageName}{@clientBuilderCall(testClass, apiTest)};
+    var client = new {@apiTest.localPackageName}Module.{@testClass.apiClassName}{@clientBuilderCall(testClass, apiTest)};
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
@@ -1,133 +1,23 @@
 @extends "nodejs/common.snip"
 
 @snippet generate(index)
-  {@header(index.fileHeader)}
-
-  {@imports(index)}
-
-  {@constants()}
-
-  {@clients(index)}
-
-  {@protos(index)}
-
-  {@exports(index)}
-@end
-
-@private header(fileHeader)
-  /*
-   {@comments(fileHeader.copyrightLines)}
+  /**
+   {@comments(index.fileHeader.copyrightLines)}
    *
-   {@comments(fileHeader.licenseLines)}
+   {@comments(index.fileHeader.licenseLines)}
    */
+
   'use strict';
-@end
 
-@private imports(index)
-  # TODO(landrito): move this to an import section transformer.
-  var extend = require('extend');
+  const VERSION = require('../package.json').version;
+
+  // Import the clients for each version supported by this package.
   var gapic = {
-    {@index.apiVersion}: require('./{@index.apiVersion}')
+    {@index.apiVersion}: require('./{@index.apiVersion}'),
   };
-  var gaxGrpc = require('google-gax').grpc();
-  var path = require('path');
-@end
 
-@private constants()
-   const VERSION = require('../package.json').version;
- @end
+  module.exports = gapic.{@index.apiVersion};
+  module.exports.{@index.apiVersion} = gapic.{@index.apiVersion};
+  module.exports.default = Object.assign({}, module.exports);
 
-@private clients(index)
-  @join service : index.requireViews on BREAK.add(BREAK)
-    {@client(service, index.apiVersion)}
-  @end
-@end
-
-@private client(service, version)
-   /**
-    * Create an {@service.clientName} with additional helpers for common
-    * tasks.
-    *
-    {@comments(@service.doc.lines)}
-    *
-    * @@param {object=} options - [Configuration object](#/docs).
-    * @@param {object=} options.credentials - Credentials object.
-    * @@param {string=} options.credentials.client_email
-    * @@param {string=} options.credentials.private_key
-    * @@param {string=} options.email - Account email address. Required when using a
-    *     .pem or .p12 keyFilename.
-    * @@param {string=} options.keyFilename - Full path to the a .json, .pem, or
-    *     .p12 key downloaded from the Google Developers Console. If you provide
-    *     a path to a JSON file, the projectId option above is not necessary.
-    *     NOTE: .pem and .p12 require you to specify options.email as well.
-    * @@param {number=} options.port - The port on which to connect to
-    *     the remote host.
-    * @@param {string=} options.projectId - The project ID from the Google
-    *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
-    *     the environment variable GCLOUD_PROJECT for your project ID. If your
-    *     app is running in an environment which supports
-    *     {@@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
-    *     your project ID will be detected automatically.
-    * @@param {function=} options.promise - Custom promise module to use instead
-    *     of native Promises.
-    * @@param {string=} options.servicePath - The domain name of the
-    *     API remote host.
-    */
-   function {@service.localName}(options) {
-     // Define the header options.
-     options = extend({}, options, {
-       libName: 'gccl',
-       libVersion: VERSION
-     });
-
-     // Create the client with the provided options.
-     var client = gapic.{@version}(options).{@service.clientName}(options);
-     return client;
-   }
-@end
-
-@private protos(index)
-  var {@index.apiVersion}Protos = {};
-
-  @join stub : index.stubs on BREAK.add(BREAK)
-    {@messages(index.isGcloud, index.apiVersion, stub)}
-  @end
-@end
-
-@private messages(isGcloud, version, stub)
-    extend({@version}Protos, gaxGrpc.loadProto(
-      # This does not follow the import in main.snip since version index is not generated
-      # for unversioned Apis. This will be changed when top level indexes are supported
-      # for unversioned Apis.
-      path.join(__dirname, '..', 'protos'), '{@stub.protoFileName}')
-        .{@stub.namespace});
-@end
-
-@private exports(index)
-  @if index.hasMultipleServices
-    {@multipleServicesExports(index.requireViews, index.apiVersion)}
-  @else
-    {@singleServiceExport(index.primaryService, index.apiVersion)}
-  @end
-@end
-
-@private multipleServicesExports(services, version)
-  @join service : services
-    module.exports.{@service.serviceName} = {@service.localName};
-  @end
-
-  module.exports.types = {@version}Protos;
-
-  module.exports.{@version} = {};
-  @join service : services
-    module.exports.{@version}.{@service.serviceName} = {@service.localName};
-  @end
-  module.exports.{@version}.types = {@version}Protos;
-@end
-
-@private singleServiceExport(service, version)
-  module.exports = {@service.localName};
-  module.exports.types = {@version}Protos;
-  module.exports.{@version} = {@service.localName};
-  module.exports.{@version}.types = {@version}Protos;
 @end

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -2474,7 +2474,7 @@ class LibraryServiceClient {
       gaxGrpc.loadProto(
         path.join(__dirname, '..', '..', 'protos'),
         'library.proto'
-      ),,
+      ),
       gaxGrpc.loadProto(
         path.join(__dirname, '..', '..', 'protos'),
         'tagger.proto'

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -2318,6 +2318,8 @@ const protobuf = require('protobufjs');
  */
 class LibraryServiceClient {
   constructor(opts) {
+    this._descriptors = {};
+
     // Ensure that options include the service address and port.
     opts = Object.assign({
       clientConfig: {},
@@ -2344,6 +2346,17 @@ class LibraryServiceClient {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
 
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'library.proto'
+      ),
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'tagger.proto'
+      ),
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -2363,7 +2376,7 @@ class LibraryServiceClient {
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
-    this._pageDescriptors = {
+    this._descriptors.page = {
       listShelves: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
@@ -2388,7 +2401,7 @@ class LibraryServiceClient {
 
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
-    this._streamDescriptors = {
+    this._descriptors.stream = {
       streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
       streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
       discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
@@ -2397,7 +2410,7 @@ class LibraryServiceClient {
 
     // Some methods on this API support automatically batching
     // requests; denote this.
-    var batchingDescriptors = {
+    this._descriptors.batching = {
       publishSeries: new gax.BundleDescriptor(
         'books',
         [
@@ -2405,7 +2418,7 @@ class LibraryServiceClient {
           'shelf.name',
         ],
         'bookNames',
-        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book),
+        gax.createByteLengthFunction(protos.google.example.library.v1.Book),
       ),
       addComments: new gax.BundleDescriptor(
         'comments',
@@ -2413,7 +2426,7 @@ class LibraryServiceClient {
           'name',
         ],
         null,
-        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Comment),
+        gax.createByteLengthFunction(protos.google.example.library.v1.Comment),
       ),
     };
 
@@ -2448,7 +2461,7 @@ class LibraryServiceClient {
       'google.example.library.v1.GetBigBookMetadata'
     );
 
-    this.longrunningDescriptors = {
+    this._descriptors.longrunning = {
       getBigBook: new gax.LongrunningDescriptor(
         this.operationsClient,
         getBigBookResponse.decode.bind(getBigBookResponse),
@@ -2467,18 +2480,6 @@ class LibraryServiceClient {
       gapicConfig,
       opts.clientConfig,
       {'x-goog-api-client': clientHeader.join(' ')},
-    );
-
-    // Load the applicable protos.
-    var protos = merge({},
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos'),
-        'library.proto'
-      ),
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos'),
-        'tagger.proto'
-      ),
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -2531,7 +2532,7 @@ class LibraryServiceClient {
           return stub[methodName].apply(stub, args);
         }),
         defaults[methodName],
-        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+        this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
     }
 
@@ -2554,7 +2555,7 @@ class LibraryServiceClient {
           return stub[methodName].apply(stub, args);
         }),
         defaults[methodName],
-        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+        this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
     }
   }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -84,7 +84,6 @@ $ npm install --save @google-cloud/library
     "Google Example Library API"
   ],
   "dependencies": {
-    "extend": "^3.0",
     "google-gax": "^0.14.0",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
@@ -154,7 +153,7 @@ describe('LibraryServiceSmokeTest', function() {
   });
 });
 ============== file: src/index.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -169,85 +168,20 @@ describe('LibraryServiceSmokeTest', function() {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-var extend = require('extend');
-var gapic = {
-  v1: require('./v1')
-};
-var gaxGrpc = require('google-gax').grpc();
-var path = require('path');
+'use strict';
 
 const VERSION = require('../package.json').version;
 
-/**
- * Create an libraryServiceClient with additional helpers for common
- * tasks.
- *
- * This API represents a simple digital library.  It lets you manage Shelf
- * resources and Book resources in the library. It defines the following
- * resource model:
- *
- * - The API has a collection of {@link Shelf}
- *   resources, named ``bookShelves/*``
- *
- * - Each Shelf has a collection of {@link Book}
- *   resources, named `bookShelves/*/books/*`
- *
- * Check out [cloud docs!](https://cloud.google.com/library/example/link).
- * This is [not a cloud link](http://www.google.com).
- *
- * Service comment may include special characters: <>&"`'@.
- *
- * @param {object=} options - [Configuration object](#/docs).
- * @param {object=} options.credentials - Credentials object.
- * @param {string=} options.credentials.client_email
- * @param {string=} options.credentials.private_key
- * @param {string=} options.email - Account email address. Required when using a
- *     .pem or .p12 keyFilename.
- * @param {string=} options.keyFilename - Full path to the a .json, .pem, or
- *     .p12 key downloaded from the Google Developers Console. If you provide
- *     a path to a JSON file, the projectId option above is not necessary.
- *     NOTE: .pem and .p12 require you to specify options.email as well.
- * @param {number=} options.port - The port on which to connect to
- *     the remote host.
- * @param {string=} options.projectId - The project ID from the Google
- *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
- *     the environment variable GCLOUD_PROJECT for your project ID. If your
- *     app is running in an environment which supports
- *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
- *     your project ID will be detected automatically.
- * @param {function=} options.promise - Custom promise module to use instead
- *     of native Promises.
- * @param {string=} options.servicePath - The domain name of the
- *     API remote host.
- */
-function libraryV1(options) {
-  // Define the header options.
-  options = extend({}, options, {
-    libName: 'gccl',
-    libVersion: VERSION
-  });
+// Import the clients for each version supported by this package.
+var gapic = {
+  v1: require('./v1'),
+};
 
-  // Create the client with the provided options.
-  var client = gapic.v1(options).libraryServiceClient(options);
-  return client;
-}
+module.exports = gapic.v1;
+module.exports.v1 = gapic.v1;
+module.exports.default = Object.assign({}, module.exports);
 
-var v1Protos = {};
-
-extend(v1Protos, gaxGrpc.loadProto(
-  path.join(__dirname, '..', 'protos'), 'library.proto')
-    .google.example.library.v1);
-
-extend(v1Protos, gaxGrpc.loadProto(
-  path.join(__dirname, '..', 'protos'), 'tagger.proto')
-    .google.tagger.v1);
-
-module.exports = libraryV1;
-module.exports.types = v1Protos;
-module.exports.v1 = libraryV1;
-module.exports.v1.types = v1Protos;
 ============== file: src/v1/doc/google/example/library/v1/doc_field_mask.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -2332,22 +2266,10 @@ var Unused = {
  */
 'use strict';
 
-var libraryServiceClient = require('./library_service_client');
-var gax = require('google-gax');
-var extend = require('extend');
+const LibraryServiceClient = require('./library_service_client');
 
-function v1(options) {
-  options = extend({
-    scopes: v1.ALL_SCOPES
-  }, options);
-  var gaxGrpc = gax.grpc(options);
-  return libraryServiceClient(gaxGrpc);
-}
+module.exports.LibraryServiceClient = LibraryServiceClient;
 
-v1.SERVICE_ADDRESS = libraryServiceClient.SERVICE_ADDRESS;
-v1.ALL_SCOPES = libraryServiceClient.ALL_SCOPES;
-
-module.exports = v1;
 ============== file: src/v1/library_service_client.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -2363,66 +2285,15 @@ module.exports = v1;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * EDITING INSTRUCTIONS
- * This file was generated from the file
- * https://github.com/googleapis/googleapis/blob/master/library.proto,
- * and updates to that file get reflected here through a refresh process.
- * For the short term, the refresh process will only be runnable by Google
- * engineers.
- *
- * The only allowed edits are to method and file documentation. A 3-way
- * merge preserves those additions if the generated source changes.
  */
+
 'use strict';
 
-var configData = require('./library_service_client_config');
-var extend = require('extend');
-var gax = require('google-gax');
-var merge = require('lodash.merge');
-var path = require('path');
-var protobuf = require('protobufjs');
-
-var SERVICE_ADDRESS = 'library-example.googleapis.com';
-
-var DEFAULT_SERVICE_PORT = 443;
-
-var CODE_GEN_NAME_VERSION = 'gapic/0.0.5';
-
-var PAGE_DESCRIPTORS = {
-  listShelves: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'shelves'),
-  listBooks: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'books'),
-  listStrings: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'strings'),
-  findRelatedBooks: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'names')
-};
-
-var STREAM_DESCRIPTORS = {
-  streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-  streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-  discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
-  monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING)
-};
-
-/*!
- * The scopes needed to make gRPC calls to all of the methods defined in
- * this service.
- */
-var ALL_SCOPES = [
-  'https://www.googleapis.com/auth/cloud-platform',
-  'https://www.googleapis.com/auth/library'
-];
+const configData = require('./library_service_client_config');
+const gax = require('google-gax');
+const merge = require('lodash.merge');
+const path = require('path');
+const protobuf = require('protobufjs');
 
 /**
  * This API represents a simple digital library.  It lets you manage Shelf
@@ -2443,143 +2314,269 @@ var ALL_SCOPES = [
  *
  * @class
  */
-function LibraryServiceClient(gaxGrpc, loadedProtos, opts) {
-  opts = extend({
-    servicePath: SERVICE_ADDRESS,
-    port: DEFAULT_SERVICE_PORT,
-    clientConfig: {}
-  }, opts);
+class LibraryServiceClient {
+  constructor(opts) {
+    // Ensure that options include the service address and port.
+    opts = Object.assign({
+      clientConfig: {},
+      port: this.constructor.port,
+      servicePath: this.constructor.servicePath,
+    }, opts);
 
-  var googleApiClient = [
-    'gl-node/' + process.versions.node
-  ];
-  if (opts.libName && opts.libVersion) {
-    googleApiClient.push(opts.libName + '/' + opts.libVersion);
-  }
-  googleApiClient.push(
-    CODE_GEN_NAME_VERSION,
-    'gax/' + gax.version,
-    'grpc/' + gaxGrpc.grpcVersion
-  );
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    Object.assign(opts, {scopes: this.constructor.scopes});
+    var gaxGrpc = gax.grpc(opts);
 
-  var bundleDescriptors = {
-    publishSeries: new gax.BundleDescriptor(
-      'books',
-      [
-        'edition',
-        'shelf.name'
-      ],
-      'bookNames',
-      gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book)),
-    addComments: new gax.BundleDescriptor(
-      'comments',
-      [
-        'name'
-      ],
-      null,
-      gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Comment))
-  };
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
 
-  this.operationsClient = new gax.lro({
-    auth: gaxGrpc.auth,
-    grpc: gaxGrpc.grpc
-  }).operationsClient(opts);
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${this.version}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
 
-  var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
-  protoFilesRoot = protobuf.loadSync(
-    path.join(__dirname, '..', '..', 'protos', 'library.proto'),
-    protoFilesRoot);
-  protoFilesRoot = protobuf.loadSync(
-    path.join(__dirname, '..', '..', 'protos', 'tagger.proto'),
-    protoFilesRoot);
 
-  var getBigBookResponse = protoFilesRoot.lookup('google.example.library.v1.Book');
-  var getBigBookMetadata = protoFilesRoot.lookup('google.example.library.v1.GetBigBookMetadata');
-  var getBigNothingResponse = protoFilesRoot.lookup('google.protobuf.Empty');
-  var getBigNothingMetadata = protoFilesRoot.lookup('google.example.library.v1.GetBigBookMetadata');
+    // Some of the methods on this service return "paged" results,
+    // (e.g. 50 results at a time, with tokens to get subsequent
+    // pages). Denote the keys used for pagination and results.
+    this._pageDescriptors = {
+      listShelves: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'shelves'
+      ),
 
-  this.longrunningDescriptors = {
-    getBigBook: new gax.LongrunningDescriptor(
-      this.operationsClient,
-      getBigBookResponse.decode.bind(getBigBookResponse),
-      getBigBookMetadata.decode.bind(getBigBookMetadata)),
-    getBigNothing: new gax.LongrunningDescriptor(
-      this.operationsClient,
-      getBigNothingResponse.decode.bind(getBigNothingResponse),
-      getBigNothingMetadata.decode.bind(getBigNothingMetadata))
-  };
+      listBooks: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'books'
+      ),
 
-  var defaults = gaxGrpc.constructSettings(
+      listStrings: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'strings'
+      ),
+
+      findRelatedBooks: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'names'
+      ),
+    };
+
+    // Some of the methods on this service provide streaming responses.
+    // Provide descriptors for these.
+    this._streamDescriptors = {
+      streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+
+      streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+
+      discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
+
+      monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
+    };
+
+    // Some methods on this API support automatically batching
+    // requests; denote this.
+    var batchingDescriptors = {
+      publishSeries: new gax.BundleDescriptor(
+        'books',
+        [
+          'edition',
+
+          'shelf.name',
+        ],
+        'bookNames',
+        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book),
+      ),
+
+      addComments: new gax.BundleDescriptor(
+        'comments',
+        [
+          'name',
+        ],
+        null,
+        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Comment),
+      ),
+    };
+
+    // This API contains "long-running operations", which return a
+    // an Operation object that allows for tracking of the operation,
+    // rather than holding a request open.
+    this.operationsClient = new gax.lro({
+      auth: gaxGrpc.auth,
+      grpc: gaxGrpc.grpc,
+    }).operationsClient(opts);
+
+    var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+    protoFilesRoot = protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'library.proto'),
+      protoFilesRoot
+    );
+    protoFilesRoot = protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'tagger.proto'),
+      protoFilesRoot
+    );
+
+    var getBigBookResponse = protoFilesRoot.lookup(
+      'google.example.library.v1.Book'
+    );
+    var getBigBookMetadata = protoFilesRoot.lookup(
+      'google.example.library.v1.GetBigBookMetadata'
+    );
+    var getBigNothingResponse = protoFilesRoot.lookup(
+      'google.protobuf.Empty'
+    );
+    var getBigNothingMetadata = protoFilesRoot.lookup(
+      'google.example.library.v1.GetBigBookMetadata'
+    );
+
+    this.longrunningDescriptors = {
+      getBigBook: new gax.LongrunningDescriptor(
+        this.operationsClient,
+        getBigBookResponse.decode.bind(getBigBookResponse),
+        getBigBookMetadata.decode.bind(getBigBookMetadata)
+      ),
+
+      getBigNothing: new gax.LongrunningDescriptor(
+        this.operationsClient,
+        getBigNothingResponse.decode.bind(getBigNothingResponse),
+        getBigNothingMetadata.decode.bind(getBigNothingMetadata)
+      ),
+    };
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
       'google.example.library.v1.LibraryService',
-      configData,
+      gapicConfig,
       opts.clientConfig,
-      {'x-goog-api-client': googleApiClient.join(' ')});
+      {'x-goog-api-client': clientHeader.join(' ')},
+    );
 
-  var self = this;
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'library.proto'
+      ),,
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'tagger.proto'
+      ),
+    );
 
-  this.auth = gaxGrpc.auth;
-  var libraryServiceStub = gaxGrpc.createStub(
-      loadedProtos.google.example.library.v1.LibraryService,
-      opts);
-  var libraryServiceStubMethods = [
-    'createShelf',
-    'getShelf',
-    'listShelves',
-    'deleteShelf',
-    'mergeShelves',
-    'createBook',
-    'publishSeries',
-    'getBook',
-    'listBooks',
-    'deleteBook',
-    'updateBook',
-    'moveBook',
-    'listStrings',
-    'addComments',
-    'getBookFromArchive',
-    'getBookFromAnywhere',
-    'getBookFromAbsolutelyAnywhere',
-    'updateBookIndex',
-    'streamShelves',
-    'streamBooks',
-    'discussBook',
-    'monologAboutBook',
-    'findRelatedBooks',
-    'addTag',
-    'getBigBook',
-    'getBigNothing',
-    'testOptionalRequiredFlatteningParams'
-  ];
-  libraryServiceStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      libraryServiceStub.then(function(libraryServiceStub) {
-        return function() {
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.example.library.v1.LibraryService.
+    var libraryServiceStub = gaxGrpc.createStub(
+      protos.google.example.library.v1.LibraryService,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var libraryServiceStubMethods = [
+      'createShelf',
+      'getShelf',
+      'listShelves',
+      'deleteShelf',
+      'mergeShelves',
+      'createBook',
+      'publishSeries',
+      'getBook',
+      'listBooks',
+      'deleteBook',
+      'updateBook',
+      'moveBook',
+      'listStrings',
+      'addComments',
+      'getBookFromArchive',
+      'getBookFromAnywhere',
+      'getBookFromAbsolutelyAnywhere',
+      'updateBookIndex',
+      'streamShelves',
+      'streamBooks',
+      'discussBook',
+      'monologAboutBook',
+      'findRelatedBooks',
+      'addTag',
+      'getBigBook',
+      'getBigNothing',
+      'testOptionalRequiredFlatteningParams',
+    ];
+    for (let methodName of libraryServiceStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        libraryServiceStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return libraryServiceStub[methodName].apply(libraryServiceStub, args);
-        };
-      }),
-      defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
-  });
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+      );
+    }
 
-  var labelerStub = gaxGrpc.createStub(
-      loadedProtos.google.tagger.v1.Labeler,
-      opts);
-  var labelerStubMethods = [
-    'addLabel'
-  ];
-  labelerStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      labelerStub.then(function(labelerStub) {
-        return function() {
+    // Put together the "service stub" for
+    // google.tagger.v1.Labeler.
+    var labelerStub = gaxGrpc.createStub(
+      protos.google.tagger.v1.Labeler,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var labelerStubMethods = [
+      'addLabel',
+    ];
+    for (let methodName of labelerStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        labelerStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return labelerStub[methodName].apply(labelerStub, args);
-        };
-      }),
-      defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
-  });
-}
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+      );
+    }
+  }
+
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'library-example.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+      'https://www.googleapis.com/auth/cloud-platform',
+
+      'https://www.googleapis.com/auth/library',
+    ];
+  }
+
 
 // Path templates
 
@@ -2691,2054 +2688,1964 @@ LibraryServiceClient.prototype.matchReturnFromReturnName = function(returnName) 
   return RETURN_PATH_TEMPLATE.match(returnName).return;
 };
 
-/**
- * Get the project ID used by this class.
- * @param {function(Error, string)} callback - the callback to be called with
- *   the current project Id.
- */
-LibraryServiceClient.prototype.getProjectId = function(callback) {
-  return this.auth.getProjectId(callback);
-};
-
-// Service calls
-
-/**
- * Creates a shelf, and returns the new Shelf.
- * RPC method comment may include special characters: <>&"`'@.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {Object} request.shelf
- *   The shelf to create.
- *
- *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var shelf = {};
- * client.createShelf({shelf: shelf}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.createShelf = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
+  /**
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
+   */
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
   }
 
-  return this._createShelf(request, options, callback);
-};
-
-/**
- * Gets a shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf to retrieve.
- * @param {string} request.options
- *   To test 'options' parameter name conflict.
- * @param {Object=} request.message
- *   Field to verify that message-type query parameter gets flattened.
- *
- *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
- * @param {Object=} request.stringBuilder
- *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * var options = '';
- * var request = {
- *     name: formattedName,
- *     options: options
- * };
- * client.getShelf(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getShelf = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getShelf(request, options, callback);
-};
-
-/**
- * Lists shelves.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of [Shelf]{@link google.example.library.v1.Shelf}.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Shelf]{@link google.example.library.v1.Shelf}.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Shelf]{@link google.example.library.v1.Shelf} in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * client.listShelves({}).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.listShelves(nextRequest, options).then(callback);
- *     }
- * }
- * client.listShelves({}, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.listShelves = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._listShelves(request, options, callback);
-};
-
-/**
- * Equivalent to {@link listShelves}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link listShelves} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits an object representing [Shelf]{@link google.example.library.v1.Shelf} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- *
- * client.listShelvesStream({})
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.listShelvesStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return PAGE_DESCRIPTORS.listShelves.createStream(this._listShelves, request, options);
-};
-
-/**
- * Deletes a shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf to delete.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * client.deleteShelf({name: formattedName}).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.deleteShelf = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._deleteShelf(request, options, callback);
-};
-
-/**
- * Merges two shelves by adding all books from the shelf named
- * `other_shelf_name` to shelf `name`, and deletes
- * `other_shelf_name`. Returns the updated shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf we're adding books to.
- * @param {string} request.otherShelfName
- *   The name of the shelf we're removing books from and deleting.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
- * var request = {
- *     name: formattedName,
- *     otherShelfName: formattedOtherShelfName
- * };
- * client.mergeShelves(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.mergeShelves = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._mergeShelves(request, options, callback);
-};
-
-/**
- * Creates a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf in which the book is created.
- * @param {Object} request.book
- *   The book to create.
- *
- *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * var book = {};
- * var request = {
- *     name: formattedName,
- *     book: book
- * };
- * client.createBook(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.createBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._createBook(request, options, callback);
-};
-
-/**
- * Creates a series of books.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {Object} request.shelf
- *   The shelf in which the series is created.
- *
- *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
- * @param {Object[]} request.books
- *   The books to publish in the series.
- *
- *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
- * @param {Object} request.seriesUuid
- *   Uniquely identifies the series to the publishing house.
- *
- *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
- * @param {number=} request.edition
- *   The edition of the series
- * @param {boolean=} request.reviewCopy
- *   If the book is in a pre-publish state
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var shelf = {};
- * var books = [];
- * var seriesString = 'foobar';
- * var seriesUuid = {
- *     seriesString : seriesString
- * };
- * var request = {
- *     shelf: shelf,
- *     books: books,
- *     seriesUuid: seriesUuid
- * };
- * client.publishSeries(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.publishSeries = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._publishSeries(request, options, callback);
-};
-
-/**
- * Gets a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * client.getBook({name: formattedName}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBook(request, options, callback);
-};
-
-/**
- * Lists books in a shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf whose books we'd like to list.
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {string=} request.filter
- *   To test python built-in wrapping.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of [Book]{@link google.example.library.v1.Book}.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Book]{@link google.example.library.v1.Book}.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Book]{@link google.example.library.v1.Book} in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * var formattedName = client.shelfPath("[SHELF_ID]");
- *
- * client.listBooks({name: formattedName}).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- * var formattedName = client.shelfPath("[SHELF_ID]");
- *
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.listBooks(nextRequest, options).then(callback);
- *     }
- * }
- * client.listBooks({name: formattedName}, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.listBooks = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._listBooks(request, options, callback);
-};
-
-/**
- * Equivalent to {@link listBooks}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link listBooks} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf whose books we'd like to list.
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {string=} request.filter
- *   To test python built-in wrapping.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits an object representing [Book]{@link google.example.library.v1.Book} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * client.listBooksStream({name: formattedName})
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.listBooksStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return PAGE_DESCRIPTORS.listBooks.createStream(this._listBooks, request, options);
-};
-
-/**
- * Deletes a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to delete.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * client.deleteBook({name: formattedName}).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.deleteBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._deleteBook(request, options, callback);
-};
-
-/**
- * Updates a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to update.
- * @param {Object} request.book
- *   The book to update with.
- *
- *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
- * @param {Object=} request.updateMask
- *   A field mask to apply, rendered as an HTTP parameter.
- *
- *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
- * @param {Object=} request.physicalMask
- *   To test Python import clash resolution.
- *
- *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var book = {};
- * var request = {
- *     name: formattedName,
- *     book: book
- * };
- * client.updateBook(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.updateBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._updateBook(request, options, callback);
-};
-
-/**
- * Moves a book to another shelf, and returns the new book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to move.
- * @param {string} request.otherShelfName
- *   The name of the destination shelf.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
- * var request = {
- *     name: formattedName,
- *     otherShelfName: formattedOtherShelfName
- * };
- * client.moveBook(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.moveBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._moveBook(request, options, callback);
-};
-
-/**
- * Lists a primitive resource. To test go page streaming.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string=} request.name
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of string.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of string.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of string in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * client.listStrings({}).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.listStrings(nextRequest, options).then(callback);
- *     }
- * }
- * client.listStrings({}, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.listStrings = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._listStrings(request, options, callback);
-};
-
-/**
- * Equivalent to {@link listStrings}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link listStrings} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string=} request.name
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits a string on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- *
- * client.listStringsStream({})
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.listStringsStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return PAGE_DESCRIPTORS.listStrings.createStream(this._listStrings, request, options);
-};
-
-/**
- * Adds comments to a book
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- * @param {Object[]} request.comments
- *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var comment = '';
- * var stage = library.v1.types.Comment.Stage.UNSET;
- * var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
- * var commentsElement = {
- *     comment : comment,
- *     stage : stage,
- *     alignment : alignment
- * };
- * var comments = [commentsElement];
- * var request = {
- *     name: formattedName,
- *     comments: comments
- * };
- * client.addComments(request).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.addComments = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._addComments(request, options, callback);
-};
-
-/**
- * Gets a book from an archive.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
- * client.getBookFromArchive({name: formattedName}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBookFromArchive = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBookFromArchive(request, options, callback);
-};
-
-/**
- * Gets a book from a shelf or archive.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {string} request.altBookName
- *   An alternate book name, used to test restricting flattened field to a
- *   single resource name type in a oneof.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var formattedAltBookName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var request = {
- *     name: formattedName,
- *     altBookName: formattedAltBookName
- * };
- * client.getBookFromAnywhere(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBookFromAnywhere = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBookFromAnywhere(request, options, callback);
-};
-
-/**
- * Test proper OneOf-Any resource name mapping
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * client.getBookFromAbsolutelyAnywhere({name: formattedName}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBookFromAbsolutelyAnywhere = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBookFromAbsolutelyAnywhere(request, options, callback);
-};
-
-/**
- * Updates the index of a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to update.
- * @param {string} request.indexName
- *   The name of the index for the book
- * @param {Object.<string, string>} request.indexMap
- *   The index to update the book with
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var indexName = 'default index';
- * var indexMapItem = '';
- * var indexMap = {'default_key' : indexMapItem,};
- * var request = {
- *     name: formattedName,
- *     indexName: indexName,
- *     indexMap: indexMap
- * };
- * client.updateBookIndex(request).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.updateBookIndex = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._updateBookIndex(request, options, callback);
-};
-
-/**
- * Test server streaming
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits [StreamShelvesResponse]{@link google.example.library.v1.StreamShelvesResponse} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- *
- * client.streamShelves({}).on('data', function(response) {
- *   // doThingsWith(response)
- * });
- */
-LibraryServiceClient.prototype.streamShelves = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._streamShelves(request, options);
-};
-
-/**
- * Test server streaming, non-paged responses.
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf whose books we'd like to list.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits [Book]{@link google.example.library.v1.Book} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var name = '';
- * client.streamBooks({name: name}).on('data', function(response) {
- *   // doThingsWith(response)
- * });
- */
-LibraryServiceClient.prototype.streamBooks = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._streamBooks(request, options);
-};
-
-/**
- * Test bidi-streaming.
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which is both readable and writable. It accepts objects
- *   representing [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method, and
- *   will emit objects representing [Comment]{@link google.example.library.v1.Comment} on 'data' event asynchronously.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var stream = client.discussBook().on('data', function(response) {
- *     // doThingsWith(response)
- * });
- * var name = '';
- * var request = {
- *     name : name
- * };
- * // Write request objects.
- * stream.write(request);
- */
-LibraryServiceClient.prototype.discussBook = function(options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._discussBook(options);
-};
-
-/**
- * Test client streaming.
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Comment]{@link google.example.library.v1.Comment}.
- * @returns {Stream} - A writable stream which accepts objects representing
- *   [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var stream = client.monologAboutBook(function(err, response) {
- *     if (err) {
- *         console.error(err);
- *         return;
- *     }
- *     // doThingsWith(response)
- * });
- * var name = '';
- * var request = {
- *     name : name
- * };
- * // Write request objects.
- * stream.write(request);
- */
-LibraryServiceClient.prototype.monologAboutBook = function(options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._monologAboutBook(options, callback);
-};
-
-/**
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string[]} request.names
- * @param {string[]} request.shelves
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of string.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of string.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of string in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * var namesElement = '';
- * var names = [namesElement];
- * var shelves = [];
- * var request = {
- *     names: names,
- *     shelves: shelves
- * };
- *
- * client.findRelatedBooks(request).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- * var namesElement = '';
- * var names = [namesElement];
- * var shelves = [];
- * var request = {
- *     names: names,
- *     shelves: shelves
- * };
- *
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.findRelatedBooks(nextRequest, options).then(callback);
- *     }
- * }
- * client.findRelatedBooks(request, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.findRelatedBooks = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._findRelatedBooks(request, options, callback);
-};
-
-/**
- * Equivalent to {@link findRelatedBooks}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link findRelatedBooks} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string[]} request.names
- * @param {string[]} request.shelves
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits a string on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var namesElement = '';
- * var names = [namesElement];
- * var shelves = [];
- * var request = {
- *     names: names,
- *     shelves: shelves
- * };
- * client.findRelatedBooksStream(request)
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.findRelatedBooksStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return PAGE_DESCRIPTORS.findRelatedBooks.createStream(this._findRelatedBooks, request, options);
-};
-
-/**
- * Adds a tag to the book. This RPC is a mixin.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.resource
- *   REQUIRED: The resource which the tag is being added to.
- *   Resource is usually specified as a path, such as,
- *   projects/{project}/zones/{zone}/disks/{disk}.
- * @param {string} request.tag
- *   REQUIRED: The tag to add.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var tag = '';
- * var request = {
- *     resource: formattedResource,
- *     tag: tag
- * };
- * client.addTag(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.addTag = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._addTag(request, options, callback);
-};
-
-/**
- * Adds a label to the entity.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.resource
- *   REQUIRED: The resource which the label is being added to.
- *   Resource is usually specified as a path, such as,
- *   projects/{project}/zones/{zone}/disks/{disk}.
- * @param {string} request.label
- *   REQUIRED: The label to add.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var label = '';
- * var request = {
- *     resource: formattedResource,
- *     label: label
- * };
- * client.addLabel(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.addLabel = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._addLabel(request, options, callback);
-};
-
-/**
- * Test long-running operations
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the promise pattern.
- * client.getBigBook({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Operation#promise starts polling for the completion of the LRO.
- *     return operation.promise();
- * }).then(function(responses) {
- *     // The final result of the operation.
- *     var result = responses[0];
- *
- *     // The metadata value of the completed operation.
- *     var metadata = responses[1];
- *
- *     // The response of the api call returning the complete operation.
- *     var finalApiResponse = responses[2];
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the event emitter pattern.
- * client.getBigBook({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Adding a listener for the "complete" event starts polling for the
- *     // completion of the operation.
- *     operation.on('complete', function(result, metadata, finalApiResponse) {
- *       // doSomethingWith(result);
- *     });
- *
- *     // Adding a listener for the "progress" event causes the callback to be
- *     // called on any change in metadata when the operation is polled.
- *     operation.on('progress', function(metadata, apiResponse) {
- *       // doSomethingWith(metadata)
- *     })
- *
- *     // Adding a listener for the "error" event handles any errors found during polling.
- *     operation.on('error', function(err) {
- *       // throw(err);
- *     })
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBigBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBigBook(request, options, callback);
-};
-
-/**
- * Test long-running operations with empty return type.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the promise pattern.
- * client.getBigNothing({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Operation#promise starts polling for the completion of the LRO.
- *     return operation.promise();
- * }).then(function(responses) {
- *     // The final result of the operation.
- *     var result = responses[0];
- *
- *     // The metadata value of the completed operation.
- *     var metadata = responses[1];
- *
- *     // The response of the api call returning the complete operation.
- *     var finalApiResponse = responses[2];
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the event emitter pattern.
- * client.getBigNothing({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Adding a listener for the "complete" event starts polling for the
- *     // completion of the operation.
- *     operation.on('complete', function(result, metadata, finalApiResponse) {
- *       // doSomethingWith(result);
- *     });
- *
- *     // Adding a listener for the "progress" event causes the callback to be
- *     // called on any change in metadata when the operation is polled.
- *     operation.on('progress', function(metadata, apiResponse) {
- *       // doSomethingWith(metadata)
- *     })
- *
- *     // Adding a listener for the "error" event handles any errors found during polling.
- *     operation.on('error', function(err) {
- *       // throw(err);
- *     })
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBigNothing = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBigNothing(request, options, callback);
-};
-
-/**
- * Test optional flattening parameters of all types
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {number} request.requiredSingularInt32
- * @param {number} request.requiredSingularInt64
- * @param {number} request.requiredSingularFloat
- * @param {number} request.requiredSingularDouble
- * @param {boolean} request.requiredSingularBool
- * @param {number} request.requiredSingularEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string} request.requiredSingularString
- * @param {string} request.requiredSingularBytes
- * @param {Object} request.requiredSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string} request.requiredSingularResourceName
- * @param {string} request.requiredSingularResourceNameOneof
- * @param {number} request.requiredSingularFixed32
- * @param {number} request.requiredSingularFixed64
- * @param {number[]} request.requiredRepeatedInt32
- * @param {number[]} request.requiredRepeatedInt64
- * @param {number[]} request.requiredRepeatedFloat
- * @param {number[]} request.requiredRepeatedDouble
- * @param {boolean[]} request.requiredRepeatedBool
- * @param {number[]} request.requiredRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string[]} request.requiredRepeatedString
- * @param {string[]} request.requiredRepeatedBytes
- * @param {Object[]} request.requiredRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string[]} request.requiredRepeatedResourceName
- * @param {string[]} request.requiredRepeatedResourceNameOneof
- * @param {number[]} request.requiredRepeatedFixed32
- * @param {number[]} request.requiredRepeatedFixed64
- * @param {Object.<number, string>} request.requiredMap
- * @param {number=} request.optionalSingularInt32
- * @param {number=} request.optionalSingularInt64
- * @param {number=} request.optionalSingularFloat
- * @param {number=} request.optionalSingularDouble
- * @param {boolean=} request.optionalSingularBool
- * @param {number=} request.optionalSingularEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string=} request.optionalSingularString
- * @param {string=} request.optionalSingularBytes
- * @param {Object=} request.optionalSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string=} request.optionalSingularResourceName
- * @param {string=} request.optionalSingularResourceNameOneof
- * @param {number=} request.optionalSingularFixed32
- * @param {number=} request.optionalSingularFixed64
- * @param {number[]=} request.optionalRepeatedInt32
- * @param {number[]=} request.optionalRepeatedInt64
- * @param {number[]=} request.optionalRepeatedFloat
- * @param {number[]=} request.optionalRepeatedDouble
- * @param {boolean[]=} request.optionalRepeatedBool
- * @param {number[]=} request.optionalRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string[]=} request.optionalRepeatedString
- * @param {string[]=} request.optionalRepeatedBytes
- * @param {Object[]=} request.optionalRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string[]=} request.optionalRepeatedResourceName
- * @param {string[]=} request.optionalRepeatedResourceNameOneof
- * @param {number[]=} request.optionalRepeatedFixed32
- * @param {number[]=} request.optionalRepeatedFixed64
- * @param {Object.<number, string>=} request.optionalMap
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var requiredSingularInt32 = 0;
- * var requiredSingularInt64 = 0;
- * var requiredSingularFloat = 0.0;
- * var requiredSingularDouble = 0.0;
- * var requiredSingularBool = false;
- * var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
- * var requiredSingularString = '';
- * var requiredSingularBytes = '';
- * var requiredSingularMessage = {};
- * var requiredSingularResourceName = '';
- * var requiredSingularResourceNameOneof = '';
- * var requiredSingularFixed32 = 0;
- * var requiredSingularFixed64 = 0;
- * var requiredRepeatedInt32 = [];
- * var requiredRepeatedInt64 = [];
- * var requiredRepeatedFloat = [];
- * var requiredRepeatedDouble = [];
- * var requiredRepeatedBool = [];
- * var requiredRepeatedEnum = [];
- * var requiredRepeatedString = [];
- * var requiredRepeatedBytes = [];
- * var requiredRepeatedMessage = [];
- * var formattedRequiredRepeatedResourceName = [];
- * var formattedRequiredRepeatedResourceNameOneof = [];
- * var requiredRepeatedFixed32 = [];
- * var requiredRepeatedFixed64 = [];
- * var requiredMap = {};
- * var request = {
- *     requiredSingularInt32: requiredSingularInt32,
- *     requiredSingularInt64: requiredSingularInt64,
- *     requiredSingularFloat: requiredSingularFloat,
- *     requiredSingularDouble: requiredSingularDouble,
- *     requiredSingularBool: requiredSingularBool,
- *     requiredSingularEnum: requiredSingularEnum,
- *     requiredSingularString: requiredSingularString,
- *     requiredSingularBytes: requiredSingularBytes,
- *     requiredSingularMessage: requiredSingularMessage,
- *     requiredSingularResourceName: requiredSingularResourceName,
- *     requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
- *     requiredSingularFixed32: requiredSingularFixed32,
- *     requiredSingularFixed64: requiredSingularFixed64,
- *     requiredRepeatedInt32: requiredRepeatedInt32,
- *     requiredRepeatedInt64: requiredRepeatedInt64,
- *     requiredRepeatedFloat: requiredRepeatedFloat,
- *     requiredRepeatedDouble: requiredRepeatedDouble,
- *     requiredRepeatedBool: requiredRepeatedBool,
- *     requiredRepeatedEnum: requiredRepeatedEnum,
- *     requiredRepeatedString: requiredRepeatedString,
- *     requiredRepeatedBytes: requiredRepeatedBytes,
- *     requiredRepeatedMessage: requiredRepeatedMessage,
- *     requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
- *     requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
- *     requiredRepeatedFixed32: requiredRepeatedFixed32,
- *     requiredRepeatedFixed64: requiredRepeatedFixed64,
- *     requiredMap: requiredMap
- * };
- * client.testOptionalRequiredFlatteningParams(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.testOptionalRequiredFlatteningParams = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._testOptionalRequiredFlatteningParams(request, options, callback);
-};
-
-/**
- * @class
- * @param {*} gaxGrpc
- */
-function LibraryServiceClientBuilder(gaxGrpc) {
-  if (!(this instanceof LibraryServiceClientBuilder)) {
-    return new LibraryServiceClientBuilder(gaxGrpc);
-  }
-
-  var libraryServiceStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', '..', 'protos'), 'library.proto');
-  extend(this, libraryServiceStubProtos.google.example.library.v1);
-
-  var labelerStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', '..', 'protos'), 'tagger.proto');
-  extend(this, labelerStubProtos.google.tagger.v1);
-
-  var protos = merge(
-    {},
-    libraryServiceStubProtos,
-    labelerStubProtos
-  );
+  // Service calls
 
   /**
-   * Build a new instance of {@link LibraryServiceClient}.
+   * Creates a shelf, and returns the new Shelf.
+   * RPC method comment may include special characters: <>&"`'@.
    *
-   * @method LibraryServiceClientBuilder#libraryServiceClient
-   * @param {Object=} opts - The optional parameters.
-   * @param {String=} opts.servicePath
-   *   The domain name of the API remote host.
-   * @param {number=} opts.port
-   *   The port on which to connect to the remote host.
-   * @param {grpc.ClientCredentials=} opts.sslCreds
-   *   A ClientCredentials for use with an SSL-enabled channel.
-   * @param {Object=} opts.clientConfig
-   *   The customized config to build the call settings. See
-   *   {@link gax.constructSettings} for the format.
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object} request.shelf
+   *   The shelf to create.
+   *
+   *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var shelf = {};
+   * client.createShelf({shelf: shelf}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
    */
-  this.libraryServiceClient = function(opts) {
-    return new LibraryServiceClient(gaxGrpc, protos, opts);
+  createShelf(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.createShelf(request, options, callback);
   };
-  extend(this.libraryServiceClient, LibraryServiceClient);
+
+  /**
+   * Gets a shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf to retrieve.
+   * @param {string} request.options
+   *   To test 'options' parameter name conflict.
+   * @param {Object=} request.message
+   *   Field to verify that message-type query parameter gets flattened.
+   *
+   *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
+   * @param {Object=} request.stringBuilder
+   *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * var options = '';
+   * var request = {
+   *     name: formattedName,
+   *     options: options
+   * };
+   * client.getShelf(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getShelf(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getShelf(request, options, callback);
+  };
+
+  /**
+   * Lists shelves.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of [Shelf]{@link google.example.library.v1.Shelf}.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of [Shelf]{@link google.example.library.v1.Shelf}.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [Shelf]{@link google.example.library.v1.Shelf} in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * client.listShelves({}).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.listShelves(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.listShelves({}, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  listShelves(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.listShelves(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link listShelves}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link listShelves} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits an object representing [Shelf]{@link google.example.library.v1.Shelf} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.listShelvesStream({})
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  listShelvesStream(request, options) {
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._pageDescriptors.listShelves.createStream(
+      this._innerApiCalls.listShelves,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Deletes a shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf to delete.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * client.deleteShelf({name: formattedName}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  deleteShelf(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.deleteShelf(request, options, callback);
+  };
+
+  /**
+   * Merges two shelves by adding all books from the shelf named
+   * `other_shelf_name` to shelf `name`, and deletes
+   * `other_shelf_name`. Returns the updated shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf we're adding books to.
+   * @param {string} request.otherShelfName
+   *   The name of the shelf we're removing books from and deleting.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
+   * var request = {
+   *     name: formattedName,
+   *     otherShelfName: formattedOtherShelfName
+   * };
+   * client.mergeShelves(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  mergeShelves(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.mergeShelves(request, options, callback);
+  };
+
+  /**
+   * Creates a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf in which the book is created.
+   * @param {Object} request.book
+   *   The book to create.
+   *
+   *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * var book = {};
+   * var request = {
+   *     name: formattedName,
+   *     book: book
+   * };
+   * client.createBook(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  createBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.createBook(request, options, callback);
+  };
+
+  /**
+   * Creates a series of books.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object} request.shelf
+   *   The shelf in which the series is created.
+   *
+   *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
+   * @param {Object[]} request.books
+   *   The books to publish in the series.
+   *
+   *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+   * @param {Object} request.seriesUuid
+   *   Uniquely identifies the series to the publishing house.
+   *
+   *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
+   * @param {number=} request.edition
+   *   The edition of the series
+   * @param {boolean=} request.reviewCopy
+   *   If the book is in a pre-publish state
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var shelf = {};
+   * var books = [];
+   * var seriesString = 'foobar';
+   * var seriesUuid = {
+   *     seriesString : seriesString
+   * };
+   * var request = {
+   *     shelf: shelf,
+   *     books: books,
+   *     seriesUuid: seriesUuid
+   * };
+   * client.publishSeries(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  publishSeries(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.publishSeries(request, options, callback);
+  };
+
+  /**
+   * Gets a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * client.getBook({name: formattedName}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBook(request, options, callback);
+  };
+
+  /**
+   * Lists books in a shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf whose books we'd like to list.
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {string=} request.filter
+   *   To test python built-in wrapping.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of [Book]{@link google.example.library.v1.Book}.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of [Book]{@link google.example.library.v1.Book}.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [Book]{@link google.example.library.v1.Book} in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   *
+   * client.listBooks({name: formattedName}).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   *
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.listBooks(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.listBooks({name: formattedName}, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  listBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.listBooks(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link listBooks}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link listBooks} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf whose books we'd like to list.
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {string=} request.filter
+   *   To test python built-in wrapping.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits an object representing [Book]{@link google.example.library.v1.Book} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * client.listBooksStream({name: formattedName})
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  listBooksStream(request, options) {
+    options = options || {};
+
+    return this._pageDescriptors.listBooks.createStream(
+      this._innerApiCalls.listBooks,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Deletes a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to delete.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * client.deleteBook({name: formattedName}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  deleteBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.deleteBook(request, options, callback);
+  };
+
+  /**
+   * Updates a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to update.
+   * @param {Object} request.book
+   *   The book to update with.
+   *
+   *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+   * @param {Object=} request.updateMask
+   *   A field mask to apply, rendered as an HTTP parameter.
+   *
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+   * @param {Object=} request.physicalMask
+   *   To test Python import clash resolution.
+   *
+   *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var book = {};
+   * var request = {
+   *     name: formattedName,
+   *     book: book
+   * };
+   * client.updateBook(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  updateBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.updateBook(request, options, callback);
+  };
+
+  /**
+   * Moves a book to another shelf, and returns the new book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to move.
+   * @param {string} request.otherShelfName
+   *   The name of the destination shelf.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
+   * var request = {
+   *     name: formattedName,
+   *     otherShelfName: formattedOtherShelfName
+   * };
+   * client.moveBook(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  moveBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.moveBook(request, options, callback);
+  };
+
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string=} request.name
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of string in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * client.listStrings({}).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.listStrings(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.listStrings({}, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  listStrings(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.listStrings(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link listStrings}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link listStrings} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string=} request.name
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits a string on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.listStringsStream({})
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  listStringsStream(request, options) {
+    options = options || {};
+
+    return this._pageDescriptors.listStrings.createStream(
+      this._innerApiCalls.listStrings,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Adds comments to a book
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   * @param {Object[]} request.comments
+   *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var comment = '';
+   * var stage = library.v1.types.Comment.Stage.UNSET;
+   * var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+   * var commentsElement = {
+   *     comment : comment,
+   *     stage : stage,
+   *     alignment : alignment
+   * };
+   * var comments = [commentsElement];
+   * var request = {
+   *     name: formattedName,
+   *     comments: comments
+   * };
+   * client.addComments(request).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  addComments(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.addComments(request, options, callback);
+  };
+
+  /**
+   * Gets a book from an archive.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
+   * client.getBookFromArchive({name: formattedName}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBookFromArchive(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBookFromArchive(request, options, callback);
+  };
+
+  /**
+   * Gets a book from a shelf or archive.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {string} request.altBookName
+   *   An alternate book name, used to test restricting flattened field to a
+   *   single resource name type in a oneof.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var formattedAltBookName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var request = {
+   *     name: formattedName,
+   *     altBookName: formattedAltBookName
+   * };
+   * client.getBookFromAnywhere(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBookFromAnywhere(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBookFromAnywhere(request, options, callback);
+  };
+
+  /**
+   * Test proper OneOf-Any resource name mapping
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * client.getBookFromAbsolutelyAnywhere({name: formattedName}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBookFromAbsolutelyAnywhere(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBookFromAbsolutelyAnywhere(request, options, callback);
+  };
+
+  /**
+   * Updates the index of a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to update.
+   * @param {string} request.indexName
+   *   The name of the index for the book
+   * @param {Object.<string, string>} request.indexMap
+   *   The index to update the book with
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var indexName = 'default index';
+   * var indexMapItem = '';
+   * var indexMap = {'default_key' : indexMapItem,};
+   * var request = {
+   *     name: formattedName,
+   *     indexName: indexName,
+   *     indexMap: indexMap
+   * };
+   * client.updateBookIndex(request).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  updateBookIndex(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.updateBookIndex(request, options, callback);
+  };
+
+  /**
+   * Test server streaming
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [StreamShelvesResponse]{@link google.example.library.v1.StreamShelvesResponse} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.streamShelves({}).on('data', function(response) {
+   *   // doThingsWith(response)
+   * });
+   */
+  streamShelves(request, options) {
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.streamShelves(request, options);
+  };
+
+  /**
+   * Test server streaming, non-paged responses.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf whose books we'd like to list.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [Book]{@link google.example.library.v1.Book} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var name = '';
+   * client.streamBooks({name: name}).on('data', function(response) {
+   *   // doThingsWith(response)
+   * });
+   */
+  streamBooks(request, options) {
+    options = options || {};
+
+    return this._innerApiCalls.streamBooks(request, options);
+  };
+
+  /**
+   * Test bidi-streaming.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which is both readable and writable. It accepts objects
+   *   representing [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method, and
+   *   will emit objects representing [Comment]{@link google.example.library.v1.Comment} on 'data' event asynchronously.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var stream = client.discussBook().on('data', function(response) {
+   *     // doThingsWith(response)
+   * });
+   * var name = '';
+   * var request = {
+   *     name : name
+   * };
+   * // Write request objects.
+   * stream.write(request);
+   */
+  discussBook(options) {
+    options = options || {};
+
+    return this._innerApiCalls.discussBook(options);
+  };
+
+  /**
+   * Test client streaming.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Comment]{@link google.example.library.v1.Comment}.
+   * @returns {Stream} - A writable stream which accepts objects representing
+   *   [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var stream = client.monologAboutBook(function(err, response) {
+   *     if (err) {
+   *         console.error(err);
+   *         return;
+   *     }
+   *     // doThingsWith(response)
+   * });
+   * var name = '';
+   * var request = {
+   *     name : name
+   * };
+   * // Write request objects.
+   * stream.write(request);
+   */
+  monologAboutBook(options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.monologAboutBook(options, callback);
+  };
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string[]} request.names
+   * @param {string[]} request.shelves
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of string in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * var namesElement = '';
+   * var names = [namesElement];
+   * var shelves = [];
+   * var request = {
+   *     names: names,
+   *     shelves: shelves
+   * };
+   *
+   * client.findRelatedBooks(request).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   * var namesElement = '';
+   * var names = [namesElement];
+   * var shelves = [];
+   * var request = {
+   *     names: names,
+   *     shelves: shelves
+   * };
+   *
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.findRelatedBooks(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.findRelatedBooks(request, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  findRelatedBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.findRelatedBooks(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link findRelatedBooks}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link findRelatedBooks} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string[]} request.names
+   * @param {string[]} request.shelves
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits a string on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var namesElement = '';
+   * var names = [namesElement];
+   * var shelves = [];
+   * var request = {
+   *     names: names,
+   *     shelves: shelves
+   * };
+   * client.findRelatedBooksStream(request)
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  findRelatedBooksStream(request, options) {
+    options = options || {};
+
+    return this._pageDescriptors.findRelatedBooks.createStream(
+      this._innerApiCalls.findRelatedBooks,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.resource
+   *   REQUIRED: The resource which the tag is being added to.
+   *   Resource is usually specified as a path, such as,
+   *   projects/{project}/zones/{zone}/disks/{disk}.
+   * @param {string} request.tag
+   *   REQUIRED: The tag to add.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var tag = '';
+   * var request = {
+   *     resource: formattedResource,
+   *     tag: tag
+   * };
+   * client.addTag(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  addTag(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.addTag(request, options, callback);
+  };
+
+  /**
+   * Adds a label to the entity.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.resource
+   *   REQUIRED: The resource which the label is being added to.
+   *   Resource is usually specified as a path, such as,
+   *   projects/{project}/zones/{zone}/disks/{disk}.
+   * @param {string} request.label
+   *   REQUIRED: The label to add.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var label = '';
+   * var request = {
+   *     resource: formattedResource,
+   *     label: label
+   * };
+   * client.addLabel(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  addLabel(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.addLabel(request, options, callback);
+  };
+
+  /**
+   * Test long-running operations
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the promise pattern.
+   * client.getBigBook({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Operation#promise starts polling for the completion of the LRO.
+   *     return operation.promise();
+   * }).then(function(responses) {
+   *     // The final result of the operation.
+   *     var result = responses[0];
+   *
+   *     // The metadata value of the completed operation.
+   *     var metadata = responses[1];
+   *
+   *     // The response of the api call returning the complete operation.
+   *     var finalApiResponse = responses[2];
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the event emitter pattern.
+   * client.getBigBook({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Adding a listener for the "complete" event starts polling for the
+   *     // completion of the operation.
+   *     operation.on('complete', function(result, metadata, finalApiResponse) {
+   *       // doSomethingWith(result);
+   *     });
+   *
+   *     // Adding a listener for the "progress" event causes the callback to be
+   *     // called on any change in metadata when the operation is polled.
+   *     operation.on('progress', function(metadata, apiResponse) {
+   *       // doSomethingWith(metadata)
+   *     })
+   *
+   *     // Adding a listener for the "error" event handles any errors found during polling.
+   *     operation.on('error', function(err) {
+   *       // throw(err);
+   *     })
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBigBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBigBook(request, options, callback);
+  };
+
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the promise pattern.
+   * client.getBigNothing({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Operation#promise starts polling for the completion of the LRO.
+   *     return operation.promise();
+   * }).then(function(responses) {
+   *     // The final result of the operation.
+   *     var result = responses[0];
+   *
+   *     // The metadata value of the completed operation.
+   *     var metadata = responses[1];
+   *
+   *     // The response of the api call returning the complete operation.
+   *     var finalApiResponse = responses[2];
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the event emitter pattern.
+   * client.getBigNothing({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Adding a listener for the "complete" event starts polling for the
+   *     // completion of the operation.
+   *     operation.on('complete', function(result, metadata, finalApiResponse) {
+   *       // doSomethingWith(result);
+   *     });
+   *
+   *     // Adding a listener for the "progress" event causes the callback to be
+   *     // called on any change in metadata when the operation is polled.
+   *     operation.on('progress', function(metadata, apiResponse) {
+   *       // doSomethingWith(metadata)
+   *     })
+   *
+   *     // Adding a listener for the "error" event handles any errors found during polling.
+   *     operation.on('error', function(err) {
+   *       // throw(err);
+   *     })
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBigNothing(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBigNothing(request, options, callback);
+  };
+
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {number} request.requiredSingularInt32
+   * @param {number} request.requiredSingularInt64
+   * @param {number} request.requiredSingularFloat
+   * @param {number} request.requiredSingularDouble
+   * @param {boolean} request.requiredSingularBool
+   * @param {number} request.requiredSingularEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string} request.requiredSingularString
+   * @param {string} request.requiredSingularBytes
+   * @param {Object} request.requiredSingularMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string} request.requiredSingularResourceName
+   * @param {string} request.requiredSingularResourceNameOneof
+   * @param {number} request.requiredSingularFixed32
+   * @param {number} request.requiredSingularFixed64
+   * @param {number[]} request.requiredRepeatedInt32
+   * @param {number[]} request.requiredRepeatedInt64
+   * @param {number[]} request.requiredRepeatedFloat
+   * @param {number[]} request.requiredRepeatedDouble
+   * @param {boolean[]} request.requiredRepeatedBool
+   * @param {number[]} request.requiredRepeatedEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string[]} request.requiredRepeatedString
+   * @param {string[]} request.requiredRepeatedBytes
+   * @param {Object[]} request.requiredRepeatedMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string[]} request.requiredRepeatedResourceName
+   * @param {string[]} request.requiredRepeatedResourceNameOneof
+   * @param {number[]} request.requiredRepeatedFixed32
+   * @param {number[]} request.requiredRepeatedFixed64
+   * @param {Object.<number, string>} request.requiredMap
+   * @param {number=} request.optionalSingularInt32
+   * @param {number=} request.optionalSingularInt64
+   * @param {number=} request.optionalSingularFloat
+   * @param {number=} request.optionalSingularDouble
+   * @param {boolean=} request.optionalSingularBool
+   * @param {number=} request.optionalSingularEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string=} request.optionalSingularString
+   * @param {string=} request.optionalSingularBytes
+   * @param {Object=} request.optionalSingularMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string=} request.optionalSingularResourceName
+   * @param {string=} request.optionalSingularResourceNameOneof
+   * @param {number=} request.optionalSingularFixed32
+   * @param {number=} request.optionalSingularFixed64
+   * @param {number[]=} request.optionalRepeatedInt32
+   * @param {number[]=} request.optionalRepeatedInt64
+   * @param {number[]=} request.optionalRepeatedFloat
+   * @param {number[]=} request.optionalRepeatedDouble
+   * @param {boolean[]=} request.optionalRepeatedBool
+   * @param {number[]=} request.optionalRepeatedEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string[]=} request.optionalRepeatedString
+   * @param {string[]=} request.optionalRepeatedBytes
+   * @param {Object[]=} request.optionalRepeatedMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string[]=} request.optionalRepeatedResourceName
+   * @param {string[]=} request.optionalRepeatedResourceNameOneof
+   * @param {number[]=} request.optionalRepeatedFixed32
+   * @param {number[]=} request.optionalRepeatedFixed64
+   * @param {Object.<number, string>=} request.optionalMap
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var requiredSingularInt32 = 0;
+   * var requiredSingularInt64 = 0;
+   * var requiredSingularFloat = 0.0;
+   * var requiredSingularDouble = 0.0;
+   * var requiredSingularBool = false;
+   * var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   * var requiredSingularString = '';
+   * var requiredSingularBytes = '';
+   * var requiredSingularMessage = {};
+   * var requiredSingularResourceName = '';
+   * var requiredSingularResourceNameOneof = '';
+   * var requiredSingularFixed32 = 0;
+   * var requiredSingularFixed64 = 0;
+   * var requiredRepeatedInt32 = [];
+   * var requiredRepeatedInt64 = [];
+   * var requiredRepeatedFloat = [];
+   * var requiredRepeatedDouble = [];
+   * var requiredRepeatedBool = [];
+   * var requiredRepeatedEnum = [];
+   * var requiredRepeatedString = [];
+   * var requiredRepeatedBytes = [];
+   * var requiredRepeatedMessage = [];
+   * var formattedRequiredRepeatedResourceName = [];
+   * var formattedRequiredRepeatedResourceNameOneof = [];
+   * var requiredRepeatedFixed32 = [];
+   * var requiredRepeatedFixed64 = [];
+   * var requiredMap = {};
+   * var request = {
+   *     requiredSingularInt32: requiredSingularInt32,
+   *     requiredSingularInt64: requiredSingularInt64,
+   *     requiredSingularFloat: requiredSingularFloat,
+   *     requiredSingularDouble: requiredSingularDouble,
+   *     requiredSingularBool: requiredSingularBool,
+   *     requiredSingularEnum: requiredSingularEnum,
+   *     requiredSingularString: requiredSingularString,
+   *     requiredSingularBytes: requiredSingularBytes,
+   *     requiredSingularMessage: requiredSingularMessage,
+   *     requiredSingularResourceName: requiredSingularResourceName,
+   *     requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+   *     requiredSingularFixed32: requiredSingularFixed32,
+   *     requiredSingularFixed64: requiredSingularFixed64,
+   *     requiredRepeatedInt32: requiredRepeatedInt32,
+   *     requiredRepeatedInt64: requiredRepeatedInt64,
+   *     requiredRepeatedFloat: requiredRepeatedFloat,
+   *     requiredRepeatedDouble: requiredRepeatedDouble,
+   *     requiredRepeatedBool: requiredRepeatedBool,
+   *     requiredRepeatedEnum: requiredRepeatedEnum,
+   *     requiredRepeatedString: requiredRepeatedString,
+   *     requiredRepeatedBytes: requiredRepeatedBytes,
+   *     requiredRepeatedMessage: requiredRepeatedMessage,
+   *     requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
+   *     requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+   *     requiredRepeatedFixed32: requiredRepeatedFixed32,
+   *     requiredRepeatedFixed64: requiredRepeatedFixed64,
+   *     requiredMap: requiredMap
+   * };
+   * client.testOptionalRequiredFlatteningParams(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  testOptionalRequiredFlatteningParams(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.testOptionalRequiredFlatteningParams(request, options, callback);
+  };
 }
-module.exports = LibraryServiceClientBuilder;
-module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
-module.exports.ALL_SCOPES = ALL_SCOPES;
+
+
+module.exports = LibraryServiceClient;
+
 ============== file: src/v1/library_service_client_config.json ==============
 {
   "interfaces": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -4878,18 +4878,19 @@ module.exports = LibraryServiceClient;
  */
 'use strict';
 
-var assert = require('assert');
-var library = require('../src');
-var through2 = require('through2');
+const assert = require('assert');
+const through2 = require('through2');
+
+const libraryModule = require('../src');
 
 var FAKE_STATUS_CODE = 1;
 var error = new Error();
 error.code = FAKE_STATUS_CODE;
 
-describe('LibraryServiceClient', function() {
-  describe('createShelf', function() {
-    it('invokes createShelf without error', function(done) {
-      var client = library.v1();
+describe('LibraryServiceClient', () => {
+  describe('createShelf', () => {
+    it('invokes createShelf without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -4908,17 +4909,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createShelf = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createShelf = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.createShelf(request, function(err, response) {
+      client.createShelf(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes createShelf with error', function(done) {
-      var client = library.v1();
+    it('invokes createShelf with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -4927,9 +4928,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createShelf = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createShelf = mockSimpleGrpcMethod(request, null, error);
 
-      client.createShelf(request, function(err, response) {
+      client.createShelf(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -4937,9 +4938,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getShelf', function() {
-    it('invokes getShelf without error', function(done) {
-      var client = library.v1();
+  describe('getShelf', () => {
+    it('invokes getShelf without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -4960,17 +4961,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getShelf = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getShelf = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getShelf(request, function(err, response) {
+      client.getShelf(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getShelf with error', function(done) {
-      var client = library.v1();
+    it('invokes getShelf with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -4981,9 +4982,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getShelf = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getShelf = mockSimpleGrpcMethod(request, null, error);
 
-      client.getShelf(request, function(err, response) {
+      client.getShelf(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -4991,9 +4992,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('listShelves', function() {
-    it('invokes listShelves without error', function(done) {
-      var client = library.v1();
+  describe('listShelves', () => {
+    it('invokes listShelves without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
@@ -5008,28 +5009,28 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listShelves = function(actualRequest, options, callback) {
+      client._innerApiCalls.listShelves = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.shelves);
       };
 
-      client.listShelves(request, function(err, response) {
+      client.listShelves(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.shelves);
         done();
       });
     });
 
-    it('invokes listShelves with error', function(done) {
-      var client = library.v1();
+    it('invokes listShelves with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._listShelves = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listShelves = mockSimpleGrpcMethod(request, null, error);
 
-      client.listShelves(request, function(err, response) {
+      client.listShelves(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5037,9 +5038,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('deleteShelf', function() {
-    it('invokes deleteShelf without error', function(done) {
-      var client = library.v1();
+  describe('deleteShelf', () => {
+    it('invokes deleteShelf without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5048,16 +5049,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteShelf = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.deleteShelf = mockSimpleGrpcMethod(request);
 
-      client.deleteShelf(request, function(err) {
+      client.deleteShelf(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes deleteShelf with error', function(done) {
-      var client = library.v1();
+    it('invokes deleteShelf with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5066,9 +5067,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteShelf = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteShelf = mockSimpleGrpcMethod(request, null, error);
 
-      client.deleteShelf(request, function(err) {
+      client.deleteShelf(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5076,9 +5077,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('mergeShelves', function() {
-    it('invokes mergeShelves without error', function(done) {
-      var client = library.v1();
+  describe('mergeShelves', () => {
+    it('invokes mergeShelves without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5099,17 +5100,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._mergeShelves = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.mergeShelves = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.mergeShelves(request, function(err, response) {
+      client.mergeShelves(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes mergeShelves with error', function(done) {
-      var client = library.v1();
+    it('invokes mergeShelves with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5120,9 +5121,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._mergeShelves = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.mergeShelves = mockSimpleGrpcMethod(request, null, error);
 
-      client.mergeShelves(request, function(err, response) {
+      client.mergeShelves(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5130,9 +5131,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('createBook', function() {
-    it('invokes createBook without error', function(done) {
-      var client = library.v1();
+  describe('createBook', () => {
+    it('invokes createBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5155,17 +5156,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.createBook(request, function(err, response) {
+      client.createBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes createBook with error', function(done) {
-      var client = library.v1();
+    it('invokes createBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5176,9 +5177,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.createBook(request, function(err, response) {
+      client.createBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5186,9 +5187,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('publishSeries', function() {
-    it('invokes publishSeries without error', function(done) {
-      var client = library.v1();
+  describe('publishSeries', () => {
+    it('invokes publishSeries without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -5211,17 +5212,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._publishSeries = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.publishSeries = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.publishSeries(request, function(err, response) {
+      client.publishSeries(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes publishSeries with error', function(done) {
-      var client = library.v1();
+    it('invokes publishSeries with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -5237,9 +5238,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._publishSeries = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.publishSeries = mockSimpleGrpcMethod(request, null, error);
 
-      client.publishSeries(request, function(err, response) {
+      client.publishSeries(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5247,9 +5248,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBook', function() {
-    it('invokes getBook without error', function(done) {
-      var client = library.v1();
+  describe('getBook', () => {
+    it('invokes getBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5270,17 +5271,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBook(request, function(err, response) {
+      client.getBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBook with error', function(done) {
-      var client = library.v1();
+    it('invokes getBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5289,9 +5290,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBook(request, function(err, response) {
+      client.getBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5299,9 +5300,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('listBooks', function() {
-    it('invokes listBooks without error', function(done) {
-      var client = library.v1();
+  describe('listBooks', () => {
+    it('invokes listBooks without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5319,20 +5320,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listBooks = function(actualRequest, options, callback) {
+      client._innerApiCalls.listBooks = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.books);
       };
 
-      client.listBooks(request, function(err, response) {
+      client.listBooks(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.books);
         done();
       });
     });
 
-    it('invokes listBooks with error', function(done) {
-      var client = library.v1();
+    it('invokes listBooks with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -5341,9 +5342,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listBooks = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listBooks = mockSimpleGrpcMethod(request, null, error);
 
-      client.listBooks(request, function(err, response) {
+      client.listBooks(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5351,9 +5352,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('deleteBook', function() {
-    it('invokes deleteBook without error', function(done) {
-      var client = library.v1();
+  describe('deleteBook', () => {
+    it('invokes deleteBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5362,16 +5363,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteBook = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.deleteBook = mockSimpleGrpcMethod(request);
 
-      client.deleteBook(request, function(err) {
+      client.deleteBook(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes deleteBook with error', function(done) {
-      var client = library.v1();
+    it('invokes deleteBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5380,9 +5381,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.deleteBook(request, function(err) {
+      client.deleteBook(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5390,9 +5391,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('updateBook', function() {
-    it('invokes updateBook without error', function(done) {
-      var client = library.v1();
+  describe('updateBook', () => {
+    it('invokes updateBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5415,17 +5416,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.updateBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.updateBook(request, function(err, response) {
+      client.updateBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes updateBook with error', function(done) {
-      var client = library.v1();
+    it('invokes updateBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5436,9 +5437,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.updateBook(request, function(err, response) {
+      client.updateBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5446,9 +5447,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('moveBook', function() {
-    it('invokes moveBook without error', function(done) {
-      var client = library.v1();
+  describe('moveBook', () => {
+    it('invokes moveBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5471,17 +5472,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._moveBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.moveBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.moveBook(request, function(err, response) {
+      client.moveBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes moveBook with error', function(done) {
-      var client = library.v1();
+    it('invokes moveBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5492,9 +5493,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._moveBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.moveBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.moveBook(request, function(err, response) {
+      client.moveBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5502,9 +5503,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('listStrings', function() {
-    it('invokes listStrings without error', function(done) {
-      var client = library.v1();
+  describe('listStrings', () => {
+    it('invokes listStrings without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
@@ -5519,28 +5520,28 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listStrings = function(actualRequest, options, callback) {
+      client._innerApiCalls.listStrings = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.strings);
       };
 
-      client.listStrings(request, function(err, response) {
+      client.listStrings(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.strings);
         done();
       });
     });
 
-    it('invokes listStrings with error', function(done) {
-      var client = library.v1();
+    it('invokes listStrings with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._listStrings = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listStrings = mockSimpleGrpcMethod(request, null, error);
 
-      client.listStrings(request, function(err, response) {
+      client.listStrings(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5548,9 +5549,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('addComments', function() {
-    it('invokes addComments without error', function(done) {
-      var client = library.v1();
+  describe('addComments', () => {
+    it('invokes addComments without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5569,16 +5570,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addComments = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.addComments = mockSimpleGrpcMethod(request);
 
-      client.addComments(request, function(err) {
+      client.addComments(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes addComments with error', function(done) {
-      var client = library.v1();
+    it('invokes addComments with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5597,9 +5598,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addComments = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.addComments = mockSimpleGrpcMethod(request, null, error);
 
-      client.addComments(request, function(err) {
+      client.addComments(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5607,9 +5608,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBookFromArchive', function() {
-    it('invokes getBookFromArchive without error', function(done) {
-      var client = library.v1();
+  describe('getBookFromArchive', () => {
+    it('invokes getBookFromArchive without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
@@ -5630,17 +5631,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromArchive = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBookFromArchive = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBookFromArchive(request, function(err, response) {
+      client.getBookFromArchive(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBookFromArchive with error', function(done) {
-      var client = library.v1();
+    it('invokes getBookFromArchive with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
@@ -5649,9 +5650,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromArchive = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBookFromArchive = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBookFromArchive(request, function(err, response) {
+      client.getBookFromArchive(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5659,9 +5660,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBookFromAnywhere', function() {
-    it('invokes getBookFromAnywhere without error', function(done) {
-      var client = library.v1();
+  describe('getBookFromAnywhere', () => {
+    it('invokes getBookFromAnywhere without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5684,17 +5685,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBookFromAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBookFromAnywhere(request, function(err, response) {
+      client.getBookFromAnywhere(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBookFromAnywhere with error', function(done) {
-      var client = library.v1();
+    it('invokes getBookFromAnywhere with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5705,9 +5706,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAnywhere = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBookFromAnywhere = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBookFromAnywhere(request, function(err, response) {
+      client.getBookFromAnywhere(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5715,9 +5716,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBookFromAbsolutelyAnywhere', function() {
-    it('invokes getBookFromAbsolutelyAnywhere without error', function(done) {
-      var client = library.v1();
+  describe('getBookFromAbsolutelyAnywhere', () => {
+    it('invokes getBookFromAbsolutelyAnywhere without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5738,17 +5739,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBookFromAbsolutelyAnywhere(request, function(err, response) {
+      client.getBookFromAbsolutelyAnywhere(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBookFromAbsolutelyAnywhere with error', function(done) {
-      var client = library.v1();
+    it('invokes getBookFromAbsolutelyAnywhere with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5757,9 +5758,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBookFromAbsolutelyAnywhere(request, function(err, response) {
+      client.getBookFromAbsolutelyAnywhere(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5767,9 +5768,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('updateBookIndex', function() {
-    it('invokes updateBookIndex without error', function(done) {
-      var client = library.v1();
+  describe('updateBookIndex', () => {
+    it('invokes updateBookIndex without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5783,16 +5784,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBookIndex = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.updateBookIndex = mockSimpleGrpcMethod(request);
 
-      client.updateBookIndex(request, function(err) {
+      client.updateBookIndex(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes updateBookIndex with error', function(done) {
-      var client = library.v1();
+    it('invokes updateBookIndex with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -5806,9 +5807,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBookIndex = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateBookIndex = mockSimpleGrpcMethod(request, null, error);
 
-      client.updateBookIndex(request, function(err) {
+      client.updateBookIndex(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5816,9 +5817,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('streamShelves', function() {
-    it('invokes streamShelves without error', function(done) {
-      var client = library.v1();
+  describe('streamShelves', () => {
+    it('invokes streamShelves without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
@@ -5831,34 +5832,34 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamShelves = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, expectedResponse);
 
       var stream = client.streamShelves(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.deepStrictEqual(response, expectedResponse);
-        done()
+        done();
       });
-      stream.on('error', function(err) {
+      stream.on('error', err => {
         done(err);
       });
 
       stream.write();
     });
 
-    it('invokes streamShelves with error', function(done) {
-      var client = library.v1();
+    it('invokes streamShelves with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._streamShelves = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamShelves(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.fail();
-      })
-      stream.on('error', function(err) {
+      });
+      stream.on('error', err =>){
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5868,9 +5869,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('streamBooks', function() {
-    it('invokes streamBooks without error', function(done) {
-      var client = library.v1();
+  describe('streamBooks', () => {
+    it('invokes streamBooks without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -5891,22 +5892,22 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamBooks = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.streamBooks = mockServerStreamingGrpcMethod(request, expectedResponse);
 
       var stream = client.streamBooks(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.deepStrictEqual(response, expectedResponse);
-        done()
+        done();
       });
-      stream.on('error', function(err) {
+      stream.on('error', err => {
         done(err);
       });
 
       stream.write();
     });
 
-    it('invokes streamBooks with error', function(done) {
-      var client = library.v1();
+    it('invokes streamBooks with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -5915,13 +5916,13 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamBooks = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.streamBooks = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamBooks(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.fail();
-      })
-      stream.on('error', function(err) {
+      });
+      stream.on('error', err =>){
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5931,9 +5932,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('discussBook', function() {
-    it('invokes discussBook without error', function(done) {
-      var client = library.v1();
+  describe('discussBook', () => {
+    it('invokes discussBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -5950,20 +5951,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._discussBook = mockBidiStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.discussBook = mockBidiStreamingGrpcMethod(request, expectedResponse);
 
-      var stream = client.discussBook().on('data', function(response) {
+      var stream = client.discussBook().on('data', response => {
         assert.deepStrictEqual(response, expectedResponse);
-        done()
-      }).on('error', function(err) {
+        done();
+      }).on('error', err => {
         done(err);
       });
 
       stream.write(request);
     });
 
-    it('invokes discussBook with error', function(done) {
-      var client = library.v1();
+    it('invokes discussBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -5972,11 +5973,11 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._discussBook = mockBidiStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.discussBook = mockBidiStreamingGrpcMethod(request, null, error);
 
-      var stream = client.discussBook().on('data', function(response) {
+      var stream = client.discussBook().on('data', response => {
         assert.fail();
-      }).on('error', function(err) {
+      }).on('error', err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -5986,9 +5987,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('findRelatedBooks', function() {
-    it('invokes findRelatedBooks without error', function(done) {
-      var client = library.v1();
+  describe('findRelatedBooks', () => {
+    it('invokes findRelatedBooks without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -6009,20 +6010,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._findRelatedBooks = function(actualRequest, options, callback) {
+      client._innerApiCalls.findRelatedBooks = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.names);
       };
 
-      client.findRelatedBooks(request, function(err, response) {
+      client.findRelatedBooks(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.names);
         done();
       });
     });
 
-    it('invokes findRelatedBooks with error', function(done) {
-      var client = library.v1();
+    it('invokes findRelatedBooks with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -6034,9 +6035,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._findRelatedBooks = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.findRelatedBooks = mockSimpleGrpcMethod(request, null, error);
 
-      client.findRelatedBooks(request, function(err, response) {
+      client.findRelatedBooks(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -6044,9 +6045,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('addTag', function() {
-    it('invokes addTag without error', function(done) {
-      var client = library.v1();
+  describe('addTag', () => {
+    it('invokes addTag without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6060,17 +6061,17 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._addTag = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.addTag = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.addTag(request, function(err, response) {
+      client.addTag(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes addTag with error', function(done) {
-      var client = library.v1();
+    it('invokes addTag with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6081,9 +6082,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addTag = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.addTag = mockSimpleGrpcMethod(request, null, error);
 
-      client.addTag(request, function(err, response) {
+      client.addTag(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -6091,9 +6092,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('addLabel', function() {
-    it('invokes addLabel without error', function(done) {
-      var client = library.v1();
+  describe('addLabel', () => {
+    it('invokes addLabel without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6107,17 +6108,17 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._addLabel = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.addLabel = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.addLabel(request, function(err, response) {
+      client.addLabel(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes addLabel with error', function(done) {
-      var client = library.v1();
+    it('invokes addLabel with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6128,9 +6129,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addLabel = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.addLabel = mockSimpleGrpcMethod(request, null, error);
 
-      client.addLabel(request, function(err, response) {
+      client.addLabel(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -6139,8 +6140,8 @@ describe('LibraryServiceClient', function() {
   });
 
   describe('getBigBook', function() {
-    it('invokes getBigBook without error', function(done) {
-      var client = library.v1();
+    it('invokes getBigBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6161,21 +6162,21 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBigBook = mockLongRunningGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBigBook = mockLongRunningGrpcMethod(request, expectedResponse);
 
-      client.getBigBook(request).then(function(responses) {
+      client.getBigBook(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.deepStrictEqual(responses[0], expectedResponse);
         done();
-      }).catch(function(err) {
+      }).catch(err => {
         done(err);
       });
     });
 
-    it('invokes getBigBook with error', function(done) {
-      var client = library.v1();
+    it('invokes getBigBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6184,30 +6185,30 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBigBook = mockLongRunningGrpcMethod(request, null, error);
+      client._innerApiCalls.getBigBook = mockLongRunningGrpcMethod(request, null, error);
 
-      client.getBigBook(request).then(function(responses) {
+      client.getBigBook(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.fail();
-      }).catch(function(err) {
+      }).catch(err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
       });
     });
 
-    it('has longrunning decoder functions', function() {
-      var client = library.v1();
+    it('has longrunning decoder functions', () => {
+      var client = new libraryModule.v1.LibraryServiceClient();
       assert(client.longrunningDescriptors.getBigBook.responseDecoder instanceof Function);
       assert(client.longrunningDescriptors.getBigBook.metadataDecoder instanceof Function);
     });
   });
 
   describe('getBigNothing', function() {
-    it('invokes getBigNothing without error', function(done) {
-      var client = library.v1();
+    it('invokes getBigNothing without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6219,21 +6220,21 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._getBigNothing = mockLongRunningGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBigNothing = mockLongRunningGrpcMethod(request, expectedResponse);
 
-      client.getBigNothing(request).then(function(responses) {
+      client.getBigNothing(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.deepStrictEqual(responses[0], expectedResponse);
         done();
-      }).catch(function(err) {
+      }).catch(err => {
         done(err);
       });
     });
 
-    it('invokes getBigNothing with error', function(done) {
-      var client = library.v1();
+    it('invokes getBigNothing with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -6242,30 +6243,30 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBigNothing = mockLongRunningGrpcMethod(request, null, error);
+      client._innerApiCalls.getBigNothing = mockLongRunningGrpcMethod(request, null, error);
 
-      client.getBigNothing(request).then(function(responses) {
+      client.getBigNothing(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.fail();
-      }).catch(function(err) {
+      }).catch(err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
       });
     });
 
-    it('has longrunning decoder functions', function() {
-      var client = library.v1();
+    it('has longrunning decoder functions', () => {
+      var client = new libraryModule.v1.LibraryServiceClient();
       assert(client.longrunningDescriptors.getBigNothing.responseDecoder instanceof Function);
       assert(client.longrunningDescriptors.getBigNothing.metadataDecoder instanceof Function);
     });
   });
 
-  describe('testOptionalRequiredFlatteningParams', function() {
-    it('invokes testOptionalRequiredFlatteningParams without error', function(done) {
-      var client = library.v1();
+  describe('testOptionalRequiredFlatteningParams', () => {
+    it('invokes testOptionalRequiredFlatteningParams without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var requiredSingularInt32 = -72313594;
@@ -6329,17 +6330,17 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.testOptionalRequiredFlatteningParams(request, function(err, response) {
+      client.testOptionalRequiredFlatteningParams(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes testOptionalRequiredFlatteningParams with error', function(done) {
-      var client = library.v1();
+    it('invokes testOptionalRequiredFlatteningParams with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var requiredSingularInt32 = -72313594;
@@ -6400,9 +6401,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, null, error);
 
-      client.testOptionalRequiredFlatteningParams(request, function(err, response) {
+      client.testOptionalRequiredFlatteningParams(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -6417,21 +6418,24 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     assert.deepStrictEqual(actualRequest, expectedRequest);
     if (error) {
       callback(error);
-    } else if (response) {
+    }
+    else if (response) {
       callback(null, response);
-    } else {
+    }
+    else {
       callback(null);
     }
   };
 }
 
 function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
-  return function(actualRequest) {
+  return actualRequest => {
     assert.deepStrictEqual(actualRequest, expectedRequest);
-    var mockStream = through2.obj(function (chunk, enc, callback) {
+    var mockStream = through2.obj((chunk, enc, callback) => {
       if (error) {
         callback(error);
-      } else {
+      }
+      else {
         callback(null, response);
       }
     });
@@ -6440,12 +6444,13 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
 }
 
 function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
-  return function() {
-    var mockStream = through2.obj(function (chunk, enc, callback) {
+  return () => {
+    var mockStream = through2.obj((chunk, enc, callback) => {
       assert.deepStrictEqual(chunk, expectedRequest);
       if (error) {
         callback(error);
-      } else {
+      }
+      else {
         callback(null, response);
       }
     });
@@ -6454,14 +6459,15 @@ function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
 }
 
 function mockLongRunningGrpcMethod(expectedRequest, response, error) {
-  return function(request) {
+  return request => {
     assert.deepStrictEqual(request, expectedRequest);
     var mockOperation = {
       promise: function() {
-        return new Promise(function(resolve, reject) {
+        return new Promise((resolve, reject) => {
           if (error) {
             reject(error);
-          } else {
+          }
+          else {
             resolve([response]);
           }
         });

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -29,7 +29,7 @@ $ npm install --save @google-cloud/library
  });
 
  var formattedName = client.bookPath("testShelf-" + Date.now().toString(), projectId);
- var rating = library.v1.types.Book.Rating.GOOD;
+ var rating = 'GOOD';
  var book = {
    rating: rating,
  };
@@ -137,7 +137,7 @@ describe('LibraryServiceSmokeTest', () => {
     });
 
     var formattedName = client.bookPath("testShelf-" + Date.now().toString(), projectId);
-    var rating = library.v1.types.Book.Rating.GOOD;
+    var rating = 'GOOD';
     var book = {
       rating: rating,
     };
@@ -3578,8 +3578,8 @@ class LibraryServiceClient {
    *
    * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
    * var comment = '';
-   * var stage = library.v1.types.Comment.Stage.UNSET;
-   * var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+   * var stage = 'UNSET';
+   * var alignment = 'CHAR';
    * var commentsElement = {
    *   comment: comment,
    *   stage: stage,
@@ -4494,7 +4494,7 @@ class LibraryServiceClient {
    * var requiredSingularFloat = 0.0;
    * var requiredSingularDouble = 0.0;
    * var requiredSingularBool = false;
-   * var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   * var requiredSingularEnum = 'ZERO';
    * var requiredSingularString = '';
    * var requiredSingularBytes = '';
    * var requiredSingularMessage = {};
@@ -5556,8 +5556,8 @@ describe('LibraryServiceClient', () => {
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var comment = '95';
-      var stage = library.v1.types.Comment.Stage.UNSET;
-      var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+      var stage = 'UNSET';
+      var alignment = 'CHAR';
       var commentsElement = {
         comment: comment,
         stage: stage,
@@ -5584,8 +5584,8 @@ describe('LibraryServiceClient', () => {
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var comment = '95';
-      var stage = library.v1.types.Comment.Stage.UNSET;
-      var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+      var stage = 'UNSET';
+      var alignment = 'CHAR';
       var commentsElement = {
         comment: comment,
         stage: stage,
@@ -6274,7 +6274,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;
-      var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      var requiredSingularEnum = 'ZERO';
       var requiredSingularString = 'requiredSingularString-1949894503';
       var requiredSingularBytes = '-29';
       var requiredSingularMessage = {};
@@ -6348,7 +6348,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;
-      var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      var requiredSingularEnum = 'ZERO';
       var requiredSingularString = 'requiredSingularString-1949894503';
       var requiredSingularBytes = '-29';
       var requiredSingularMessage = {};

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -22,9 +22,9 @@ $ npm install --save @google-cloud/library
 ### Preview
 #### LibraryServiceClient
 ```js
- var library = require('@google-cloud/library');
+ const library = require('@google-cloud/library');
 
- var client = library({
+ var client = library.LibraryServiceClient({
    // optional auth parameters.
  });
 
@@ -123,16 +123,16 @@ $ npm install --save @google-cloud/library
  */
 'use strict';
 
-describe('LibraryServiceSmokeTest', function() {
+describe('LibraryServiceSmokeTest', () => {
   if (!process.env.SMOKE_TEST_PROJECT) {
     throw new Error("Usage: SMOKE_TEST_PROJECT=<project_id> node #{$0}");
   }
   var projectId = process.env.SMOKE_TEST_PROJECT;
 
-  it('successfully makes a call to the service', function(done) {
-    var library = require('../src');
+  it('successfully makes a call to the service', done => {
+    const library = require('../src');
 
-    var client = library.v1({
+    var client = new library.v1.LibraryServiceClient({
       // optional auth parameters.
     });
 
@@ -2620,9 +2620,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2674,9 +2674,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2735,9 +2735,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2812,9 +2812,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2855,9 +2855,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2900,9 +2900,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2955,9 +2955,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3020,9 +3020,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3076,9 +3076,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3142,9 +3142,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3231,9 +3231,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3272,9 +3272,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3325,9 +3325,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3378,9 +3378,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3446,9 +3446,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3528,9 +3528,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3570,9 +3570,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3624,9 +3624,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3673,9 +3673,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3724,9 +3724,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3771,9 +3771,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3814,9 +3814,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3849,9 +3849,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3880,9 +3880,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3918,9 +3918,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -3984,9 +3984,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -4083,9 +4083,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -4137,9 +4137,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -4192,9 +4192,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -4243,9 +4243,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -4333,9 +4333,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -4483,9 +4483,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -2289,7 +2289,7 @@ module.exports.LibraryServiceClient = LibraryServiceClient;
 
 'use strict';
 
-const configData = require('./library_service_client_config');
+const gapicConfig = require('./library_service_client_config');
 const gax = require('google-gax');
 const merge = require('lodash.merge');
 const path = require('path');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -2756,7 +2756,7 @@ class LibraryServiceClient {
    * // Or obtain the paged response.
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.
@@ -3167,7 +3167,7 @@ class LibraryServiceClient {
    *
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.
@@ -3467,7 +3467,7 @@ class LibraryServiceClient {
    * // Or obtain the paged response.
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.
@@ -4021,7 +4021,7 @@ class LibraryServiceClient {
    *
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -2325,7 +2325,7 @@ class LibraryServiceClient {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    Object.assign(opts, {scopes: this.constructor.scopes});
+    opts.scopes = this.constructor.scopes;
     var gaxGrpc = gax.grpc(opts);
 
     // Save the auth object to the client, for use by other methods.
@@ -2343,6 +2343,21 @@ class LibraryServiceClient {
     }
 
 
+    // This API contains "path templates"; forward-slash-separated
+    // identifiers to uniquely identify resources within the API.
+    // Create useful helper objects for these.
+    this._pathTemplates = {
+      shelfPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf_id}'
+      ),
+      bookPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf_id}/books/{book_id}'
+      ),
+      returnPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf}/books/{book}/returns/{return}'
+      ),
+    };
+
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
@@ -2352,19 +2367,16 @@ class LibraryServiceClient {
         'nextPageToken',
         'shelves'
       ),
-
       listBooks: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'books'
       ),
-
       listStrings: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'strings'
       ),
-
       findRelatedBooks: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
@@ -2376,11 +2388,8 @@ class LibraryServiceClient {
     // Provide descriptors for these.
     this._streamDescriptors = {
       streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-
       streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-
       discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
-
       monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
     };
 
@@ -2391,13 +2400,11 @@ class LibraryServiceClient {
         'books',
         [
           'edition',
-
           'shelf.name',
         ],
         'bookNames',
         gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book),
       ),
-
       addComments: new gax.BundleDescriptor(
         'comments',
         [
@@ -2445,7 +2452,6 @@ class LibraryServiceClient {
         getBigBookResponse.decode.bind(getBigBookResponse),
         getBigBookMetadata.decode.bind(getBigBookMetadata)
       ),
-
       getBigNothing: new gax.LongrunningDescriptor(
         this.operationsClient,
         getBigNothingResponse.decode.bind(getBigNothingResponse),
@@ -2577,117 +2583,6 @@ class LibraryServiceClient {
     ];
   }
 
-
-// Path templates
-
-var SHELF_PATH_TEMPLATE = new gax.PathTemplate(
-    'shelves/{shelf_id}');
-
-var BOOK_PATH_TEMPLATE = new gax.PathTemplate(
-    'shelves/{shelf_id}/books/{book_id}');
-
-var RETURN_PATH_TEMPLATE = new gax.PathTemplate(
-    'shelves/{shelf}/books/{book}/returns/{return}');
-
-/**
- * Returns a fully-qualified shelf resource name string.
- * @param {String} shelfId
- * @returns {String}
- */
-LibraryServiceClient.prototype.shelfPath = function(shelfId) {
-  return SHELF_PATH_TEMPLATE.render({
-    shelf_id: shelfId
-  });
-};
-
-/**
- * Returns a fully-qualified book resource name string.
- * @param {String} shelfId
- * @param {String} bookId
- * @returns {String}
- */
-LibraryServiceClient.prototype.bookPath = function(shelfId, bookId) {
-  return BOOK_PATH_TEMPLATE.render({
-    shelf_id: shelfId,
-    book_id: bookId
-  });
-};
-
-/**
- * Returns a fully-qualified return resource name string.
- * @param {String} shelf
- * @param {String} book
- * @param {String} return_
- * @returns {String}
- */
-LibraryServiceClient.prototype.returnPath = function(shelf, book, return_) {
-  return RETURN_PATH_TEMPLATE.render({
-    shelf: shelf,
-    book: book,
-    return: return_
-  });
-};
-
-/**
- * Parses the shelfName from a shelf resource.
- * @param {String} shelfName
- *   A fully-qualified path representing a shelf resources.
- * @returns {String} - A string representing the shelf_id.
- */
-LibraryServiceClient.prototype.matchShelfIdFromShelfName = function(shelfName) {
-  return SHELF_PATH_TEMPLATE.match(shelfName).shelf_id;
-};
-
-/**
- * Parses the bookName from a book resource.
- * @param {String} bookName
- *   A fully-qualified path representing a book resources.
- * @returns {String} - A string representing the shelf_id.
- */
-LibraryServiceClient.prototype.matchShelfIdFromBookName = function(bookName) {
-  return BOOK_PATH_TEMPLATE.match(bookName).shelf_id;
-};
-
-/**
- * Parses the bookName from a book resource.
- * @param {String} bookName
- *   A fully-qualified path representing a book resources.
- * @returns {String} - A string representing the book_id.
- */
-LibraryServiceClient.prototype.matchBookIdFromBookName = function(bookName) {
-  return BOOK_PATH_TEMPLATE.match(bookName).book_id;
-};
-
-/**
- * Parses the returnName from a return resource.
- * @param {String} returnName
- *   A fully-qualified path representing a return resources.
- * @returns {String} - A string representing the shelf.
- */
-LibraryServiceClient.prototype.matchShelfFromReturnName = function(returnName) {
-  return RETURN_PATH_TEMPLATE.match(returnName).shelf;
-};
-
-/**
- * Parses the returnName from a return resource.
- * @param {String} returnName
- *   A fully-qualified path representing a return resources.
- * @returns {String} - A string representing the book.
- */
-LibraryServiceClient.prototype.matchBookFromReturnName = function(returnName) {
-  return RETURN_PATH_TEMPLATE.match(returnName).book;
-};
-
-/**
- * Parses the returnName from a return resource.
- * @param {String} returnName
- *   A fully-qualified path representing a return resources.
- * @returns {String} - A string representing the return.
- */
-LibraryServiceClient.prototype.matchReturnFromReturnName = function(returnName) {
-  return RETURN_PATH_TEMPLATE.match(returnName).return;
-};
-
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
@@ -2697,7 +2592,122 @@ LibraryServiceClient.prototype.matchReturnFromReturnName = function(returnName) 
     return this.auth.getProjectId(callback);
   }
 
-  // Service calls
+  // --------------------
+  // -- Path templates --
+  // --------------------
+
+  /**
+   * Return a fully-qualified shelf resource name string.
+   *
+   * @param {String} shelfId
+   * @returns {String}
+   */
+  shelfPath(shelfId) {
+    return this._pathTemplates.shelfPathTemplate.render({
+      shelf_id: shelfId,
+    });
+  }
+
+  /**
+   * Return a fully-qualified book resource name string.
+   *
+   * @param {String} shelfId
+   * @param {String} bookId
+   * @returns {String}
+   */
+  bookPath(shelfId, bookId) {
+    return this._pathTemplates.bookPathTemplate.render({
+      shelf_id: shelfId,
+      book_id: bookId,
+    });
+  }
+
+  /**
+   * Return a fully-qualified return resource name string.
+   *
+   * @param {String} shelf
+   * @param {String} book
+   * @param {String} return_
+   * @returns {String}
+   */
+  returnPath(shelf, book, return_) {
+    return this._pathTemplates.returnPathTemplate.render({
+      shelf: shelf,
+      book: book,
+      return: return_,
+    });
+  }
+
+
+  /**
+   * Parse the shelfName from a shelf resource.
+   *
+   * @param {String} shelfName
+   *   A fully-qualified path representing a shelf resources.
+   * @returns {String} - A string representing the shelf_id.
+   */
+  matchShelfIdFromShelfName(shelfName) {
+    return shelfPathTemplate.match(shelfName).shelf_id;
+  }
+
+  /**
+   * Parse the bookName from a book resource.
+   *
+   * @param {String} bookName
+   *   A fully-qualified path representing a book resources.
+   * @returns {String} - A string representing the shelf_id.
+   */
+  matchShelfIdFromBookName(bookName) {
+    return bookPathTemplate.match(bookName).shelf_id;
+  }
+
+  /**
+   * Parse the bookName from a book resource.
+   *
+   * @param {String} bookName
+   *   A fully-qualified path representing a book resources.
+   * @returns {String} - A string representing the book_id.
+   */
+  matchBookIdFromBookName(bookName) {
+    return bookPathTemplate.match(bookName).book_id;
+  }
+
+  /**
+   * Parse the returnName from a return resource.
+   *
+   * @param {String} returnName
+   *   A fully-qualified path representing a return resources.
+   * @returns {String} - A string representing the shelf.
+   */
+  matchShelfFromReturnName(returnName) {
+    return returnPathTemplate.match(returnName).shelf;
+  }
+
+  /**
+   * Parse the returnName from a return resource.
+   *
+   * @param {String} returnName
+   *   A fully-qualified path representing a return resources.
+   * @returns {String} - A string representing the book.
+   */
+  matchBookFromReturnName(returnName) {
+    return returnPathTemplate.match(returnName).book;
+  }
+
+  /**
+   * Parse the returnName from a return resource.
+   *
+   * @param {String} returnName
+   *   A fully-qualified path representing a return resources.
+   * @returns {String} - A string representing the return.
+   */
+  matchReturnFromReturnName(returnName) {
+    return returnPathTemplate.match(returnName).return;
+  }
+
+  // -------------------
+  // -- Service calls --
+  // -------------------
 
   /**
    * Creates a shelf, and returns the new Shelf.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -6202,8 +6202,8 @@ describe('LibraryServiceClient', () => {
 
     it('has longrunning decoder functions', () => {
       var client = new libraryModule.v1.LibraryServiceClient();
-      assert(client.longrunningDescriptors.getBigBook.responseDecoder instanceof Function);
-      assert(client.longrunningDescriptors.getBigBook.metadataDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigBook.responseDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigBook.metadataDecoder instanceof Function);
     });
   });
 
@@ -6260,8 +6260,8 @@ describe('LibraryServiceClient', () => {
 
     it('has longrunning decoder functions', () => {
       var client = new libraryModule.v1.LibraryServiceClient();
-      assert(client.longrunningDescriptors.getBigNothing.responseDecoder instanceof Function);
-      assert(client.longrunningDescriptors.getBigNothing.metadataDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigNothing.responseDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigNothing.metadataDecoder instanceof Function);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -252,6 +252,8 @@ const protobuf = require('protobufjs');
  */
 class LibraryServiceClient {
   constructor(opts) {
+    this._descriptors = {};
+
     // Ensure that options include the service address and port.
     opts = Object.assign({
       clientConfig: {},
@@ -278,6 +280,17 @@ class LibraryServiceClient {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
 
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'library.proto'
+      ),
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'tagger.proto'
+      ),
+    );
 
     // This API contains "path templates"; forward-slash-separated
     // identifiers to uniquely identify resources within the API.
@@ -297,7 +310,7 @@ class LibraryServiceClient {
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
-    this._pageDescriptors = {
+    this._descriptors.page = {
       listShelves: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
@@ -322,7 +335,7 @@ class LibraryServiceClient {
 
     // Some of the methods on this service provide streaming responses.
     // Provide descriptors for these.
-    this._streamDescriptors = {
+    this._descriptors.stream = {
       streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
       streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
       discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
@@ -331,7 +344,7 @@ class LibraryServiceClient {
 
     // Some methods on this API support automatically batching
     // requests; denote this.
-    var batchingDescriptors = {
+    this._descriptors.batching = {
       publishSeries: new gax.BundleDescriptor(
         'books',
         [
@@ -339,7 +352,7 @@ class LibraryServiceClient {
           'shelf.name',
         ],
         'bookNames',
-        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book),
+        gax.createByteLengthFunction(protos.google.example.library.v1.Book),
       ),
       addComments: new gax.BundleDescriptor(
         'comments',
@@ -347,7 +360,7 @@ class LibraryServiceClient {
           'name',
         ],
         null,
-        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Comment),
+        gax.createByteLengthFunction(protos.google.example.library.v1.Comment),
       ),
     };
 
@@ -382,7 +395,7 @@ class LibraryServiceClient {
       'google.example.library.v1.GetBigBookMetadata'
     );
 
-    this.longrunningDescriptors = {
+    this._descriptors.longrunning = {
       getBigBook: new gax.LongrunningDescriptor(
         this.operationsClient,
         getBigBookResponse.decode.bind(getBigBookResponse),
@@ -401,18 +414,6 @@ class LibraryServiceClient {
       gapicConfig,
       opts.clientConfig,
       {'x-goog-api-client': clientHeader.join(' ')},
-    );
-
-    // Load the applicable protos.
-    var protos = merge({},
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos'),
-        'library.proto'
-      ),
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos'),
-        'tagger.proto'
-      ),
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -465,7 +466,7 @@ class LibraryServiceClient {
           return stub[methodName].apply(stub, args);
         }),
         defaults[methodName],
-        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+        this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
     }
 
@@ -488,7 +489,7 @@ class LibraryServiceClient {
           return stub[methodName].apply(stub, args);
         }),
         defaults[methodName],
-        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+        this._descriptors.page[methodName] || this._descriptors.batching[methodName] || this._descriptors.stream[methodName] || this._descriptors.longrunning[methodName]
       );
     }
   }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -259,7 +259,7 @@ class LibraryServiceClient {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    Object.assign(opts, {scopes: this.constructor.scopes});
+    opts.scopes = this.constructor.scopes;
     var gaxGrpc = gax.grpc(opts);
 
     // Save the auth object to the client, for use by other methods.
@@ -277,6 +277,21 @@ class LibraryServiceClient {
     }
 
 
+    // This API contains "path templates"; forward-slash-separated
+    // identifiers to uniquely identify resources within the API.
+    // Create useful helper objects for these.
+    this._pathTemplates = {
+      shelfPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf_id}'
+      ),
+      bookPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf_id}/books/{book_id}'
+      ),
+      returnPathTemplate: new gax.PathTemplate(
+        'shelves/{shelf}/books/{book}/returns/{return}'
+      ),
+    };
+
     // Some of the methods on this service return "paged" results,
     // (e.g. 50 results at a time, with tokens to get subsequent
     // pages). Denote the keys used for pagination and results.
@@ -286,19 +301,16 @@ class LibraryServiceClient {
         'nextPageToken',
         'shelves'
       ),
-
       listBooks: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'books'
       ),
-
       listStrings: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
         'strings'
       ),
-
       findRelatedBooks: new gax.PageDescriptor(
         'pageToken',
         'nextPageToken',
@@ -310,11 +322,8 @@ class LibraryServiceClient {
     // Provide descriptors for these.
     this._streamDescriptors = {
       streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-
       streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-
       discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
-
       monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
     };
 
@@ -325,13 +334,11 @@ class LibraryServiceClient {
         'books',
         [
           'edition',
-
           'shelf.name',
         ],
         'bookNames',
         gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book),
       ),
-
       addComments: new gax.BundleDescriptor(
         'comments',
         [
@@ -379,7 +386,6 @@ class LibraryServiceClient {
         getBigBookResponse.decode.bind(getBigBookResponse),
         getBigBookMetadata.decode.bind(getBigBookMetadata)
       ),
-
       getBigNothing: new gax.LongrunningDescriptor(
         this.operationsClient,
         getBigNothingResponse.decode.bind(getBigNothingResponse),
@@ -511,117 +517,6 @@ class LibraryServiceClient {
     ];
   }
 
-
-// Path templates
-
-var SHELF_PATH_TEMPLATE = new gax.PathTemplate(
-    'shelves/{shelf_id}');
-
-var BOOK_PATH_TEMPLATE = new gax.PathTemplate(
-    'shelves/{shelf_id}/books/{book_id}');
-
-var RETURN_PATH_TEMPLATE = new gax.PathTemplate(
-    'shelves/{shelf}/books/{book}/returns/{return}');
-
-/**
- * Returns a fully-qualified shelf resource name string.
- * @param {String} shelfId
- * @returns {String}
- */
-LibraryServiceClient.prototype.shelfPath = function(shelfId) {
-  return SHELF_PATH_TEMPLATE.render({
-    shelf_id: shelfId
-  });
-};
-
-/**
- * Returns a fully-qualified book resource name string.
- * @param {String} shelfId
- * @param {String} bookId
- * @returns {String}
- */
-LibraryServiceClient.prototype.bookPath = function(shelfId, bookId) {
-  return BOOK_PATH_TEMPLATE.render({
-    shelf_id: shelfId,
-    book_id: bookId
-  });
-};
-
-/**
- * Returns a fully-qualified return resource name string.
- * @param {String} shelf
- * @param {String} book
- * @param {String} return_
- * @returns {String}
- */
-LibraryServiceClient.prototype.returnPath = function(shelf, book, return_) {
-  return RETURN_PATH_TEMPLATE.render({
-    shelf: shelf,
-    book: book,
-    return: return_
-  });
-};
-
-/**
- * Parses the shelfName from a shelf resource.
- * @param {String} shelfName
- *   A fully-qualified path representing a shelf resources.
- * @returns {String} - A string representing the shelf_id.
- */
-LibraryServiceClient.prototype.matchShelfIdFromShelfName = function(shelfName) {
-  return SHELF_PATH_TEMPLATE.match(shelfName).shelf_id;
-};
-
-/**
- * Parses the bookName from a book resource.
- * @param {String} bookName
- *   A fully-qualified path representing a book resources.
- * @returns {String} - A string representing the shelf_id.
- */
-LibraryServiceClient.prototype.matchShelfIdFromBookName = function(bookName) {
-  return BOOK_PATH_TEMPLATE.match(bookName).shelf_id;
-};
-
-/**
- * Parses the bookName from a book resource.
- * @param {String} bookName
- *   A fully-qualified path representing a book resources.
- * @returns {String} - A string representing the book_id.
- */
-LibraryServiceClient.prototype.matchBookIdFromBookName = function(bookName) {
-  return BOOK_PATH_TEMPLATE.match(bookName).book_id;
-};
-
-/**
- * Parses the returnName from a return resource.
- * @param {String} returnName
- *   A fully-qualified path representing a return resources.
- * @returns {String} - A string representing the shelf.
- */
-LibraryServiceClient.prototype.matchShelfFromReturnName = function(returnName) {
-  return RETURN_PATH_TEMPLATE.match(returnName).shelf;
-};
-
-/**
- * Parses the returnName from a return resource.
- * @param {String} returnName
- *   A fully-qualified path representing a return resources.
- * @returns {String} - A string representing the book.
- */
-LibraryServiceClient.prototype.matchBookFromReturnName = function(returnName) {
-  return RETURN_PATH_TEMPLATE.match(returnName).book;
-};
-
-/**
- * Parses the returnName from a return resource.
- * @param {String} returnName
- *   A fully-qualified path representing a return resources.
- * @returns {String} - A string representing the return.
- */
-LibraryServiceClient.prototype.matchReturnFromReturnName = function(returnName) {
-  return RETURN_PATH_TEMPLATE.match(returnName).return;
-};
-
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
@@ -631,7 +526,122 @@ LibraryServiceClient.prototype.matchReturnFromReturnName = function(returnName) 
     return this.auth.getProjectId(callback);
   }
 
-  // Service calls
+  // --------------------
+  // -- Path templates --
+  // --------------------
+
+  /**
+   * Return a fully-qualified shelf resource name string.
+   *
+   * @param {String} shelfId
+   * @returns {String}
+   */
+  shelfPath(shelfId) {
+    return this._pathTemplates.shelfPathTemplate.render({
+      shelf_id: shelfId,
+    });
+  }
+
+  /**
+   * Return a fully-qualified book resource name string.
+   *
+   * @param {String} shelfId
+   * @param {String} bookId
+   * @returns {String}
+   */
+  bookPath(shelfId, bookId) {
+    return this._pathTemplates.bookPathTemplate.render({
+      shelf_id: shelfId,
+      book_id: bookId,
+    });
+  }
+
+  /**
+   * Return a fully-qualified return resource name string.
+   *
+   * @param {String} shelf
+   * @param {String} book
+   * @param {String} return_
+   * @returns {String}
+   */
+  returnPath(shelf, book, return_) {
+    return this._pathTemplates.returnPathTemplate.render({
+      shelf: shelf,
+      book: book,
+      return: return_,
+    });
+  }
+
+
+  /**
+   * Parse the shelfName from a shelf resource.
+   *
+   * @param {String} shelfName
+   *   A fully-qualified path representing a shelf resources.
+   * @returns {String} - A string representing the shelf_id.
+   */
+  matchShelfIdFromShelfName(shelfName) {
+    return shelfPathTemplate.match(shelfName).shelf_id;
+  }
+
+  /**
+   * Parse the bookName from a book resource.
+   *
+   * @param {String} bookName
+   *   A fully-qualified path representing a book resources.
+   * @returns {String} - A string representing the shelf_id.
+   */
+  matchShelfIdFromBookName(bookName) {
+    return bookPathTemplate.match(bookName).shelf_id;
+  }
+
+  /**
+   * Parse the bookName from a book resource.
+   *
+   * @param {String} bookName
+   *   A fully-qualified path representing a book resources.
+   * @returns {String} - A string representing the book_id.
+   */
+  matchBookIdFromBookName(bookName) {
+    return bookPathTemplate.match(bookName).book_id;
+  }
+
+  /**
+   * Parse the returnName from a return resource.
+   *
+   * @param {String} returnName
+   *   A fully-qualified path representing a return resources.
+   * @returns {String} - A string representing the shelf.
+   */
+  matchShelfFromReturnName(returnName) {
+    return returnPathTemplate.match(returnName).shelf;
+  }
+
+  /**
+   * Parse the returnName from a return resource.
+   *
+   * @param {String} returnName
+   *   A fully-qualified path representing a return resources.
+   * @returns {String} - A string representing the book.
+   */
+  matchBookFromReturnName(returnName) {
+    return returnPathTemplate.match(returnName).book;
+  }
+
+  /**
+   * Parse the returnName from a return resource.
+   *
+   * @param {String} returnName
+   *   A fully-qualified path representing a return resources.
+   * @returns {String} - A string representing the return.
+   */
+  matchReturnFromReturnName(returnName) {
+    return returnPathTemplate.match(returnName).return;
+  }
+
+  // -------------------
+  // -- Service calls --
+  // -------------------
 
   /**
    * Creates a shelf, and returns the new Shelf.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -84,7 +84,6 @@ $ npm install --save @google-cloud/library
     "Google Example Library API"
   ],
   "dependencies": {
-    "extend": "^3.0",
     "google-gax": "^0.14.0",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.merge": "^4.6.0",
@@ -154,7 +153,7 @@ describe('LibraryServiceSmokeTest', function() {
   });
 });
 ============== file: src/index.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -169,85 +168,20 @@ describe('LibraryServiceSmokeTest', function() {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-var extend = require('extend');
-var gapic = {
-  v1: require('./v1')
-};
-var gaxGrpc = require('google-gax').grpc();
-var path = require('path');
+'use strict';
 
 const VERSION = require('../package.json').version;
 
-/**
- * Create an libraryServiceClient with additional helpers for common
- * tasks.
- *
- * This API represents a simple digital library.  It lets you manage Shelf
- * resources and Book resources in the library. It defines the following
- * resource model:
- *
- * - The API has a collection of {@link Shelf}
- *   resources, named ``bookShelves/*``
- *
- * - Each Shelf has a collection of {@link Book}
- *   resources, named `bookShelves/*/books/*`
- *
- * Check out [cloud docs!](https://cloud.google.com/library/example/link).
- * This is [not a cloud link](http://www.google.com).
- *
- * Service comment may include special characters: <>&"`'@.
- *
- * @param {object=} options - [Configuration object](#/docs).
- * @param {object=} options.credentials - Credentials object.
- * @param {string=} options.credentials.client_email
- * @param {string=} options.credentials.private_key
- * @param {string=} options.email - Account email address. Required when using a
- *     .pem or .p12 keyFilename.
- * @param {string=} options.keyFilename - Full path to the a .json, .pem, or
- *     .p12 key downloaded from the Google Developers Console. If you provide
- *     a path to a JSON file, the projectId option above is not necessary.
- *     NOTE: .pem and .p12 require you to specify options.email as well.
- * @param {number=} options.port - The port on which to connect to
- *     the remote host.
- * @param {string=} options.projectId - The project ID from the Google
- *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
- *     the environment variable GCLOUD_PROJECT for your project ID. If your
- *     app is running in an environment which supports
- *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
- *     your project ID will be detected automatically.
- * @param {function=} options.promise - Custom promise module to use instead
- *     of native Promises.
- * @param {string=} options.servicePath - The domain name of the
- *     API remote host.
- */
-function libraryV1(options) {
-  // Define the header options.
-  options = extend({}, options, {
-    libName: 'gccl',
-    libVersion: VERSION
-  });
+// Import the clients for each version supported by this package.
+var gapic = {
+  v1: require('./v1'),
+};
 
-  // Create the client with the provided options.
-  var client = gapic.v1(options).libraryServiceClient(options);
-  return client;
-}
+module.exports = gapic.v1;
+module.exports.v1 = gapic.v1;
+module.exports.default = Object.assign({}, module.exports);
 
-var v1Protos = {};
-
-extend(v1Protos, gaxGrpc.loadProto(
-  path.join(__dirname, '..', 'protos'), 'library.proto')
-    .google.example.library.v1);
-
-extend(v1Protos, gaxGrpc.loadProto(
-  path.join(__dirname, '..', 'protos'), 'tagger.proto')
-    .google.tagger.v1);
-
-module.exports = libraryV1;
-module.exports.types = v1Protos;
-module.exports.v1 = libraryV1;
-module.exports.v1.types = v1Protos;
 ============== file: src/v1/index.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -266,22 +200,10 @@ module.exports.v1.types = v1Protos;
  */
 'use strict';
 
-var libraryServiceClient = require('./library_service_client');
-var gax = require('google-gax');
-var extend = require('extend');
+const LibraryServiceClient = require('./library_service_client');
 
-function v1(options) {
-  options = extend({
-    scopes: v1.ALL_SCOPES
-  }, options);
-  var gaxGrpc = gax.grpc(options);
-  return libraryServiceClient(gaxGrpc);
-}
+module.exports.LibraryServiceClient = LibraryServiceClient;
 
-v1.SERVICE_ADDRESS = libraryServiceClient.SERVICE_ADDRESS;
-v1.ALL_SCOPES = libraryServiceClient.ALL_SCOPES;
-
-module.exports = v1;
 ============== file: src/v1/library_service_client.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -297,66 +219,15 @@ module.exports = v1;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * EDITING INSTRUCTIONS
- * This file was generated from the file
- * https://github.com/googleapis/googleapis/blob/master/library.proto,
- * and updates to that file get reflected here through a refresh process.
- * For the short term, the refresh process will only be runnable by Google
- * engineers.
- *
- * The only allowed edits are to method and file documentation. A 3-way
- * merge preserves those additions if the generated source changes.
  */
+
 'use strict';
 
-var configData = require('./library_service_client_config');
-var extend = require('extend');
-var gax = require('google-gax');
-var merge = require('lodash.merge');
-var path = require('path');
-var protobuf = require('protobufjs');
-
-var SERVICE_ADDRESS = 'library-example.googleapis.com';
-
-var DEFAULT_SERVICE_PORT = 443;
-
-var CODE_GEN_NAME_VERSION = 'gapic/0.0.5';
-
-var PAGE_DESCRIPTORS = {
-  listShelves: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'shelves'),
-  listBooks: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'books'),
-  listStrings: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'strings'),
-  findRelatedBooks: new gax.PageDescriptor(
-      'pageToken',
-      'nextPageToken',
-      'names')
-};
-
-var STREAM_DESCRIPTORS = {
-  streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-  streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
-  discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
-  monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING)
-};
-
-/*!
- * The scopes needed to make gRPC calls to all of the methods defined in
- * this service.
- */
-var ALL_SCOPES = [
-  'https://www.googleapis.com/auth/cloud-platform',
-  'https://www.googleapis.com/auth/library'
-];
+const configData = require('./library_service_client_config');
+const gax = require('google-gax');
+const merge = require('lodash.merge');
+const path = require('path');
+const protobuf = require('protobufjs');
 
 /**
  * This API represents a simple digital library.  It lets you manage Shelf
@@ -377,143 +248,269 @@ var ALL_SCOPES = [
  *
  * @class
  */
-function LibraryServiceClient(gaxGrpc, loadedProtos, opts) {
-  opts = extend({
-    servicePath: SERVICE_ADDRESS,
-    port: DEFAULT_SERVICE_PORT,
-    clientConfig: {}
-  }, opts);
+class LibraryServiceClient {
+  constructor(opts) {
+    // Ensure that options include the service address and port.
+    opts = Object.assign({
+      clientConfig: {},
+      port: this.constructor.port,
+      servicePath: this.constructor.servicePath,
+    }, opts);
 
-  var googleApiClient = [
-    'gl-node/' + process.versions.node
-  ];
-  if (opts.libName && opts.libVersion) {
-    googleApiClient.push(opts.libName + '/' + opts.libVersion);
-  }
-  googleApiClient.push(
-    CODE_GEN_NAME_VERSION,
-    'gax/' + gax.version,
-    'grpc/' + gaxGrpc.grpcVersion
-  );
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    Object.assign(opts, {scopes: this.constructor.scopes});
+    var gaxGrpc = gax.grpc(opts);
 
-  var bundleDescriptors = {
-    publishSeries: new gax.BundleDescriptor(
-      'books',
-      [
-        'edition',
-        'shelf.name'
-      ],
-      'bookNames',
-      gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book)),
-    addComments: new gax.BundleDescriptor(
-      'comments',
-      [
-        'name'
-      ],
-      null,
-      gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Comment))
-  };
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
 
-  this.operationsClient = new gax.lro({
-    auth: gaxGrpc.auth,
-    grpc: gaxGrpc.grpc
-  }).operationsClient(opts);
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${this.version}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
 
-  var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
-  protoFilesRoot = protobuf.loadSync(
-    path.join(__dirname, '..', '..', 'protos', 'library.proto'),
-    protoFilesRoot);
-  protoFilesRoot = protobuf.loadSync(
-    path.join(__dirname, '..', '..', 'protos', 'tagger.proto'),
-    protoFilesRoot);
 
-  var getBigBookResponse = protoFilesRoot.lookup('google.example.library.v1.Book');
-  var getBigBookMetadata = protoFilesRoot.lookup('google.example.library.v1.GetBigBookMetadata');
-  var getBigNothingResponse = protoFilesRoot.lookup('google.protobuf.Empty');
-  var getBigNothingMetadata = protoFilesRoot.lookup('google.example.library.v1.GetBigBookMetadata');
+    // Some of the methods on this service return "paged" results,
+    // (e.g. 50 results at a time, with tokens to get subsequent
+    // pages). Denote the keys used for pagination and results.
+    this._pageDescriptors = {
+      listShelves: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'shelves'
+      ),
 
-  this.longrunningDescriptors = {
-    getBigBook: new gax.LongrunningDescriptor(
-      this.operationsClient,
-      getBigBookResponse.decode.bind(getBigBookResponse),
-      getBigBookMetadata.decode.bind(getBigBookMetadata)),
-    getBigNothing: new gax.LongrunningDescriptor(
-      this.operationsClient,
-      getBigNothingResponse.decode.bind(getBigNothingResponse),
-      getBigNothingMetadata.decode.bind(getBigNothingMetadata))
-  };
+      listBooks: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'books'
+      ),
 
-  var defaults = gaxGrpc.constructSettings(
+      listStrings: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'strings'
+      ),
+
+      findRelatedBooks: new gax.PageDescriptor(
+        'pageToken',
+        'nextPageToken',
+        'names'
+      ),
+    };
+
+    // Some of the methods on this service provide streaming responses.
+    // Provide descriptors for these.
+    this._streamDescriptors = {
+      streamShelves: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+
+      streamBooks: new gax.StreamDescriptor(gax.StreamType.SERVER_STREAMING),
+
+      discussBook: new gax.StreamDescriptor(gax.StreamType.BIDI_STREAMING),
+
+      monologAboutBook: new gax.StreamDescriptor(gax.StreamType.CLIENT_STREAMING),
+    };
+
+    // Some methods on this API support automatically batching
+    // requests; denote this.
+    var batchingDescriptors = {
+      publishSeries: new gax.BundleDescriptor(
+        'books',
+        [
+          'edition',
+
+          'shelf.name',
+        ],
+        'bookNames',
+        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Book),
+      ),
+
+      addComments: new gax.BundleDescriptor(
+        'comments',
+        [
+          'name',
+        ],
+        null,
+        gax.createByteLengthFunction(loadedProtos.google.example.library.v1.Comment),
+      ),
+    };
+
+    // This API contains "long-running operations", which return a
+    // an Operation object that allows for tracking of the operation,
+    // rather than holding a request open.
+    this.operationsClient = new gax.lro({
+      auth: gaxGrpc.auth,
+      grpc: gaxGrpc.grpc,
+    }).operationsClient(opts);
+
+    var protoFilesRoot = new gax.grpc.GoogleProtoFilesRoot();
+    protoFilesRoot = protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'library.proto'),
+      protoFilesRoot
+    );
+    protoFilesRoot = protobuf.loadSync(
+      path.join(__dirname, '..', '..', 'protos', 'tagger.proto'),
+      protoFilesRoot
+    );
+
+    var getBigBookResponse = protoFilesRoot.lookup(
+      'google.example.library.v1.Book'
+    );
+    var getBigBookMetadata = protoFilesRoot.lookup(
+      'google.example.library.v1.GetBigBookMetadata'
+    );
+    var getBigNothingResponse = protoFilesRoot.lookup(
+      'google.protobuf.Empty'
+    );
+    var getBigNothingMetadata = protoFilesRoot.lookup(
+      'google.example.library.v1.GetBigBookMetadata'
+    );
+
+    this.longrunningDescriptors = {
+      getBigBook: new gax.LongrunningDescriptor(
+        this.operationsClient,
+        getBigBookResponse.decode.bind(getBigBookResponse),
+        getBigBookMetadata.decode.bind(getBigBookMetadata)
+      ),
+
+      getBigNothing: new gax.LongrunningDescriptor(
+        this.operationsClient,
+        getBigNothingResponse.decode.bind(getBigNothingResponse),
+        getBigNothingMetadata.decode.bind(getBigNothingMetadata)
+      ),
+    };
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
       'google.example.library.v1.LibraryService',
-      configData,
+      gapicConfig,
       opts.clientConfig,
-      {'x-goog-api-client': googleApiClient.join(' ')});
+      {'x-goog-api-client': clientHeader.join(' ')},
+    );
 
-  var self = this;
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'library.proto'
+      ),,
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'tagger.proto'
+      ),
+    );
 
-  this.auth = gaxGrpc.auth;
-  var libraryServiceStub = gaxGrpc.createStub(
-      loadedProtos.google.example.library.v1.LibraryService,
-      opts);
-  var libraryServiceStubMethods = [
-    'createShelf',
-    'getShelf',
-    'listShelves',
-    'deleteShelf',
-    'mergeShelves',
-    'createBook',
-    'publishSeries',
-    'getBook',
-    'listBooks',
-    'deleteBook',
-    'updateBook',
-    'moveBook',
-    'listStrings',
-    'addComments',
-    'getBookFromArchive',
-    'getBookFromAnywhere',
-    'getBookFromAbsolutelyAnywhere',
-    'updateBookIndex',
-    'streamShelves',
-    'streamBooks',
-    'discussBook',
-    'monologAboutBook',
-    'findRelatedBooks',
-    'addTag',
-    'getBigBook',
-    'getBigNothing',
-    'testOptionalRequiredFlatteningParams'
-  ];
-  libraryServiceStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      libraryServiceStub.then(function(libraryServiceStub) {
-        return function() {
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.example.library.v1.LibraryService.
+    var libraryServiceStub = gaxGrpc.createStub(
+      protos.google.example.library.v1.LibraryService,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var libraryServiceStubMethods = [
+      'createShelf',
+      'getShelf',
+      'listShelves',
+      'deleteShelf',
+      'mergeShelves',
+      'createBook',
+      'publishSeries',
+      'getBook',
+      'listBooks',
+      'deleteBook',
+      'updateBook',
+      'moveBook',
+      'listStrings',
+      'addComments',
+      'getBookFromArchive',
+      'getBookFromAnywhere',
+      'getBookFromAbsolutelyAnywhere',
+      'updateBookIndex',
+      'streamShelves',
+      'streamBooks',
+      'discussBook',
+      'monologAboutBook',
+      'findRelatedBooks',
+      'addTag',
+      'getBigBook',
+      'getBigNothing',
+      'testOptionalRequiredFlatteningParams',
+    ];
+    for (let methodName of libraryServiceStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        libraryServiceStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return libraryServiceStub[methodName].apply(libraryServiceStub, args);
-        };
-      }),
-      defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
-  });
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+      );
+    }
 
-  var labelerStub = gaxGrpc.createStub(
-      loadedProtos.google.tagger.v1.Labeler,
-      opts);
-  var labelerStubMethods = [
-    'addLabel'
-  ];
-  labelerStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      labelerStub.then(function(labelerStub) {
-        return function() {
+    // Put together the "service stub" for
+    // google.tagger.v1.Labeler.
+    var labelerStub = gaxGrpc.createStub(
+      protos.google.tagger.v1.Labeler,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var labelerStubMethods = [
+      'addLabel',
+    ];
+    for (let methodName of labelerStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        labelerStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return labelerStub[methodName].apply(labelerStub, args);
-        };
-      }),
-      defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
-  });
-}
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]
+      );
+    }
+  }
+
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'library-example.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+      'https://www.googleapis.com/auth/cloud-platform',
+
+      'https://www.googleapis.com/auth/library',
+    ];
+  }
+
 
 // Path templates
 
@@ -625,2054 +622,1964 @@ LibraryServiceClient.prototype.matchReturnFromReturnName = function(returnName) 
   return RETURN_PATH_TEMPLATE.match(returnName).return;
 };
 
-/**
- * Get the project ID used by this class.
- * @param {function(Error, string)} callback - the callback to be called with
- *   the current project Id.
- */
-LibraryServiceClient.prototype.getProjectId = function(callback) {
-  return this.auth.getProjectId(callback);
-};
-
-// Service calls
-
-/**
- * Creates a shelf, and returns the new Shelf.
- * RPC method comment may include special characters: <>&"`'@.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {Object} request.shelf
- *   The shelf to create.
- *
- *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var shelf = {};
- * client.createShelf({shelf: shelf}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.createShelf = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
+  /**
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
+   */
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
   }
 
-  return this._createShelf(request, options, callback);
-};
-
-/**
- * Gets a shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf to retrieve.
- * @param {string} request.options
- *   To test 'options' parameter name conflict.
- * @param {Object=} request.message
- *   Field to verify that message-type query parameter gets flattened.
- *
- *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
- * @param {Object=} request.stringBuilder
- *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * var options = '';
- * var request = {
- *     name: formattedName,
- *     options: options
- * };
- * client.getShelf(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getShelf = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getShelf(request, options, callback);
-};
-
-/**
- * Lists shelves.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of [Shelf]{@link google.example.library.v1.Shelf}.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Shelf]{@link google.example.library.v1.Shelf}.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Shelf]{@link google.example.library.v1.Shelf} in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * client.listShelves({}).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.listShelves(nextRequest, options).then(callback);
- *     }
- * }
- * client.listShelves({}, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.listShelves = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._listShelves(request, options, callback);
-};
-
-/**
- * Equivalent to {@link listShelves}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link listShelves} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits an object representing [Shelf]{@link google.example.library.v1.Shelf} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- *
- * client.listShelvesStream({})
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.listShelvesStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return PAGE_DESCRIPTORS.listShelves.createStream(this._listShelves, request, options);
-};
-
-/**
- * Deletes a shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf to delete.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * client.deleteShelf({name: formattedName}).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.deleteShelf = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._deleteShelf(request, options, callback);
-};
-
-/**
- * Merges two shelves by adding all books from the shelf named
- * `other_shelf_name` to shelf `name`, and deletes
- * `other_shelf_name`. Returns the updated shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf we're adding books to.
- * @param {string} request.otherShelfName
- *   The name of the shelf we're removing books from and deleting.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
- * var request = {
- *     name: formattedName,
- *     otherShelfName: formattedOtherShelfName
- * };
- * client.mergeShelves(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.mergeShelves = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._mergeShelves(request, options, callback);
-};
-
-/**
- * Creates a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf in which the book is created.
- * @param {Object} request.book
- *   The book to create.
- *
- *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * var book = {};
- * var request = {
- *     name: formattedName,
- *     book: book
- * };
- * client.createBook(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.createBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._createBook(request, options, callback);
-};
-
-/**
- * Creates a series of books.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {Object} request.shelf
- *   The shelf in which the series is created.
- *
- *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
- * @param {Object[]} request.books
- *   The books to publish in the series.
- *
- *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
- * @param {Object} request.seriesUuid
- *   Uniquely identifies the series to the publishing house.
- *
- *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
- * @param {number=} request.edition
- *   The edition of the series
- * @param {boolean=} request.reviewCopy
- *   If the book is in a pre-publish state
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var shelf = {};
- * var books = [];
- * var seriesString = 'foobar';
- * var seriesUuid = {
- *     seriesString : seriesString
- * };
- * var request = {
- *     shelf: shelf,
- *     books: books,
- *     seriesUuid: seriesUuid
- * };
- * client.publishSeries(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.publishSeries = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._publishSeries(request, options, callback);
-};
-
-/**
- * Gets a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * client.getBook({name: formattedName}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBook(request, options, callback);
-};
-
-/**
- * Lists books in a shelf.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf whose books we'd like to list.
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {string=} request.filter
- *   To test python built-in wrapping.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of [Book]{@link google.example.library.v1.Book}.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of [Book]{@link google.example.library.v1.Book}.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of [Book]{@link google.example.library.v1.Book} in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * var formattedName = client.shelfPath("[SHELF_ID]");
- *
- * client.listBooks({name: formattedName}).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- * var formattedName = client.shelfPath("[SHELF_ID]");
- *
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.listBooks(nextRequest, options).then(callback);
- *     }
- * }
- * client.listBooks({name: formattedName}, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.listBooks = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._listBooks(request, options, callback);
-};
-
-/**
- * Equivalent to {@link listBooks}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link listBooks} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf whose books we'd like to list.
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {string=} request.filter
- *   To test python built-in wrapping.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits an object representing [Book]{@link google.example.library.v1.Book} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.shelfPath("[SHELF_ID]");
- * client.listBooksStream({name: formattedName})
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.listBooksStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return PAGE_DESCRIPTORS.listBooks.createStream(this._listBooks, request, options);
-};
-
-/**
- * Deletes a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to delete.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * client.deleteBook({name: formattedName}).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.deleteBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._deleteBook(request, options, callback);
-};
-
-/**
- * Updates a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to update.
- * @param {Object} request.book
- *   The book to update with.
- *
- *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
- * @param {Object=} request.updateMask
- *   A field mask to apply, rendered as an HTTP parameter.
- *
- *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
- * @param {Object=} request.physicalMask
- *   To test Python import clash resolution.
- *
- *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var book = {};
- * var request = {
- *     name: formattedName,
- *     book: book
- * };
- * client.updateBook(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.updateBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._updateBook(request, options, callback);
-};
-
-/**
- * Moves a book to another shelf, and returns the new book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to move.
- * @param {string} request.otherShelfName
- *   The name of the destination shelf.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
- * var request = {
- *     name: formattedName,
- *     otherShelfName: formattedOtherShelfName
- * };
- * client.moveBook(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.moveBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._moveBook(request, options, callback);
-};
-
-/**
- * Lists a primitive resource. To test go page streaming.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string=} request.name
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of string.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of string.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of string in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * client.listStrings({}).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.listStrings(nextRequest, options).then(callback);
- *     }
- * }
- * client.listStrings({}, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.listStrings = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._listStrings(request, options, callback);
-};
-
-/**
- * Equivalent to {@link listStrings}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link listStrings} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string=} request.name
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits a string on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- *
- * client.listStringsStream({})
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.listStringsStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return PAGE_DESCRIPTORS.listStrings.createStream(this._listStrings, request, options);
-};
-
-/**
- * Adds comments to a book
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- * @param {Object[]} request.comments
- *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var comment = '';
- * var stage = library.v1.types.Comment.Stage.UNSET;
- * var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
- * var commentsElement = {
- *     comment : comment,
- *     stage : stage,
- *     alignment : alignment
- * };
- * var comments = [commentsElement];
- * var request = {
- *     name: formattedName,
- *     comments: comments
- * };
- * client.addComments(request).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.addComments = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._addComments(request, options, callback);
-};
-
-/**
- * Gets a book from an archive.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
- * client.getBookFromArchive({name: formattedName}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBookFromArchive = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBookFromArchive(request, options, callback);
-};
-
-/**
- * Gets a book from a shelf or archive.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {string} request.altBookName
- *   An alternate book name, used to test restricting flattened field to a
- *   single resource name type in a oneof.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var formattedAltBookName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var request = {
- *     name: formattedName,
- *     altBookName: formattedAltBookName
- * };
- * client.getBookFromAnywhere(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBookFromAnywhere = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBookFromAnywhere(request, options, callback);
-};
-
-/**
- * Test proper OneOf-Any resource name mapping
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * client.getBookFromAbsolutelyAnywhere({name: formattedName}).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBookFromAbsolutelyAnywhere = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBookFromAbsolutelyAnywhere(request, options, callback);
-};
-
-/**
- * Updates the index of a book.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to update.
- * @param {string} request.indexName
- *   The name of the index for the book
- * @param {Object.<string, string>} request.indexMap
- *   The index to update the book with
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var indexName = 'default index';
- * var indexMapItem = '';
- * var indexMap = {'default_key' : indexMapItem,};
- * var request = {
- *     name: formattedName,
- *     indexName: indexName,
- *     indexMap: indexMap
- * };
- * client.updateBookIndex(request).catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.updateBookIndex = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._updateBookIndex(request, options, callback);
-};
-
-/**
- * Test server streaming
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits [StreamShelvesResponse]{@link google.example.library.v1.StreamShelvesResponse} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- *
- * client.streamShelves({}).on('data', function(response) {
- *   // doThingsWith(response)
- * });
- */
-LibraryServiceClient.prototype.streamShelves = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._streamShelves(request, options);
-};
-
-/**
- * Test server streaming, non-paged responses.
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the shelf whose books we'd like to list.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits [Book]{@link google.example.library.v1.Book} on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var name = '';
- * client.streamBooks({name: name}).on('data', function(response) {
- *   // doThingsWith(response)
- * });
- */
-LibraryServiceClient.prototype.streamBooks = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._streamBooks(request, options);
-};
-
-/**
- * Test bidi-streaming.
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which is both readable and writable. It accepts objects
- *   representing [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method, and
- *   will emit objects representing [Comment]{@link google.example.library.v1.Comment} on 'data' event asynchronously.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var stream = client.discussBook().on('data', function(response) {
- *     // doThingsWith(response)
- * });
- * var name = '';
- * var request = {
- *     name : name
- * };
- * // Write request objects.
- * stream.write(request);
- */
-LibraryServiceClient.prototype.discussBook = function(options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._discussBook(options);
-};
-
-/**
- * Test client streaming.
- * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
- *
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [Comment]{@link google.example.library.v1.Comment}.
- * @returns {Stream} - A writable stream which accepts objects representing
- *   [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var stream = client.monologAboutBook(function(err, response) {
- *     if (err) {
- *         console.error(err);
- *         return;
- *     }
- *     // doThingsWith(response)
- * });
- * var name = '';
- * var request = {
- *     name : name
- * };
- * // Write request objects.
- * stream.write(request);
- */
-LibraryServiceClient.prototype.monologAboutBook = function(options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._monologAboutBook(options, callback);
-};
-
-/**
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string[]} request.names
- * @param {string[]} request.shelves
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is Array of string.
- *
- *   When autoPaginate: false is specified through options, it contains the result
- *   in a single response. If the response indicates the next page exists, the third
- *   parameter is set to be used for the next request object. The fourth parameter keeps
- *   the raw response object of an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is Array of string.
- *
- *   When autoPaginate: false is specified through options, the array has three elements.
- *   The first element is Array of string in a single response.
- *   The second element is the next request object if the response
- *   indicates the next page exists, or null. The third element is
- *   an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
- *
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * // Iterate over all elements.
- * var namesElement = '';
- * var names = [namesElement];
- * var shelves = [];
- * var request = {
- *     names: names,
- *     shelves: shelves
- * };
- *
- * client.findRelatedBooks(request).then(function(responses) {
- *     var resources = responses[0];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i])
- *     }
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * // Or obtain the paged response.
- * var namesElement = '';
- * var names = [namesElement];
- * var shelves = [];
- * var request = {
- *     names: names,
- *     shelves: shelves
- * };
- *
- *
- * var options = {autoPaginate: false};
- * function callback(responses) {
- *     // The actual resources in a response.
- *     var resources = responses[0];
- *     // The next request if the response shows there's more responses.
- *     var nextRequest = responses[1];
- *     // The actual response object, if necessary.
- *     // var rawResponse = responses[2];
- *     for (var i = 0; i < resources.length; ++i) {
- *         // doThingsWith(resources[i]);
- *     }
- *     if (nextRequest) {
- *         // Fetch the next page.
- *         return client.findRelatedBooks(nextRequest, options).then(callback);
- *     }
- * }
- * client.findRelatedBooks(request, options)
- *     .then(callback)
- *     .catch(function(err) {
- *         console.error(err);
- *     });
- */
-LibraryServiceClient.prototype.findRelatedBooks = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._findRelatedBooks(request, options, callback);
-};
-
-/**
- * Equivalent to {@link findRelatedBooks}, but returns a NodeJS Stream object.
- *
- * This fetches the paged responses for {@link findRelatedBooks} continuously
- * and invokes the callback registered for 'data' event for each element in the
- * responses.
- *
- * The returned object has 'end' method when no more elements are required.
- *
- * autoPaginate option will be ignored.
- *
- * @see {@link https://nodejs.org/api/stream.html}
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string[]} request.names
- * @param {string[]} request.shelves
- * @param {number=} request.pageSize
- *   The maximum number of resources contained in the underlying API
- *   response. If page streaming is performed per-resource, this
- *   parameter does not affect the return value. If page streaming is
- *   performed per-page, this determines the maximum number of
- *   resources in a page.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @returns {Stream}
- *   An object stream which emits a string on 'data' event.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var namesElement = '';
- * var names = [namesElement];
- * var shelves = [];
- * var request = {
- *     names: names,
- *     shelves: shelves
- * };
- * client.findRelatedBooksStream(request)
- * .on('data', function(element) {
- *     // doThingsWith(element)
- * }).on('error', function(err) {
- *     console.log(err);
- * });
- */
-LibraryServiceClient.prototype.findRelatedBooksStream = function(request, options) {
-  if (options === undefined) {
-    options = {};
-  }
-
-  return PAGE_DESCRIPTORS.findRelatedBooks.createStream(this._findRelatedBooks, request, options);
-};
-
-/**
- * Adds a tag to the book. This RPC is a mixin.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.resource
- *   REQUIRED: The resource which the tag is being added to.
- *   Resource is usually specified as a path, such as,
- *   projects/{project}/zones/{zone}/disks/{disk}.
- * @param {string} request.tag
- *   REQUIRED: The tag to add.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var tag = '';
- * var request = {
- *     resource: formattedResource,
- *     tag: tag
- * };
- * client.addTag(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.addTag = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._addTag(request, options, callback);
-};
-
-/**
- * Adds a label to the entity.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.resource
- *   REQUIRED: The resource which the label is being added to.
- *   Resource is usually specified as a path, such as,
- *   projects/{project}/zones/{zone}/disks/{disk}.
- * @param {string} request.label
- *   REQUIRED: The label to add.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- * var label = '';
- * var request = {
- *     resource: formattedResource,
- *     label: label
- * };
- * client.addLabel(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.addLabel = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._addLabel(request, options, callback);
-};
-
-/**
- * Test long-running operations
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the promise pattern.
- * client.getBigBook({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Operation#promise starts polling for the completion of the LRO.
- *     return operation.promise();
- * }).then(function(responses) {
- *     // The final result of the operation.
- *     var result = responses[0];
- *
- *     // The metadata value of the completed operation.
- *     var metadata = responses[1];
- *
- *     // The response of the api call returning the complete operation.
- *     var finalApiResponse = responses[2];
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the event emitter pattern.
- * client.getBigBook({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Adding a listener for the "complete" event starts polling for the
- *     // completion of the operation.
- *     operation.on('complete', function(result, metadata, finalApiResponse) {
- *       // doSomethingWith(result);
- *     });
- *
- *     // Adding a listener for the "progress" event causes the callback to be
- *     // called on any change in metadata when the operation is polled.
- *     operation.on('progress', function(metadata, apiResponse) {
- *       // doSomethingWith(metadata)
- *     })
- *
- *     // Adding a listener for the "error" event handles any errors found during polling.
- *     operation.on('error', function(err) {
- *       // throw(err);
- *     })
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBigBook = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBigBook(request, options, callback);
-};
-
-/**
- * Test long-running operations with empty return type.
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {string} request.name
- *   The name of the book to retrieve.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the promise pattern.
- * client.getBigNothing({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Operation#promise starts polling for the completion of the LRO.
- *     return operation.promise();
- * }).then(function(responses) {
- *     // The final result of the operation.
- *     var result = responses[0];
- *
- *     // The metadata value of the completed operation.
- *     var metadata = responses[1];
- *
- *     // The response of the api call returning the complete operation.
- *     var finalApiResponse = responses[2];
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- *
- * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
- *
- * // Handle the operation using the event emitter pattern.
- * client.getBigNothing({name: formattedName}).then(function(responses) {
- *     var operation = responses[0];
- *     var initialApiResponse = responses[1];
- *
- *     // Adding a listener for the "complete" event starts polling for the
- *     // completion of the operation.
- *     operation.on('complete', function(result, metadata, finalApiResponse) {
- *       // doSomethingWith(result);
- *     });
- *
- *     // Adding a listener for the "progress" event causes the callback to be
- *     // called on any change in metadata when the operation is polled.
- *     operation.on('progress', function(metadata, apiResponse) {
- *       // doSomethingWith(metadata)
- *     })
- *
- *     // Adding a listener for the "error" event handles any errors found during polling.
- *     operation.on('error', function(err) {
- *       // throw(err);
- *     })
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.getBigNothing = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._getBigNothing(request, options, callback);
-};
-
-/**
- * Test optional flattening parameters of all types
- *
- * @param {Object} request
- *   The request object that will be sent.
- * @param {number} request.requiredSingularInt32
- * @param {number} request.requiredSingularInt64
- * @param {number} request.requiredSingularFloat
- * @param {number} request.requiredSingularDouble
- * @param {boolean} request.requiredSingularBool
- * @param {number} request.requiredSingularEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string} request.requiredSingularString
- * @param {string} request.requiredSingularBytes
- * @param {Object} request.requiredSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string} request.requiredSingularResourceName
- * @param {string} request.requiredSingularResourceNameOneof
- * @param {number} request.requiredSingularFixed32
- * @param {number} request.requiredSingularFixed64
- * @param {number[]} request.requiredRepeatedInt32
- * @param {number[]} request.requiredRepeatedInt64
- * @param {number[]} request.requiredRepeatedFloat
- * @param {number[]} request.requiredRepeatedDouble
- * @param {boolean[]} request.requiredRepeatedBool
- * @param {number[]} request.requiredRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string[]} request.requiredRepeatedString
- * @param {string[]} request.requiredRepeatedBytes
- * @param {Object[]} request.requiredRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string[]} request.requiredRepeatedResourceName
- * @param {string[]} request.requiredRepeatedResourceNameOneof
- * @param {number[]} request.requiredRepeatedFixed32
- * @param {number[]} request.requiredRepeatedFixed64
- * @param {Object.<number, string>} request.requiredMap
- * @param {number=} request.optionalSingularInt32
- * @param {number=} request.optionalSingularInt64
- * @param {number=} request.optionalSingularFloat
- * @param {number=} request.optionalSingularDouble
- * @param {boolean=} request.optionalSingularBool
- * @param {number=} request.optionalSingularEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string=} request.optionalSingularString
- * @param {string=} request.optionalSingularBytes
- * @param {Object=} request.optionalSingularMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string=} request.optionalSingularResourceName
- * @param {string=} request.optionalSingularResourceNameOneof
- * @param {number=} request.optionalSingularFixed32
- * @param {number=} request.optionalSingularFixed64
- * @param {number[]=} request.optionalRepeatedInt32
- * @param {number[]=} request.optionalRepeatedInt64
- * @param {number[]=} request.optionalRepeatedFloat
- * @param {number[]=} request.optionalRepeatedDouble
- * @param {boolean[]=} request.optionalRepeatedBool
- * @param {number[]=} request.optionalRepeatedEnum
- *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
- * @param {string[]=} request.optionalRepeatedString
- * @param {string[]=} request.optionalRepeatedBytes
- * @param {Object[]=} request.optionalRepeatedMessage
- *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
- * @param {string[]=} request.optionalRepeatedResourceName
- * @param {string[]=} request.optionalRepeatedResourceNameOneof
- * @param {number[]=} request.optionalRepeatedFixed32
- * @param {number[]=} request.optionalRepeatedFixed64
- * @param {Object.<number, string>=} request.optionalMap
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error, ?Object)=} callback
- *   The function which will be called with the result of the API call.
- *
- *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
- * @returns {Promise} - The promise which resolves to an array.
- *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var library = require('@google-cloud/library');
- *
- * var client = library.v1({
- *   // optional auth parameters.
- * });
- *
- * var requiredSingularInt32 = 0;
- * var requiredSingularInt64 = 0;
- * var requiredSingularFloat = 0.0;
- * var requiredSingularDouble = 0.0;
- * var requiredSingularBool = false;
- * var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
- * var requiredSingularString = '';
- * var requiredSingularBytes = '';
- * var requiredSingularMessage = {};
- * var requiredSingularResourceName = '';
- * var requiredSingularResourceNameOneof = '';
- * var requiredSingularFixed32 = 0;
- * var requiredSingularFixed64 = 0;
- * var requiredRepeatedInt32 = [];
- * var requiredRepeatedInt64 = [];
- * var requiredRepeatedFloat = [];
- * var requiredRepeatedDouble = [];
- * var requiredRepeatedBool = [];
- * var requiredRepeatedEnum = [];
- * var requiredRepeatedString = [];
- * var requiredRepeatedBytes = [];
- * var requiredRepeatedMessage = [];
- * var formattedRequiredRepeatedResourceName = [];
- * var formattedRequiredRepeatedResourceNameOneof = [];
- * var requiredRepeatedFixed32 = [];
- * var requiredRepeatedFixed64 = [];
- * var requiredMap = {};
- * var request = {
- *     requiredSingularInt32: requiredSingularInt32,
- *     requiredSingularInt64: requiredSingularInt64,
- *     requiredSingularFloat: requiredSingularFloat,
- *     requiredSingularDouble: requiredSingularDouble,
- *     requiredSingularBool: requiredSingularBool,
- *     requiredSingularEnum: requiredSingularEnum,
- *     requiredSingularString: requiredSingularString,
- *     requiredSingularBytes: requiredSingularBytes,
- *     requiredSingularMessage: requiredSingularMessage,
- *     requiredSingularResourceName: requiredSingularResourceName,
- *     requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
- *     requiredSingularFixed32: requiredSingularFixed32,
- *     requiredSingularFixed64: requiredSingularFixed64,
- *     requiredRepeatedInt32: requiredRepeatedInt32,
- *     requiredRepeatedInt64: requiredRepeatedInt64,
- *     requiredRepeatedFloat: requiredRepeatedFloat,
- *     requiredRepeatedDouble: requiredRepeatedDouble,
- *     requiredRepeatedBool: requiredRepeatedBool,
- *     requiredRepeatedEnum: requiredRepeatedEnum,
- *     requiredRepeatedString: requiredRepeatedString,
- *     requiredRepeatedBytes: requiredRepeatedBytes,
- *     requiredRepeatedMessage: requiredRepeatedMessage,
- *     requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
- *     requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
- *     requiredRepeatedFixed32: requiredRepeatedFixed32,
- *     requiredRepeatedFixed64: requiredRepeatedFixed64,
- *     requiredMap: requiredMap
- * };
- * client.testOptionalRequiredFlatteningParams(request).then(function(responses) {
- *     var response = responses[0];
- *     // doThingsWith(response)
- * })
- * .catch(function(err) {
- *     console.error(err);
- * });
- */
-LibraryServiceClient.prototype.testOptionalRequiredFlatteningParams = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-
-  return this._testOptionalRequiredFlatteningParams(request, options, callback);
-};
-
-/**
- * @class
- * @param {*} gaxGrpc
- */
-function LibraryServiceClientBuilder(gaxGrpc) {
-  if (!(this instanceof LibraryServiceClientBuilder)) {
-    return new LibraryServiceClientBuilder(gaxGrpc);
-  }
-
-  var libraryServiceStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', '..', 'protos'), 'library.proto');
-  extend(this, libraryServiceStubProtos.google.example.library.v1);
-
-  var labelerStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', '..', 'protos'), 'tagger.proto');
-  extend(this, labelerStubProtos.google.tagger.v1);
-
-  var protos = merge(
-    {},
-    libraryServiceStubProtos,
-    labelerStubProtos
-  );
+  // Service calls
 
   /**
-   * Build a new instance of {@link LibraryServiceClient}.
+   * Creates a shelf, and returns the new Shelf.
+   * RPC method comment may include special characters: <>&"`'@.
    *
-   * @method LibraryServiceClientBuilder#libraryServiceClient
-   * @param {Object=} opts - The optional parameters.
-   * @param {String=} opts.servicePath
-   *   The domain name of the API remote host.
-   * @param {number=} opts.port
-   *   The port on which to connect to the remote host.
-   * @param {grpc.ClientCredentials=} opts.sslCreds
-   *   A ClientCredentials for use with an SSL-enabled channel.
-   * @param {Object=} opts.clientConfig
-   *   The customized config to build the call settings. See
-   *   {@link gax.constructSettings} for the format.
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object} request.shelf
+   *   The shelf to create.
+   *
+   *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var shelf = {};
+   * client.createShelf({shelf: shelf}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
    */
-  this.libraryServiceClient = function(opts) {
-    return new LibraryServiceClient(gaxGrpc, protos, opts);
+  createShelf(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.createShelf(request, options, callback);
   };
-  extend(this.libraryServiceClient, LibraryServiceClient);
+
+  /**
+   * Gets a shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf to retrieve.
+   * @param {string} request.options
+   *   To test 'options' parameter name conflict.
+   * @param {Object=} request.message
+   *   Field to verify that message-type query parameter gets flattened.
+   *
+   *   This object should have the same structure as [SomeMessage]{@link google.example.library.v1.SomeMessage}
+   * @param {Object=} request.stringBuilder
+   *   This object should have the same structure as [StringBuilder]{@link google.example.library.v1.StringBuilder}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * var options = '';
+   * var request = {
+   *     name: formattedName,
+   *     options: options
+   * };
+   * client.getShelf(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getShelf(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getShelf(request, options, callback);
+  };
+
+  /**
+   * Lists shelves.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of [Shelf]{@link google.example.library.v1.Shelf}.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of [Shelf]{@link google.example.library.v1.Shelf}.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [Shelf]{@link google.example.library.v1.Shelf} in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [ListShelvesResponse]{@link google.example.library.v1.ListShelvesResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * client.listShelves({}).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.listShelves(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.listShelves({}, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  listShelves(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.listShelves(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link listShelves}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link listShelves} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits an object representing [Shelf]{@link google.example.library.v1.Shelf} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.listShelvesStream({})
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  listShelvesStream(request, options) {
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._pageDescriptors.listShelves.createStream(
+      this._innerApiCalls.listShelves,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Deletes a shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf to delete.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * client.deleteShelf({name: formattedName}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  deleteShelf(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.deleteShelf(request, options, callback);
+  };
+
+  /**
+   * Merges two shelves by adding all books from the shelf named
+   * `other_shelf_name` to shelf `name`, and deletes
+   * `other_shelf_name`. Returns the updated shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf we're adding books to.
+   * @param {string} request.otherShelfName
+   *   The name of the shelf we're removing books from and deleting.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Shelf]{@link google.example.library.v1.Shelf}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
+   * var request = {
+   *     name: formattedName,
+   *     otherShelfName: formattedOtherShelfName
+   * };
+   * client.mergeShelves(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  mergeShelves(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.mergeShelves(request, options, callback);
+  };
+
+  /**
+   * Creates a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf in which the book is created.
+   * @param {Object} request.book
+   *   The book to create.
+   *
+   *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * var book = {};
+   * var request = {
+   *     name: formattedName,
+   *     book: book
+   * };
+   * client.createBook(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  createBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.createBook(request, options, callback);
+  };
+
+  /**
+   * Creates a series of books.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {Object} request.shelf
+   *   The shelf in which the series is created.
+   *
+   *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
+   * @param {Object[]} request.books
+   *   The books to publish in the series.
+   *
+   *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+   * @param {Object} request.seriesUuid
+   *   Uniquely identifies the series to the publishing house.
+   *
+   *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
+   * @param {number=} request.edition
+   *   The edition of the series
+   * @param {boolean=} request.reviewCopy
+   *   If the book is in a pre-publish state
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [PublishSeriesResponse]{@link google.example.library.v1.PublishSeriesResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var shelf = {};
+   * var books = [];
+   * var seriesString = 'foobar';
+   * var seriesUuid = {
+   *     seriesString : seriesString
+   * };
+   * var request = {
+   *     shelf: shelf,
+   *     books: books,
+   *     seriesUuid: seriesUuid
+   * };
+   * client.publishSeries(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  publishSeries(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.publishSeries(request, options, callback);
+  };
+
+  /**
+   * Gets a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * client.getBook({name: formattedName}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBook(request, options, callback);
+  };
+
+  /**
+   * Lists books in a shelf.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf whose books we'd like to list.
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {string=} request.filter
+   *   To test python built-in wrapping.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of [Book]{@link google.example.library.v1.Book}.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of [Book]{@link google.example.library.v1.Book}.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of [Book]{@link google.example.library.v1.Book} in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [ListBooksResponse]{@link google.example.library.v1.ListBooksResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   *
+   * client.listBooks({name: formattedName}).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   *
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.listBooks(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.listBooks({name: formattedName}, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  listBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.listBooks(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link listBooks}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link listBooks} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf whose books we'd like to list.
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {string=} request.filter
+   *   To test python built-in wrapping.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits an object representing [Book]{@link google.example.library.v1.Book} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.shelfPath("[SHELF_ID]");
+   * client.listBooksStream({name: formattedName})
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  listBooksStream(request, options) {
+    options = options || {};
+
+    return this._pageDescriptors.listBooks.createStream(
+      this._innerApiCalls.listBooks,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Deletes a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to delete.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * client.deleteBook({name: formattedName}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  deleteBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.deleteBook(request, options, callback);
+  };
+
+  /**
+   * Updates a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to update.
+   * @param {Object} request.book
+   *   The book to update with.
+   *
+   *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
+   * @param {Object=} request.updateMask
+   *   A field mask to apply, rendered as an HTTP parameter.
+   *
+   *   This object should have the same structure as [FieldMask]{@link google.protobuf.FieldMask}
+   * @param {Object=} request.physicalMask
+   *   To test Python import clash resolution.
+   *
+   *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var book = {};
+   * var request = {
+   *     name: formattedName,
+   *     book: book
+   * };
+   * client.updateBook(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  updateBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.updateBook(request, options, callback);
+  };
+
+  /**
+   * Moves a book to another shelf, and returns the new book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to move.
+   * @param {string} request.otherShelfName
+   *   The name of the destination shelf.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Book]{@link google.example.library.v1.Book}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [Book]{@link google.example.library.v1.Book}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
+   * var request = {
+   *     name: formattedName,
+   *     otherShelfName: formattedOtherShelfName
+   * };
+   * client.moveBook(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  moveBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.moveBook(request, options, callback);
+  };
+
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string=} request.name
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of string in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [ListStringsResponse]{@link google.example.library.v1.ListStringsResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * client.listStrings({}).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.listStrings(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.listStrings({}, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  listStrings(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.listStrings(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link listStrings}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link listStrings} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string=} request.name
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits a string on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.listStringsStream({})
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  listStringsStream(request, options) {
+    options = options || {};
+
+    return this._pageDescriptors.listStrings.createStream(
+      this._innerApiCalls.listStrings,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Adds comments to a book
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   * @param {Object[]} request.comments
+   *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var comment = '';
+   * var stage = library.v1.types.Comment.Stage.UNSET;
+   * var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+   * var commentsElement = {
+   *     comment : comment,
+   *     stage : stage,
+   *     alignment : alignment
+   * };
+   * var comments = [commentsElement];
+   * var request = {
+   *     name: formattedName,
+   *     comments: comments
+   * };
+   * client.addComments(request).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  addComments(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.addComments(request, options, callback);
+  };
+
+  /**
+   * Gets a book from an archive.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BookFromArchive]{@link google.example.library.v1.BookFromArchive}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
+   * client.getBookFromArchive({name: formattedName}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBookFromArchive(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBookFromArchive(request, options, callback);
+  };
+
+  /**
+   * Gets a book from a shelf or archive.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {string} request.altBookName
+   *   An alternate book name, used to test restricting flattened field to a
+   *   single resource name type in a oneof.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var formattedAltBookName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var request = {
+   *     name: formattedName,
+   *     altBookName: formattedAltBookName
+   * };
+   * client.getBookFromAnywhere(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBookFromAnywhere(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBookFromAnywhere(request, options, callback);
+  };
+
+  /**
+   * Test proper OneOf-Any resource name mapping
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [BookFromAnywhere]{@link google.example.library.v1.BookFromAnywhere}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * client.getBookFromAbsolutelyAnywhere({name: formattedName}).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBookFromAbsolutelyAnywhere(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBookFromAbsolutelyAnywhere(request, options, callback);
+  };
+
+  /**
+   * Updates the index of a book.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to update.
+   * @param {string} request.indexName
+   *   The name of the index for the book
+   * @param {Object.<string, string>} request.indexMap
+   *   The index to update the book with
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var indexName = 'default index';
+   * var indexMapItem = '';
+   * var indexMap = {'default_key' : indexMapItem,};
+   * var request = {
+   *     name: formattedName,
+   *     indexName: indexName,
+   *     indexMap: indexMap
+   * };
+   * client.updateBookIndex(request).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  updateBookIndex(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.updateBookIndex(request, options, callback);
+  };
+
+  /**
+   * Test server streaming
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [StreamShelvesResponse]{@link google.example.library.v1.StreamShelvesResponse} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.streamShelves({}).on('data', function(response) {
+   *   // doThingsWith(response)
+   * });
+   */
+  streamShelves(request, options) {
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.streamShelves(request, options);
+  };
+
+  /**
+   * Test server streaming, non-paged responses.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the shelf whose books we'd like to list.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits [Book]{@link google.example.library.v1.Book} on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var name = '';
+   * client.streamBooks({name: name}).on('data', function(response) {
+   *   // doThingsWith(response)
+   * });
+   */
+  streamBooks(request, options) {
+    options = options || {};
+
+    return this._innerApiCalls.streamBooks(request, options);
+  };
+
+  /**
+   * Test bidi-streaming.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which is both readable and writable. It accepts objects
+   *   representing [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method, and
+   *   will emit objects representing [Comment]{@link google.example.library.v1.Comment} on 'data' event asynchronously.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var stream = client.discussBook().on('data', function(response) {
+   *     // doThingsWith(response)
+   * });
+   * var name = '';
+   * var request = {
+   *     name : name
+   * };
+   * // Write request objects.
+   * stream.write(request);
+   */
+  discussBook(options) {
+    options = options || {};
+
+    return this._innerApiCalls.discussBook(options);
+  };
+
+  /**
+   * Test client streaming.
+   * gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
+   *
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [Comment]{@link google.example.library.v1.Comment}.
+   * @returns {Stream} - A writable stream which accepts objects representing
+   *   [DiscussBookRequest]{@link google.example.library.v1.DiscussBookRequest} for write() method.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var stream = client.monologAboutBook(function(err, response) {
+   *     if (err) {
+   *         console.error(err);
+   *         return;
+   *     }
+   *     // doThingsWith(response)
+   * });
+   * var name = '';
+   * var request = {
+   *     name : name
+   * };
+   * // Write request objects.
+   * stream.write(request);
+   */
+  monologAboutBook(options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.monologAboutBook(options, callback);
+  };
+
+  /**
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string[]} request.names
+   * @param {string[]} request.shelves
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Array, ?Object, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, it contains the result
+   *   in a single response. If the response indicates the next page exists, the third
+   *   parameter is set to be used for the next request object. The fourth parameter keeps
+   *   the raw response object of an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is Array of string.
+   *
+   *   When autoPaginate: false is specified through options, the array has three elements.
+   *   The first element is Array of string in a single response.
+   *   The second element is the next request object if the response
+   *   indicates the next page exists, or null. The third element is
+   *   an object representing [FindRelatedBooksResponse]{@link google.example.library.v1.FindRelatedBooksResponse}.
+   *
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * // Iterate over all elements.
+   * var namesElement = '';
+   * var names = [namesElement];
+   * var shelves = [];
+   * var request = {
+   *     names: names,
+   *     shelves: shelves
+   * };
+   *
+   * client.findRelatedBooks(request).then(function(responses) {
+   *     var resources = responses[0];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i])
+   *     }
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * // Or obtain the paged response.
+   * var namesElement = '';
+   * var names = [namesElement];
+   * var shelves = [];
+   * var request = {
+   *     names: names,
+   *     shelves: shelves
+   * };
+   *
+   *
+   * var options = {autoPaginate: false};
+   * function callback(responses) {
+   *     // The actual resources in a response.
+   *     var resources = responses[0];
+   *     // The next request if the response shows there's more responses.
+   *     var nextRequest = responses[1];
+   *     // The actual response object, if necessary.
+   *     // var rawResponse = responses[2];
+   *     for (var i = 0; i < resources.length; ++i) {
+   *         // doThingsWith(resources[i]);
+   *     }
+   *     if (nextRequest) {
+   *         // Fetch the next page.
+   *         return client.findRelatedBooks(nextRequest, options).then(callback);
+   *     }
+   * }
+   * client.findRelatedBooks(request, options)
+   *     .then(callback)
+   *     .catch(function(err) {
+   *         console.error(err);
+   *     });
+   */
+  findRelatedBooks(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.findRelatedBooks(request, options, callback);
+  };
+
+  /**
+   * Equivalent to {@link findRelatedBooks}, but returns a NodeJS Stream object.
+   *
+   * This fetches the paged responses for {@link findRelatedBooks} continuously
+   * and invokes the callback registered for 'data' event for each element in the
+   * responses.
+   *
+   * The returned object has 'end' method when no more elements are required.
+   *
+   * autoPaginate option will be ignored.
+   *
+   * @see {@link https://nodejs.org/api/stream.html}
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string[]} request.names
+   * @param {string[]} request.shelves
+   * @param {number=} request.pageSize
+   *   The maximum number of resources contained in the underlying API
+   *   response. If page streaming is performed per-resource, this
+   *   parameter does not affect the return value. If page streaming is
+   *   performed per-page, this determines the maximum number of
+   *   resources in a page.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @returns {Stream}
+   *   An object stream which emits a string on 'data' event.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var namesElement = '';
+   * var names = [namesElement];
+   * var shelves = [];
+   * var request = {
+   *     names: names,
+   *     shelves: shelves
+   * };
+   * client.findRelatedBooksStream(request)
+   * .on('data', function(element) {
+   *     // doThingsWith(element)
+   * }).on('error', function(err) {
+   *     console.log(err);
+   * });
+   */
+  findRelatedBooksStream(request, options) {
+    options = options || {};
+
+    return this._pageDescriptors.findRelatedBooks.createStream(
+      this._innerApiCalls.findRelatedBooks,
+      request,
+      options
+    );
+  };
+
+  /**
+   * Adds a tag to the book. This RPC is a mixin.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.resource
+   *   REQUIRED: The resource which the tag is being added to.
+   *   Resource is usually specified as a path, such as,
+   *   projects/{project}/zones/{zone}/disks/{disk}.
+   * @param {string} request.tag
+   *   REQUIRED: The tag to add.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [AddTagResponse]{@link google.tagger.v1.AddTagResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var tag = '';
+   * var request = {
+   *     resource: formattedResource,
+   *     tag: tag
+   * };
+   * client.addTag(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  addTag(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.addTag(request, options, callback);
+  };
+
+  /**
+   * Adds a label to the entity.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.resource
+   *   REQUIRED: The resource which the label is being added to.
+   *   Resource is usually specified as a path, such as,
+   *   projects/{project}/zones/{zone}/disks/{disk}.
+   * @param {string} request.label
+   *   REQUIRED: The label to add.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [AddLabelResponse]{@link google.tagger.v1.AddLabelResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   * var label = '';
+   * var request = {
+   *     resource: formattedResource,
+   *     label: label
+   * };
+   * client.addLabel(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  addLabel(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.addLabel(request, options, callback);
+  };
+
+  /**
+   * Test long-running operations
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the promise pattern.
+   * client.getBigBook({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Operation#promise starts polling for the completion of the LRO.
+   *     return operation.promise();
+   * }).then(function(responses) {
+   *     // The final result of the operation.
+   *     var result = responses[0];
+   *
+   *     // The metadata value of the completed operation.
+   *     var metadata = responses[1];
+   *
+   *     // The response of the api call returning the complete operation.
+   *     var finalApiResponse = responses[2];
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the event emitter pattern.
+   * client.getBigBook({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Adding a listener for the "complete" event starts polling for the
+   *     // completion of the operation.
+   *     operation.on('complete', function(result, metadata, finalApiResponse) {
+   *       // doSomethingWith(result);
+   *     });
+   *
+   *     // Adding a listener for the "progress" event causes the callback to be
+   *     // called on any change in metadata when the operation is polled.
+   *     operation.on('progress', function(metadata, apiResponse) {
+   *       // doSomethingWith(metadata)
+   *     })
+   *
+   *     // Adding a listener for the "error" event handles any errors found during polling.
+   *     operation.on('error', function(err) {
+   *       // throw(err);
+   *     })
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBigBook(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBigBook(request, options, callback);
+  };
+
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {string} request.name
+   *   The name of the book to retrieve.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the promise pattern.
+   * client.getBigNothing({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Operation#promise starts polling for the completion of the LRO.
+   *     return operation.promise();
+   * }).then(function(responses) {
+   *     // The final result of the operation.
+   *     var result = responses[0];
+   *
+   *     // The metadata value of the completed operation.
+   *     var metadata = responses[1];
+   *
+   *     // The response of the api call returning the complete operation.
+   *     var finalApiResponse = responses[2];
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   *
+   * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+   *
+   * // Handle the operation using the event emitter pattern.
+   * client.getBigNothing({name: formattedName}).then(function(responses) {
+   *     var operation = responses[0];
+   *     var initialApiResponse = responses[1];
+   *
+   *     // Adding a listener for the "complete" event starts polling for the
+   *     // completion of the operation.
+   *     operation.on('complete', function(result, metadata, finalApiResponse) {
+   *       // doSomethingWith(result);
+   *     });
+   *
+   *     // Adding a listener for the "progress" event causes the callback to be
+   *     // called on any change in metadata when the operation is polled.
+   *     operation.on('progress', function(metadata, apiResponse) {
+   *       // doSomethingWith(metadata)
+   *     })
+   *
+   *     // Adding a listener for the "error" event handles any errors found during polling.
+   *     operation.on('error', function(err) {
+   *       // throw(err);
+   *     })
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  getBigNothing(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.getBigNothing(request, options, callback);
+  };
+
+  /**
+   * Test optional flattening parameters of all types
+   *
+   * @param {Object} request
+   *   The request object that will be sent.
+   * @param {number} request.requiredSingularInt32
+   * @param {number} request.requiredSingularInt64
+   * @param {number} request.requiredSingularFloat
+   * @param {number} request.requiredSingularDouble
+   * @param {boolean} request.requiredSingularBool
+   * @param {number} request.requiredSingularEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string} request.requiredSingularString
+   * @param {string} request.requiredSingularBytes
+   * @param {Object} request.requiredSingularMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string} request.requiredSingularResourceName
+   * @param {string} request.requiredSingularResourceNameOneof
+   * @param {number} request.requiredSingularFixed32
+   * @param {number} request.requiredSingularFixed64
+   * @param {number[]} request.requiredRepeatedInt32
+   * @param {number[]} request.requiredRepeatedInt64
+   * @param {number[]} request.requiredRepeatedFloat
+   * @param {number[]} request.requiredRepeatedDouble
+   * @param {boolean[]} request.requiredRepeatedBool
+   * @param {number[]} request.requiredRepeatedEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string[]} request.requiredRepeatedString
+   * @param {string[]} request.requiredRepeatedBytes
+   * @param {Object[]} request.requiredRepeatedMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string[]} request.requiredRepeatedResourceName
+   * @param {string[]} request.requiredRepeatedResourceNameOneof
+   * @param {number[]} request.requiredRepeatedFixed32
+   * @param {number[]} request.requiredRepeatedFixed64
+   * @param {Object.<number, string>} request.requiredMap
+   * @param {number=} request.optionalSingularInt32
+   * @param {number=} request.optionalSingularInt64
+   * @param {number=} request.optionalSingularFloat
+   * @param {number=} request.optionalSingularDouble
+   * @param {boolean=} request.optionalSingularBool
+   * @param {number=} request.optionalSingularEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string=} request.optionalSingularString
+   * @param {string=} request.optionalSingularBytes
+   * @param {Object=} request.optionalSingularMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string=} request.optionalSingularResourceName
+   * @param {string=} request.optionalSingularResourceNameOneof
+   * @param {number=} request.optionalSingularFixed32
+   * @param {number=} request.optionalSingularFixed64
+   * @param {number[]=} request.optionalRepeatedInt32
+   * @param {number[]=} request.optionalRepeatedInt64
+   * @param {number[]=} request.optionalRepeatedFloat
+   * @param {number[]=} request.optionalRepeatedDouble
+   * @param {boolean[]=} request.optionalRepeatedBool
+   * @param {number[]=} request.optionalRepeatedEnum
+   *   The number should be among the values of [InnerEnum]{@link google.example.library.v1.InnerEnum}
+   * @param {string[]=} request.optionalRepeatedString
+   * @param {string[]=} request.optionalRepeatedBytes
+   * @param {Object[]=} request.optionalRepeatedMessage
+   *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
+   * @param {string[]=} request.optionalRepeatedResourceName
+   * @param {string[]=} request.optionalRepeatedResourceNameOneof
+   * @param {number[]=} request.optionalRepeatedFixed32
+   * @param {number[]=} request.optionalRepeatedFixed64
+   * @param {Object.<number, string>=} request.optionalMap
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error, ?Object)=} callback
+   *   The function which will be called with the result of the API call.
+   *
+   *   The second parameter to the callback is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
+   * @returns {Promise} - The promise which resolves to an array.
+   *   The first element of the array is an object representing [TestOptionalRequiredFlatteningParamsResponse]{@link google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse}.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var library = require('@google-cloud/library');
+   *
+   * var client = library.v1({
+   *   // optional auth parameters.
+   * });
+   *
+   * var requiredSingularInt32 = 0;
+   * var requiredSingularInt64 = 0;
+   * var requiredSingularFloat = 0.0;
+   * var requiredSingularDouble = 0.0;
+   * var requiredSingularBool = false;
+   * var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   * var requiredSingularString = '';
+   * var requiredSingularBytes = '';
+   * var requiredSingularMessage = {};
+   * var requiredSingularResourceName = '';
+   * var requiredSingularResourceNameOneof = '';
+   * var requiredSingularFixed32 = 0;
+   * var requiredSingularFixed64 = 0;
+   * var requiredRepeatedInt32 = [];
+   * var requiredRepeatedInt64 = [];
+   * var requiredRepeatedFloat = [];
+   * var requiredRepeatedDouble = [];
+   * var requiredRepeatedBool = [];
+   * var requiredRepeatedEnum = [];
+   * var requiredRepeatedString = [];
+   * var requiredRepeatedBytes = [];
+   * var requiredRepeatedMessage = [];
+   * var formattedRequiredRepeatedResourceName = [];
+   * var formattedRequiredRepeatedResourceNameOneof = [];
+   * var requiredRepeatedFixed32 = [];
+   * var requiredRepeatedFixed64 = [];
+   * var requiredMap = {};
+   * var request = {
+   *     requiredSingularInt32: requiredSingularInt32,
+   *     requiredSingularInt64: requiredSingularInt64,
+   *     requiredSingularFloat: requiredSingularFloat,
+   *     requiredSingularDouble: requiredSingularDouble,
+   *     requiredSingularBool: requiredSingularBool,
+   *     requiredSingularEnum: requiredSingularEnum,
+   *     requiredSingularString: requiredSingularString,
+   *     requiredSingularBytes: requiredSingularBytes,
+   *     requiredSingularMessage: requiredSingularMessage,
+   *     requiredSingularResourceName: requiredSingularResourceName,
+   *     requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+   *     requiredSingularFixed32: requiredSingularFixed32,
+   *     requiredSingularFixed64: requiredSingularFixed64,
+   *     requiredRepeatedInt32: requiredRepeatedInt32,
+   *     requiredRepeatedInt64: requiredRepeatedInt64,
+   *     requiredRepeatedFloat: requiredRepeatedFloat,
+   *     requiredRepeatedDouble: requiredRepeatedDouble,
+   *     requiredRepeatedBool: requiredRepeatedBool,
+   *     requiredRepeatedEnum: requiredRepeatedEnum,
+   *     requiredRepeatedString: requiredRepeatedString,
+   *     requiredRepeatedBytes: requiredRepeatedBytes,
+   *     requiredRepeatedMessage: requiredRepeatedMessage,
+   *     requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
+   *     requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+   *     requiredRepeatedFixed32: requiredRepeatedFixed32,
+   *     requiredRepeatedFixed64: requiredRepeatedFixed64,
+   *     requiredMap: requiredMap
+   * };
+   * client.testOptionalRequiredFlatteningParams(request).then(function(responses) {
+   *     var response = responses[0];
+   *     // doThingsWith(response)
+   * })
+   * .catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  testOptionalRequiredFlatteningParams(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+
+    return this._innerApiCalls.testOptionalRequiredFlatteningParams(request, options, callback);
+  };
 }
-module.exports = LibraryServiceClientBuilder;
-module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
-module.exports.ALL_SCOPES = ALL_SCOPES;
+
+
+module.exports = LibraryServiceClient;
+
 ============== file: src/v1/library_service_client_config.json ==============
 {
   "interfaces": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -29,7 +29,7 @@ $ npm install --save @google-cloud/library
  });
 
  var formattedName = client.bookPath("testShelf-" + Date.now().toString(), projectId);
- var rating = library.v1.types.Book.Rating.GOOD;
+ var rating = 'GOOD';
  var book = {
    rating: rating,
  };
@@ -137,7 +137,7 @@ describe('LibraryServiceSmokeTest', () => {
     });
 
     var formattedName = client.bookPath("testShelf-" + Date.now().toString(), projectId);
-    var rating = library.v1.types.Book.Rating.GOOD;
+    var rating = 'GOOD';
     var book = {
       rating: rating,
     };
@@ -1512,8 +1512,8 @@ class LibraryServiceClient {
    *
    * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
    * var comment = '';
-   * var stage = library.v1.types.Comment.Stage.UNSET;
-   * var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+   * var stage = 'UNSET';
+   * var alignment = 'CHAR';
    * var commentsElement = {
    *   comment: comment,
    *   stage: stage,
@@ -2428,7 +2428,7 @@ class LibraryServiceClient {
    * var requiredSingularFloat = 0.0;
    * var requiredSingularDouble = 0.0;
    * var requiredSingularBool = false;
-   * var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+   * var requiredSingularEnum = 'ZERO';
    * var requiredSingularString = '';
    * var requiredSingularBytes = '';
    * var requiredSingularMessage = {};
@@ -3490,8 +3490,8 @@ describe('LibraryServiceClient', () => {
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var comment = '95';
-      var stage = library.v1.types.Comment.Stage.UNSET;
-      var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+      var stage = 'UNSET';
+      var alignment = 'CHAR';
       var commentsElement = {
         comment: comment,
         stage: stage,
@@ -3518,8 +3518,8 @@ describe('LibraryServiceClient', () => {
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var comment = '95';
-      var stage = library.v1.types.Comment.Stage.UNSET;
-      var alignment = library.v1.types.SomeMessage2.SomeMessage3.Alignment.CHAR;
+      var stage = 'UNSET';
+      var alignment = 'CHAR';
       var commentsElement = {
         comment: comment,
         stage: stage,
@@ -4208,7 +4208,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;
-      var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      var requiredSingularEnum = 'ZERO';
       var requiredSingularString = 'requiredSingularString-1949894503';
       var requiredSingularBytes = '-29';
       var requiredSingularMessage = {};
@@ -4282,7 +4282,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;
-      var requiredSingularEnum = library.v1.types.TestOptionalRequiredFlatteningParamsRequest.InnerEnum.ZERO;
+      var requiredSingularEnum = 'ZERO';
       var requiredSingularString = 'requiredSingularString-1949894503';
       var requiredSingularBytes = '-29';
       var requiredSingularMessage = {};

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -4136,8 +4136,8 @@ describe('LibraryServiceClient', () => {
 
     it('has longrunning decoder functions', () => {
       var client = new libraryModule.v1.LibraryServiceClient();
-      assert(client.longrunningDescriptors.getBigBook.responseDecoder instanceof Function);
-      assert(client.longrunningDescriptors.getBigBook.metadataDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigBook.responseDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigBook.metadataDecoder instanceof Function);
     });
   });
 
@@ -4194,8 +4194,8 @@ describe('LibraryServiceClient', () => {
 
     it('has longrunning decoder functions', () => {
       var client = new libraryModule.v1.LibraryServiceClient();
-      assert(client.longrunningDescriptors.getBigNothing.responseDecoder instanceof Function);
-      assert(client.longrunningDescriptors.getBigNothing.metadataDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigNothing.responseDecoder instanceof Function);
+      assert(client._descriptors.longrunning.getBigNothing.metadataDecoder instanceof Function);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -223,7 +223,7 @@ module.exports.LibraryServiceClient = LibraryServiceClient;
 
 'use strict';
 
-const configData = require('./library_service_client_config');
+const gapicConfig = require('./library_service_client_config');
 const gax = require('google-gax');
 const merge = require('lodash.merge');
 const path = require('path');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -690,7 +690,7 @@ class LibraryServiceClient {
    * // Or obtain the paged response.
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.
@@ -1101,7 +1101,7 @@ class LibraryServiceClient {
    *
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.
@@ -1401,7 +1401,7 @@ class LibraryServiceClient {
    * // Or obtain the paged response.
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.
@@ -1955,7 +1955,7 @@ class LibraryServiceClient {
    *
    *
    * var options = {autoPaginate: false};
-   * var callbacl = responses => {
+   * var callback = responses => {
    *   // The actual resources in a response.
    *   var resources = responses[0];
    *   // The next request if the response shows that there are more responses.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -22,9 +22,9 @@ $ npm install --save @google-cloud/library
 ### Preview
 #### LibraryServiceClient
 ```js
- var library = require('@google-cloud/library');
+ const library = require('@google-cloud/library');
 
- var client = library({
+ var client = library.LibraryServiceClient({
    // optional auth parameters.
  });
 
@@ -123,16 +123,16 @@ $ npm install --save @google-cloud/library
  */
 'use strict';
 
-describe('LibraryServiceSmokeTest', function() {
+describe('LibraryServiceSmokeTest', () => {
   if (!process.env.SMOKE_TEST_PROJECT) {
     throw new Error("Usage: SMOKE_TEST_PROJECT=<project_id> node #{$0}");
   }
   var projectId = process.env.SMOKE_TEST_PROJECT;
 
-  it('successfully makes a call to the service', function(done) {
-    var library = require('../src');
+  it('successfully makes a call to the service', done => {
+    const library = require('../src');
 
-    var client = library.v1({
+    var client = new library.v1.LibraryServiceClient({
       // optional auth parameters.
     });
 
@@ -554,9 +554,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -608,9 +608,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -669,9 +669,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -746,9 +746,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -789,9 +789,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -834,9 +834,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -889,9 +889,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -954,9 +954,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1010,9 +1010,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1076,9 +1076,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1165,9 +1165,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1206,9 +1206,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1259,9 +1259,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1312,9 +1312,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1380,9 +1380,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1462,9 +1462,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1504,9 +1504,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1558,9 +1558,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1607,9 +1607,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1658,9 +1658,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1705,9 +1705,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1748,9 +1748,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1783,9 +1783,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1814,9 +1814,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1852,9 +1852,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -1918,9 +1918,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2017,9 +2017,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2071,9 +2071,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2126,9 +2126,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2177,9 +2177,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2267,9 +2267,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -2417,9 +2417,9 @@ class LibraryServiceClient {
    *
    * @example
    *
-   * var library = require('@google-cloud/library');
+   * const library = require('@google-cloud/library');
    *
-   * var client = library.v1({
+   * var client = new library.v1.LibraryServiceClient({
    *   // optional auth parameters.
    * });
    *

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -408,7 +408,7 @@ class LibraryServiceClient {
       gaxGrpc.loadProto(
         path.join(__dirname, '..', '..', 'protos'),
         'library.proto'
-      ),,
+      ),
       gaxGrpc.loadProto(
         path.join(__dirname, '..', '..', 'protos'),
         'tagger.proto'

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -2812,18 +2812,19 @@ module.exports = LibraryServiceClient;
  */
 'use strict';
 
-var assert = require('assert');
-var library = require('../src');
-var through2 = require('through2');
+const assert = require('assert');
+const through2 = require('through2');
+
+const libraryModule = require('../src');
 
 var FAKE_STATUS_CODE = 1;
 var error = new Error();
 error.code = FAKE_STATUS_CODE;
 
-describe('LibraryServiceClient', function() {
-  describe('createShelf', function() {
-    it('invokes createShelf without error', function(done) {
-      var client = library.v1();
+describe('LibraryServiceClient', () => {
+  describe('createShelf', () => {
+    it('invokes createShelf without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -2842,17 +2843,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createShelf = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createShelf = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.createShelf(request, function(err, response) {
+      client.createShelf(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes createShelf with error', function(done) {
-      var client = library.v1();
+    it('invokes createShelf with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -2861,9 +2862,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createShelf = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createShelf = mockSimpleGrpcMethod(request, null, error);
 
-      client.createShelf(request, function(err, response) {
+      client.createShelf(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -2871,9 +2872,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getShelf', function() {
-    it('invokes getShelf without error', function(done) {
-      var client = library.v1();
+  describe('getShelf', () => {
+    it('invokes getShelf without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -2894,17 +2895,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getShelf = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getShelf = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getShelf(request, function(err, response) {
+      client.getShelf(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getShelf with error', function(done) {
-      var client = library.v1();
+    it('invokes getShelf with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -2915,9 +2916,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getShelf = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getShelf = mockSimpleGrpcMethod(request, null, error);
 
-      client.getShelf(request, function(err, response) {
+      client.getShelf(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -2925,9 +2926,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('listShelves', function() {
-    it('invokes listShelves without error', function(done) {
-      var client = library.v1();
+  describe('listShelves', () => {
+    it('invokes listShelves without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
@@ -2942,28 +2943,28 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listShelves = function(actualRequest, options, callback) {
+      client._innerApiCalls.listShelves = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.shelves);
       };
 
-      client.listShelves(request, function(err, response) {
+      client.listShelves(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.shelves);
         done();
       });
     });
 
-    it('invokes listShelves with error', function(done) {
-      var client = library.v1();
+    it('invokes listShelves with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._listShelves = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listShelves = mockSimpleGrpcMethod(request, null, error);
 
-      client.listShelves(request, function(err, response) {
+      client.listShelves(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -2971,9 +2972,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('deleteShelf', function() {
-    it('invokes deleteShelf without error', function(done) {
-      var client = library.v1();
+  describe('deleteShelf', () => {
+    it('invokes deleteShelf without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -2982,16 +2983,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteShelf = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.deleteShelf = mockSimpleGrpcMethod(request);
 
-      client.deleteShelf(request, function(err) {
+      client.deleteShelf(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes deleteShelf with error', function(done) {
-      var client = library.v1();
+    it('invokes deleteShelf with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3000,9 +3001,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteShelf = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteShelf = mockSimpleGrpcMethod(request, null, error);
 
-      client.deleteShelf(request, function(err) {
+      client.deleteShelf(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3010,9 +3011,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('mergeShelves', function() {
-    it('invokes mergeShelves without error', function(done) {
-      var client = library.v1();
+  describe('mergeShelves', () => {
+    it('invokes mergeShelves without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3033,17 +3034,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._mergeShelves = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.mergeShelves = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.mergeShelves(request, function(err, response) {
+      client.mergeShelves(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes mergeShelves with error', function(done) {
-      var client = library.v1();
+    it('invokes mergeShelves with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3054,9 +3055,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._mergeShelves = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.mergeShelves = mockSimpleGrpcMethod(request, null, error);
 
-      client.mergeShelves(request, function(err, response) {
+      client.mergeShelves(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3064,9 +3065,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('createBook', function() {
-    it('invokes createBook without error', function(done) {
-      var client = library.v1();
+  describe('createBook', () => {
+    it('invokes createBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3089,17 +3090,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.createBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.createBook(request, function(err, response) {
+      client.createBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes createBook with error', function(done) {
-      var client = library.v1();
+    it('invokes createBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3110,9 +3111,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._createBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.createBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.createBook(request, function(err, response) {
+      client.createBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3120,9 +3121,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('publishSeries', function() {
-    it('invokes publishSeries without error', function(done) {
-      var client = library.v1();
+  describe('publishSeries', () => {
+    it('invokes publishSeries without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -3145,17 +3146,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._publishSeries = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.publishSeries = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.publishSeries(request, function(err, response) {
+      client.publishSeries(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes publishSeries with error', function(done) {
-      var client = library.v1();
+    it('invokes publishSeries with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var shelf = {};
@@ -3171,9 +3172,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._publishSeries = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.publishSeries = mockSimpleGrpcMethod(request, null, error);
 
-      client.publishSeries(request, function(err, response) {
+      client.publishSeries(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3181,9 +3182,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBook', function() {
-    it('invokes getBook without error', function(done) {
-      var client = library.v1();
+  describe('getBook', () => {
+    it('invokes getBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3204,17 +3205,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBook(request, function(err, response) {
+      client.getBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBook with error', function(done) {
-      var client = library.v1();
+    it('invokes getBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3223,9 +3224,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBook(request, function(err, response) {
+      client.getBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3233,9 +3234,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('listBooks', function() {
-    it('invokes listBooks without error', function(done) {
-      var client = library.v1();
+  describe('listBooks', () => {
+    it('invokes listBooks without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3253,20 +3254,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listBooks = function(actualRequest, options, callback) {
+      client._innerApiCalls.listBooks = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.books);
       };
 
-      client.listBooks(request, function(err, response) {
+      client.listBooks(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.books);
         done();
       });
     });
 
-    it('invokes listBooks with error', function(done) {
-      var client = library.v1();
+    it('invokes listBooks with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
@@ -3275,9 +3276,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listBooks = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listBooks = mockSimpleGrpcMethod(request, null, error);
 
-      client.listBooks(request, function(err, response) {
+      client.listBooks(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3285,9 +3286,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('deleteBook', function() {
-    it('invokes deleteBook without error', function(done) {
-      var client = library.v1();
+  describe('deleteBook', () => {
+    it('invokes deleteBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3296,16 +3297,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteBook = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.deleteBook = mockSimpleGrpcMethod(request);
 
-      client.deleteBook(request, function(err) {
+      client.deleteBook(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes deleteBook with error', function(done) {
-      var client = library.v1();
+    it('invokes deleteBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3314,9 +3315,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._deleteBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.deleteBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.deleteBook(request, function(err) {
+      client.deleteBook(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3324,9 +3325,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('updateBook', function() {
-    it('invokes updateBook without error', function(done) {
-      var client = library.v1();
+  describe('updateBook', () => {
+    it('invokes updateBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3349,17 +3350,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.updateBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.updateBook(request, function(err, response) {
+      client.updateBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes updateBook with error', function(done) {
-      var client = library.v1();
+    it('invokes updateBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3370,9 +3371,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.updateBook(request, function(err, response) {
+      client.updateBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3380,9 +3381,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('moveBook', function() {
-    it('invokes moveBook without error', function(done) {
-      var client = library.v1();
+  describe('moveBook', () => {
+    it('invokes moveBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3405,17 +3406,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._moveBook = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.moveBook = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.moveBook(request, function(err, response) {
+      client.moveBook(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes moveBook with error', function(done) {
-      var client = library.v1();
+    it('invokes moveBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3426,9 +3427,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._moveBook = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.moveBook = mockSimpleGrpcMethod(request, null, error);
 
-      client.moveBook(request, function(err, response) {
+      client.moveBook(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3436,9 +3437,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('listStrings', function() {
-    it('invokes listStrings without error', function(done) {
-      var client = library.v1();
+  describe('listStrings', () => {
+    it('invokes listStrings without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
@@ -3453,28 +3454,28 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._listStrings = function(actualRequest, options, callback) {
+      client._innerApiCalls.listStrings = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.strings);
       };
 
-      client.listStrings(request, function(err, response) {
+      client.listStrings(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.strings);
         done();
       });
     });
 
-    it('invokes listStrings with error', function(done) {
-      var client = library.v1();
+    it('invokes listStrings with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._listStrings = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.listStrings = mockSimpleGrpcMethod(request, null, error);
 
-      client.listStrings(request, function(err, response) {
+      client.listStrings(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3482,9 +3483,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('addComments', function() {
-    it('invokes addComments without error', function(done) {
-      var client = library.v1();
+  describe('addComments', () => {
+    it('invokes addComments without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3503,16 +3504,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addComments = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.addComments = mockSimpleGrpcMethod(request);
 
-      client.addComments(request, function(err) {
+      client.addComments(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes addComments with error', function(done) {
-      var client = library.v1();
+    it('invokes addComments with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3531,9 +3532,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addComments = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.addComments = mockSimpleGrpcMethod(request, null, error);
 
-      client.addComments(request, function(err) {
+      client.addComments(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3541,9 +3542,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBookFromArchive', function() {
-    it('invokes getBookFromArchive without error', function(done) {
-      var client = library.v1();
+  describe('getBookFromArchive', () => {
+    it('invokes getBookFromArchive without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
@@ -3564,17 +3565,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromArchive = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBookFromArchive = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBookFromArchive(request, function(err, response) {
+      client.getBookFromArchive(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBookFromArchive with error', function(done) {
-      var client = library.v1();
+    it('invokes getBookFromArchive with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
@@ -3583,9 +3584,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromArchive = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBookFromArchive = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBookFromArchive(request, function(err, response) {
+      client.getBookFromArchive(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3593,9 +3594,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBookFromAnywhere', function() {
-    it('invokes getBookFromAnywhere without error', function(done) {
-      var client = library.v1();
+  describe('getBookFromAnywhere', () => {
+    it('invokes getBookFromAnywhere without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3618,17 +3619,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBookFromAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBookFromAnywhere(request, function(err, response) {
+      client.getBookFromAnywhere(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBookFromAnywhere with error', function(done) {
-      var client = library.v1();
+    it('invokes getBookFromAnywhere with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3639,9 +3640,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAnywhere = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBookFromAnywhere = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBookFromAnywhere(request, function(err, response) {
+      client.getBookFromAnywhere(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3649,9 +3650,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('getBookFromAbsolutelyAnywhere', function() {
-    it('invokes getBookFromAbsolutelyAnywhere without error', function(done) {
-      var client = library.v1();
+  describe('getBookFromAbsolutelyAnywhere', () => {
+    it('invokes getBookFromAbsolutelyAnywhere without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3672,17 +3673,17 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.getBookFromAbsolutelyAnywhere(request, function(err, response) {
+      client.getBookFromAbsolutelyAnywhere(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes getBookFromAbsolutelyAnywhere with error', function(done) {
-      var client = library.v1();
+    it('invokes getBookFromAbsolutelyAnywhere with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3691,9 +3692,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.getBookFromAbsolutelyAnywhere = mockSimpleGrpcMethod(request, null, error);
 
-      client.getBookFromAbsolutelyAnywhere(request, function(err, response) {
+      client.getBookFromAbsolutelyAnywhere(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3701,9 +3702,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('updateBookIndex', function() {
-    it('invokes updateBookIndex without error', function(done) {
-      var client = library.v1();
+  describe('updateBookIndex', () => {
+    it('invokes updateBookIndex without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3717,16 +3718,16 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBookIndex = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.updateBookIndex = mockSimpleGrpcMethod(request);
 
-      client.updateBookIndex(request, function(err) {
+      client.updateBookIndex(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes updateBookIndex with error', function(done) {
-      var client = library.v1();
+    it('invokes updateBookIndex with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3740,9 +3741,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._updateBookIndex = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.updateBookIndex = mockSimpleGrpcMethod(request, null, error);
 
-      client.updateBookIndex(request, function(err) {
+      client.updateBookIndex(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3750,9 +3751,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('streamShelves', function() {
-    it('invokes streamShelves without error', function(done) {
-      var client = library.v1();
+  describe('streamShelves', () => {
+    it('invokes streamShelves without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
@@ -3765,34 +3766,34 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamShelves = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, expectedResponse);
 
       var stream = client.streamShelves(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.deepStrictEqual(response, expectedResponse);
-        done()
+        done();
       });
-      stream.on('error', function(err) {
+      stream.on('error', err => {
         done(err);
       });
 
       stream.write();
     });
 
-    it('invokes streamShelves with error', function(done) {
-      var client = library.v1();
+    it('invokes streamShelves with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._streamShelves = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamShelves(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.fail();
-      })
-      stream.on('error', function(err) {
+      });
+      stream.on('error', err =>){
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3802,9 +3803,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('streamBooks', function() {
-    it('invokes streamBooks without error', function(done) {
-      var client = library.v1();
+  describe('streamBooks', () => {
+    it('invokes streamBooks without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -3825,22 +3826,22 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamBooks = mockServerStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.streamBooks = mockServerStreamingGrpcMethod(request, expectedResponse);
 
       var stream = client.streamBooks(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.deepStrictEqual(response, expectedResponse);
-        done()
+        done();
       });
-      stream.on('error', function(err) {
+      stream.on('error', err => {
         done(err);
       });
 
       stream.write();
     });
 
-    it('invokes streamBooks with error', function(done) {
-      var client = library.v1();
+    it('invokes streamBooks with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -3849,13 +3850,13 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamBooks = mockServerStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.streamBooks = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamBooks(request);
-      stream.on('data', function(response) {
+      stream.on('data', response => {
         assert.fail();
-      })
-      stream.on('error', function(err) {
+      });
+      stream.on('error', err =>){
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3865,9 +3866,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('discussBook', function() {
-    it('invokes discussBook without error', function(done) {
-      var client = library.v1();
+  describe('discussBook', () => {
+    it('invokes discussBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -3884,20 +3885,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._discussBook = mockBidiStreamingGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.discussBook = mockBidiStreamingGrpcMethod(request, expectedResponse);
 
-      var stream = client.discussBook().on('data', function(response) {
+      var stream = client.discussBook().on('data', response => {
         assert.deepStrictEqual(response, expectedResponse);
-        done()
-      }).on('error', function(err) {
+        done();
+      }).on('error', err => {
         done(err);
       });
 
       stream.write(request);
     });
 
-    it('invokes discussBook with error', function(done) {
-      var client = library.v1();
+    it('invokes discussBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var name = 'name3373707';
@@ -3906,11 +3907,11 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._discussBook = mockBidiStreamingGrpcMethod(request, null, error);
+      client._innerApiCalls.discussBook = mockBidiStreamingGrpcMethod(request, null, error);
 
-      var stream = client.discussBook().on('data', function(response) {
+      var stream = client.discussBook().on('data', response => {
         assert.fail();
-      }).on('error', function(err) {
+      }).on('error', err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3920,9 +3921,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('findRelatedBooks', function() {
-    it('invokes findRelatedBooks without error', function(done) {
-      var client = library.v1();
+  describe('findRelatedBooks', () => {
+    it('invokes findRelatedBooks without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -3943,20 +3944,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._findRelatedBooks = function(actualRequest, options, callback) {
+      client._innerApiCalls.findRelatedBooks = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         callback(null, expectedResponse.names);
       };
 
-      client.findRelatedBooks(request, function(err, response) {
+      client.findRelatedBooks(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse.names);
         done();
       });
     });
 
-    it('invokes findRelatedBooks with error', function(done) {
-      var client = library.v1();
+    it('invokes findRelatedBooks with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -3968,9 +3969,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._findRelatedBooks = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.findRelatedBooks = mockSimpleGrpcMethod(request, null, error);
 
-      client.findRelatedBooks(request, function(err, response) {
+      client.findRelatedBooks(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -3978,9 +3979,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('addTag', function() {
-    it('invokes addTag without error', function(done) {
-      var client = library.v1();
+  describe('addTag', () => {
+    it('invokes addTag without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -3994,17 +3995,17 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._addTag = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.addTag = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.addTag(request, function(err, response) {
+      client.addTag(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes addTag with error', function(done) {
-      var client = library.v1();
+    it('invokes addTag with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4015,9 +4016,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addTag = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.addTag = mockSimpleGrpcMethod(request, null, error);
 
-      client.addTag(request, function(err, response) {
+      client.addTag(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -4025,9 +4026,9 @@ describe('LibraryServiceClient', function() {
     });
   });
 
-  describe('addLabel', function() {
-    it('invokes addLabel without error', function(done) {
-      var client = library.v1();
+  describe('addLabel', () => {
+    it('invokes addLabel without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4041,17 +4042,17 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._addLabel = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.addLabel = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.addLabel(request, function(err, response) {
+      client.addLabel(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes addLabel with error', function(done) {
-      var client = library.v1();
+    it('invokes addLabel with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4062,9 +4063,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._addLabel = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.addLabel = mockSimpleGrpcMethod(request, null, error);
 
-      client.addLabel(request, function(err, response) {
+      client.addLabel(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -4073,8 +4074,8 @@ describe('LibraryServiceClient', function() {
   });
 
   describe('getBigBook', function() {
-    it('invokes getBigBook without error', function(done) {
-      var client = library.v1();
+    it('invokes getBigBook without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4095,21 +4096,21 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBigBook = mockLongRunningGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBigBook = mockLongRunningGrpcMethod(request, expectedResponse);
 
-      client.getBigBook(request).then(function(responses) {
+      client.getBigBook(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.deepStrictEqual(responses[0], expectedResponse);
         done();
-      }).catch(function(err) {
+      }).catch(err => {
         done(err);
       });
     });
 
-    it('invokes getBigBook with error', function(done) {
-      var client = library.v1();
+    it('invokes getBigBook with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4118,30 +4119,30 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBigBook = mockLongRunningGrpcMethod(request, null, error);
+      client._innerApiCalls.getBigBook = mockLongRunningGrpcMethod(request, null, error);
 
-      client.getBigBook(request).then(function(responses) {
+      client.getBigBook(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.fail();
-      }).catch(function(err) {
+      }).catch(err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
       });
     });
 
-    it('has longrunning decoder functions', function() {
-      var client = library.v1();
+    it('has longrunning decoder functions', () => {
+      var client = new libraryModule.v1.LibraryServiceClient();
       assert(client.longrunningDescriptors.getBigBook.responseDecoder instanceof Function);
       assert(client.longrunningDescriptors.getBigBook.metadataDecoder instanceof Function);
     });
   });
 
   describe('getBigNothing', function() {
-    it('invokes getBigNothing without error', function(done) {
-      var client = library.v1();
+    it('invokes getBigNothing without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4153,21 +4154,21 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._getBigNothing = mockLongRunningGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.getBigNothing = mockLongRunningGrpcMethod(request, expectedResponse);
 
-      client.getBigNothing(request).then(function(responses) {
+      client.getBigNothing(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.deepStrictEqual(responses[0], expectedResponse);
         done();
-      }).catch(function(err) {
+      }).catch(err => {
         done(err);
       });
     });
 
-    it('invokes getBigNothing with error', function(done) {
-      var client = library.v1();
+    it('invokes getBigNothing with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -4176,30 +4177,30 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._getBigNothing = mockLongRunningGrpcMethod(request, null, error);
+      client._innerApiCalls.getBigNothing = mockLongRunningGrpcMethod(request, null, error);
 
-      client.getBigNothing(request).then(function(responses) {
+      client.getBigNothing(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(function(responses) {
+      }).then(responses => {
         assert.fail();
-      }).catch(function(err) {
+      }).catch(err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
       });
     });
 
-    it('has longrunning decoder functions', function() {
-      var client = library.v1();
+    it('has longrunning decoder functions', () => {
+      var client = new libraryModule.v1.LibraryServiceClient();
       assert(client.longrunningDescriptors.getBigNothing.responseDecoder instanceof Function);
       assert(client.longrunningDescriptors.getBigNothing.metadataDecoder instanceof Function);
     });
   });
 
-  describe('testOptionalRequiredFlatteningParams', function() {
-    it('invokes testOptionalRequiredFlatteningParams without error', function(done) {
-      var client = library.v1();
+  describe('testOptionalRequiredFlatteningParams', () => {
+    it('invokes testOptionalRequiredFlatteningParams without error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var requiredSingularInt32 = -72313594;
@@ -4263,17 +4264,17 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, expectedResponse);
+      client._innerApiCalls.testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, expectedResponse);
 
-      client.testOptionalRequiredFlatteningParams(request, function(err, response) {
+      client.testOptionalRequiredFlatteningParams(request, (err, response) => {
         assert.ifError(err);
         assert.deepStrictEqual(response, expectedResponse);
         done();
       });
     });
 
-    it('invokes testOptionalRequiredFlatteningParams with error', function(done) {
-      var client = library.v1();
+    it('invokes testOptionalRequiredFlatteningParams with error', done => {
+      var client = new libraryModule.v1.LibraryServiceClient();
 
       // Mock request
       var requiredSingularInt32 = -72313594;
@@ -4334,9 +4335,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.testOptionalRequiredFlatteningParams = mockSimpleGrpcMethod(request, null, error);
 
-      client.testOptionalRequiredFlatteningParams(request, function(err, response) {
+      client.testOptionalRequiredFlatteningParams(request, (err, response) => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -4351,21 +4352,24 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     assert.deepStrictEqual(actualRequest, expectedRequest);
     if (error) {
       callback(error);
-    } else if (response) {
+    }
+    else if (response) {
       callback(null, response);
-    } else {
+    }
+    else {
       callback(null);
     }
   };
 }
 
 function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
-  return function(actualRequest) {
+  return actualRequest => {
     assert.deepStrictEqual(actualRequest, expectedRequest);
-    var mockStream = through2.obj(function (chunk, enc, callback) {
+    var mockStream = through2.obj((chunk, enc, callback) => {
       if (error) {
         callback(error);
-      } else {
+      }
+      else {
         callback(null, response);
       }
     });
@@ -4374,12 +4378,13 @@ function mockServerStreamingGrpcMethod(expectedRequest, response, error) {
 }
 
 function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
-  return function() {
-    var mockStream = through2.obj(function (chunk, enc, callback) {
+  return () => {
+    var mockStream = through2.obj((chunk, enc, callback) => {
       assert.deepStrictEqual(chunk, expectedRequest);
       if (error) {
         callback(error);
-      } else {
+      }
+      else {
         callback(null, response);
       }
     });
@@ -4388,14 +4393,15 @@ function mockBidiStreamingGrpcMethod(expectedRequest, response, error) {
 }
 
 function mockLongRunningGrpcMethod(expectedRequest, response, error) {
-  return function(request) {
+  return request => {
     assert.deepStrictEqual(request, expectedRequest);
     var mockOperation = {
       promise: function() {
-        return new Promise(function(resolve, reject) {
+        return new Promise((resolve, reject) => {
           if (error) {
             reject(error);
-          } else {
+          }
+          else {
             resolve([response]);
           }
         });

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -60,6 +60,7 @@ $ npm install --save @google-cloud/multiple-services
   "dependencies": {
     "google-gax": "^0.14.0",
     "google-some-other-package-v1": "^0.2.1",
+    "lodash.merge": "^4.6.0",
     "lodash.union": "^4.6.0"
   },
   "devDependencies": {
@@ -128,6 +129,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 const gapicConfig = require('./decrementer_service_client_config');
 const gax = require('google-gax');
+const merge = require('lodash.merge');
 const path = require('path');
 
 /**
@@ -145,7 +147,7 @@ class DecrementerServiceClient {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    Object.assign(opts, {scopes: this.constructor.scopes});
+    opts.scopes = this.constructor.scopes;
     var gaxGrpc = gax.grpc(opts);
 
     // Save the auth object to the client, for use by other methods.
@@ -231,8 +233,6 @@ class DecrementerServiceClient {
     ];
   }
 
-
-
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
@@ -242,7 +242,9 @@ class DecrementerServiceClient {
     return this.auth.getProjectId(callback);
   }
 
-  // Service calls
+  // -------------------
+  // -- Service calls --
+  // -------------------
 
   /**
    * Decrement.
@@ -322,6 +324,7 @@ module.exports = DecrementerServiceClient;
 
 const gapicConfig = require('./incrementer_service_client_config');
 const gax = require('google-gax');
+const merge = require('lodash.merge');
 const path = require('path');
 
 /**
@@ -339,7 +342,7 @@ class IncrementerServiceClient {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    Object.assign(opts, {scopes: this.constructor.scopes});
+    opts.scopes = this.constructor.scopes;
     var gaxGrpc = gax.grpc(opts);
 
     // Save the auth object to the client, for use by other methods.
@@ -425,8 +428,6 @@ class IncrementerServiceClient {
     ];
   }
 
-
-
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
@@ -436,7 +437,9 @@ class IncrementerServiceClient {
     return this.auth.getProjectId(callback);
   }
 
-  // Service calls
+  // -------------------
+  // -- Service calls --
+  // -------------------
 
   /**
    * Increment.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -138,6 +138,8 @@ const path = require('path');
  */
 class DecrementerServiceClient {
   constructor(opts) {
+    this._descriptors = {};
+
     // Ensure that options include the service address and port.
     opts = Object.assign({
       clientConfig: {},
@@ -164,6 +166,13 @@ class DecrementerServiceClient {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
 
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'multiple_services.proto'
+      ),
+    );
 
     // Put together the default options sent with requests.
     var defaults = gaxGrpc.constructSettings(
@@ -171,14 +180,6 @@ class DecrementerServiceClient {
       gapicConfig,
       opts.clientConfig,
       {'x-goog-api-client': clientHeader.join(' ')},
-    );
-
-    // Load the applicable protos.
-    var protos = merge({},
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos'),
-        'multiple_services.proto'
-      ),
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation
@@ -333,6 +334,8 @@ const path = require('path');
  */
 class IncrementerServiceClient {
   constructor(opts) {
+    this._descriptors = {};
+
     // Ensure that options include the service address and port.
     opts = Object.assign({
       clientConfig: {},
@@ -359,6 +362,13 @@ class IncrementerServiceClient {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
 
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'multiple_services.proto'
+      ),
+    );
 
     // Put together the default options sent with requests.
     var defaults = gaxGrpc.constructSettings(
@@ -366,14 +376,6 @@ class IncrementerServiceClient {
       gapicConfig,
       opts.clientConfig,
       {'x-goog-api-client': clientHeader.join(' ')},
-    );
-
-    // Load the applicable protos.
-    var protos = merge({},
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', '..', 'protos'),
-        'multiple_services.proto'
-      ),
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -540,40 +540,41 @@ module.exports.DecrementerServiceClient = DecrementerServiceClient;
  */
 'use strict';
 
-var assert = require('assert');
-var multipleServices = require('../src');
+const assert = require('assert');
+
+const multipleServicesModule = require('../src');
 
 var FAKE_STATUS_CODE = 1;
 var error = new Error();
 error.code = FAKE_STATUS_CODE;
 
-describe('IncrementerServiceClient', function() {
-  describe('increment', function() {
-    it('invokes increment without error', function(done) {
-      var client = multipleServices.v1.incrementer();
+describe('IncrementerServiceClient', () => {
+  describe('increment', () => {
+    it('invokes increment without error', done => {
+      var client = new multipleServicesModule.v1.IncrementerServiceClient.incrementer();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._increment = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.increment = mockSimpleGrpcMethod(request);
 
-      client.increment(request, function(err) {
+      client.increment(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes increment with error', function(done) {
-      var client = multipleServices.v1.incrementer();
+    it('invokes increment with error', done => {
+      var client = new multipleServicesModule.v1.IncrementerServiceClient.incrementer();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._increment = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.increment = mockSimpleGrpcMethod(request, null, error);
 
-      client.increment(request, function(err) {
+      client.increment(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -582,33 +583,33 @@ describe('IncrementerServiceClient', function() {
   });
 
 });
-describe('DecrementerServiceClient', function() {
-  describe('decrement', function() {
-    it('invokes decrement without error', function(done) {
-      var client = multipleServices.v1.decrementer();
+describe('DecrementerServiceClient', () => {
+  describe('decrement', () => {
+    it('invokes decrement without error', done => {
+      var client = new multipleServicesModule.v1.DecrementerServiceClient.decrementer();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._decrement = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.decrement = mockSimpleGrpcMethod(request);
 
-      client.decrement(request, function(err) {
+      client.decrement(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes decrement with error', function(done) {
-      var client = multipleServices.v1.decrementer();
+    it('invokes decrement with error', done => {
+      var client = new multipleServicesModule.v1.DecrementerServiceClient.decrementer();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._decrement = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.decrement = mockSimpleGrpcMethod(request, null, error);
 
-      client.decrement(request, function(err) {
+      client.decrement(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -623,9 +624,11 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     assert.deepStrictEqual(actualRequest, expectedRequest);
     if (error) {
       callback(error);
-    } else if (response) {
+    }
+    else if (response) {
       callback(null, response);
-    } else {
+    }
+    else {
       callback(null);
     }
   };

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -268,8 +268,8 @@ class DecrementerServiceClient {
    * });
    *
    *
-   * client.decrement({}).catch(function(err) {
-   *     console.error(err);
+   * client.decrement({}).catch(err => {
+   *   console.error(err);
    * });
    */
   decrement(request, options, callback) {
@@ -463,8 +463,8 @@ class IncrementerServiceClient {
    * });
    *
    *
-   * client.increment({}).catch(function(err) {
-   *     console.error(err);
+   * client.increment({}).catch(err => {
+   *   console.error(err);
    * });
    */
   increment(request, options, callback) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -126,7 +126,7 @@ module.exports.default = Object.assign({}, module.exports);
 
 'use strict';
 
-const configData = require('./decrementer_service_client_config');
+const gapicConfig = require('./decrementer_service_client_config');
 const gax = require('google-gax');
 const path = require('path');
 
@@ -320,7 +320,7 @@ module.exports = DecrementerServiceClient;
 
 'use strict';
 
-const configData = require('./incrementer_service_client_config');
+const gapicConfig = require('./incrementer_service_client_config');
 const gax = require('google-gax');
 const path = require('path');
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -551,7 +551,7 @@ error.code = FAKE_STATUS_CODE;
 describe('IncrementerServiceClient', () => {
   describe('increment', () => {
     it('invokes increment without error', done => {
-      var client = new multipleServicesModule.v1.IncrementerServiceClient.incrementer();
+      var client = new multipleServicesModule.v1.IncrementerServiceClient();
 
       // Mock request
       var request = {};
@@ -566,7 +566,7 @@ describe('IncrementerServiceClient', () => {
     });
 
     it('invokes increment with error', done => {
-      var client = new multipleServicesModule.v1.IncrementerServiceClient.incrementer();
+      var client = new multipleServicesModule.v1.IncrementerServiceClient();
 
       // Mock request
       var request = {};
@@ -586,7 +586,7 @@ describe('IncrementerServiceClient', () => {
 describe('DecrementerServiceClient', () => {
   describe('decrement', () => {
     it('invokes decrement without error', done => {
-      var client = new multipleServicesModule.v1.DecrementerServiceClient.decrementer();
+      var client = new multipleServicesModule.v1.DecrementerServiceClient();
 
       // Mock request
       var request = {};
@@ -601,7 +601,7 @@ describe('DecrementerServiceClient', () => {
     });
 
     it('invokes decrement with error', done => {
-      var client = new multipleServicesModule.v1.DecrementerServiceClient.decrementer();
+      var client = new multipleServicesModule.v1.DecrementerServiceClient();
 
       // Mock request
       var request = {};

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -58,7 +58,6 @@ $ npm install --save @google-cloud/multiple-services
     "Google Example API"
   ],
   "dependencies": {
-    "extend": "^3.0",
     "google-gax": "^0.14.0",
     "google-some-other-package-v1": "^0.2.1",
     "lodash.union": "^4.6.0"
@@ -79,7 +78,7 @@ $ npm install --save @google-cloud/multiple-services
 }
 
 ============== file: src/index.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -94,113 +93,20 @@ $ npm install --save @google-cloud/multiple-services
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-'use strict';
 
-var extend = require('extend');
-var gapic = {
-  v1: require('./v1')
-};
-var gaxGrpc = require('google-gax').grpc();
-var path = require('path');
+'use strict';
 
 const VERSION = require('../package.json').version;
 
-/**
- * Create an incrementerServiceClient with additional helpers for common
- * tasks.
- *
+// Import the clients for each version supported by this package.
+var gapic = {
+  v1: require('./v1'),
+};
 
- *
- * @param {object=} options - [Configuration object](#/docs).
- * @param {object=} options.credentials - Credentials object.
- * @param {string=} options.credentials.client_email
- * @param {string=} options.credentials.private_key
- * @param {string=} options.email - Account email address. Required when using a
- *     .pem or .p12 keyFilename.
- * @param {string=} options.keyFilename - Full path to the a .json, .pem, or
- *     .p12 key downloaded from the Google Developers Console. If you provide
- *     a path to a JSON file, the projectId option above is not necessary.
- *     NOTE: .pem and .p12 require you to specify options.email as well.
- * @param {number=} options.port - The port on which to connect to
- *     the remote host.
- * @param {string=} options.projectId - The project ID from the Google
- *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
- *     the environment variable GCLOUD_PROJECT for your project ID. If your
- *     app is running in an environment which supports
- *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
- *     your project ID will be detected automatically.
- * @param {function=} options.promise - Custom promise module to use instead
- *     of native Promises.
- * @param {string=} options.servicePath - The domain name of the
- *     API remote host.
- */
-function incrementerV1(options) {
-  // Define the header options.
-  options = extend({}, options, {
-    libName: 'gccl',
-    libVersion: VERSION
-  });
+module.exports = gapic.v1;
+module.exports.v1 = gapic.v1;
+module.exports.default = Object.assign({}, module.exports);
 
-  // Create the client with the provided options.
-  var client = gapic.v1(options).incrementerServiceClient(options);
-  return client;
-}
-
-/**
- * Create an decrementerServiceClient with additional helpers for common
- * tasks.
- *
-
- *
- * @param {object=} options - [Configuration object](#/docs).
- * @param {object=} options.credentials - Credentials object.
- * @param {string=} options.credentials.client_email
- * @param {string=} options.credentials.private_key
- * @param {string=} options.email - Account email address. Required when using a
- *     .pem or .p12 keyFilename.
- * @param {string=} options.keyFilename - Full path to the a .json, .pem, or
- *     .p12 key downloaded from the Google Developers Console. If you provide
- *     a path to a JSON file, the projectId option above is not necessary.
- *     NOTE: .pem and .p12 require you to specify options.email as well.
- * @param {number=} options.port - The port on which to connect to
- *     the remote host.
- * @param {string=} options.projectId - The project ID from the Google
- *     Developer's Console, e.g. 'grape-spaceship-123'. We will also check
- *     the environment variable GCLOUD_PROJECT for your project ID. If your
- *     app is running in an environment which supports
- *     {@link https://developers.google.com/identity/protocols/application-default-credentials Application Default Credentials},
- *     your project ID will be detected automatically.
- * @param {function=} options.promise - Custom promise module to use instead
- *     of native Promises.
- * @param {string=} options.servicePath - The domain name of the
- *     API remote host.
- */
-function decrementerV1(options) {
-  // Define the header options.
-  options = extend({}, options, {
-    libName: 'gccl',
-    libVersion: VERSION
-  });
-
-  // Create the client with the provided options.
-  var client = gapic.v1(options).decrementerServiceClient(options);
-  return client;
-}
-
-var v1Protos = {};
-
-extend(v1Protos, gaxGrpc.loadProto(
-  path.join(__dirname, '..', 'protos'), 'multiple_services.proto')
-    .google.cloud.example.v1);
-
-module.exports.incrementer = incrementerV1;
-module.exports.decrementer = decrementerV1;
-module.exports.types = v1Protos;
-
-module.exports.v1 = {};
-module.exports.v1.incrementer = incrementerV1;
-module.exports.v1.decrementer = decrementerV1;
-module.exports.v1.types = v1Protos;
 ============== file: src/v1/decrementer_service_client.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -216,177 +122,170 @@ module.exports.v1.types = v1Protos;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * EDITING INSTRUCTIONS
- * This file was generated from the file
- * https://github.com/googleapis/googleapis/blob/master/multiple_services.proto,
- * and updates to that file get reflected here through a refresh process.
- * For the short term, the refresh process will only be runnable by Google
- * engineers.
- *
- * The only allowed edits are to method and file documentation. A 3-way
- * merge preserves those additions if the generated source changes.
  */
+
 'use strict';
 
-var configData = require('./decrementer_service_client_config');
-var extend = require('extend');
-var gax = require('google-gax');
-var path = require('path');
-
-var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
-
-var DEFAULT_SERVICE_PORT = 443;
-
-var CODE_GEN_NAME_VERSION = 'gapic/0.0.5';
-
-/*!
- * The scopes needed to make gRPC calls to all of the methods defined in
- * this service.
- */
-var ALL_SCOPES = [
-];
+const configData = require('./decrementer_service_client_config');
+const gax = require('google-gax');
+const path = require('path');
 
 /**
  *
  * @class
  */
-function DecrementerServiceClient(gaxGrpc, loadedProtos, opts) {
-  opts = extend({
-    servicePath: SERVICE_ADDRESS,
-    port: DEFAULT_SERVICE_PORT,
-    clientConfig: {}
-  }, opts);
+class DecrementerServiceClient {
+  constructor(opts) {
+    // Ensure that options include the service address and port.
+    opts = Object.assign({
+      clientConfig: {},
+      port: this.constructor.port,
+      servicePath: this.constructor.servicePath,
+    }, opts);
 
-  var googleApiClient = [
-    'gl-node/' + process.versions.node
-  ];
-  if (opts.libName && opts.libVersion) {
-    googleApiClient.push(opts.libName + '/' + opts.libVersion);
-  }
-  googleApiClient.push(
-    CODE_GEN_NAME_VERSION,
-    'gax/' + gax.version,
-    'grpc/' + gaxGrpc.grpcVersion
-  );
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    Object.assign(opts, {scopes: this.constructor.scopes});
+    var gaxGrpc = gax.grpc(opts);
 
-  var defaults = gaxGrpc.constructSettings(
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
+
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${this.version}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
+
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
       'google.cloud.example.v1.DecrementerService',
-      configData,
+      gapicConfig,
       opts.clientConfig,
-      {'x-goog-api-client': googleApiClient.join(' ')});
+      {'x-goog-api-client': clientHeader.join(' ')},
+    );
 
-  var self = this;
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'multiple_services.proto'
+      ),
+    );
 
-  this.auth = gaxGrpc.auth;
-  var decrementerServiceStub = gaxGrpc.createStub(
-      loadedProtos.google.cloud.example.v1.DecrementerService,
-      opts);
-  var decrementerServiceStubMethods = [
-    'decrement'
-  ];
-  decrementerServiceStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      decrementerServiceStub.then(function(decrementerServiceStub) {
-        return function() {
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.cloud.example.v1.DecrementerService.
+    var decrementerServiceStub = gaxGrpc.createStub(
+      protos.google.cloud.example.v1.DecrementerService,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var decrementerServiceStubMethods = [
+      'decrement',
+    ];
+    for (let methodName of decrementerServiceStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        decrementerServiceStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return decrementerServiceStub[methodName].apply(decrementerServiceStub, args);
-        };
-      }),
-      defaults[methodName],
-      null);
-  });
-}
-
-
-/**
- * Get the project ID used by this class.
- * @param {function(Error, string)} callback - the callback to be called with
- *   the current project Id.
- */
-DecrementerServiceClient.prototype.getProjectId = function(callback) {
-  return this.auth.getProjectId(callback);
-};
-
-// Service calls
-
-/**
- * Decrement.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var multipleServices = require('@google-cloud/multiple-services');
- *
- * var client = multipleServices.v1.decrementer({
- *   // optional auth parameters.
- * });
- *
- *
- * client.decrement({}).catch(function(err) {
- *     console.error(err);
- * });
- */
-DecrementerServiceClient.prototype.decrement = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._decrement(request, options, callback);
-};
-
-/**
- * @class
- * @param {*} gaxGrpc
- */
-function DecrementerServiceClientBuilder(gaxGrpc) {
-  if (!(this instanceof DecrementerServiceClientBuilder)) {
-    return new DecrementerServiceClientBuilder(gaxGrpc);
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        null
+      );
+    }
   }
 
-  var decrementerServiceStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', '..', 'protos'), 'multiple_services.proto');
-  extend(this, decrementerServiceStubProtos.google.cloud.example.v1);
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'no-path-templates.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+    ];
+  }
+
 
 
   /**
-   * Build a new instance of {@link DecrementerServiceClient}.
-   *
-   * @method DecrementerServiceClientBuilder#decrementerServiceClient
-   * @param {Object=} opts - The optional parameters.
-   * @param {String=} opts.servicePath
-   *   The domain name of the API remote host.
-   * @param {number=} opts.port
-   *   The port on which to connect to the remote host.
-   * @param {grpc.ClientCredentials=} opts.sslCreds
-   *   A ClientCredentials for use with an SSL-enabled channel.
-   * @param {Object=} opts.clientConfig
-   *   The customized config to build the call settings. See
-   *   {@link gax.constructSettings} for the format.
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
    */
-  this.decrementerServiceClient = function(opts) {
-    return new DecrementerServiceClient(gaxGrpc, decrementerServiceStubProtos, opts);
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
+  }
+
+  // Service calls
+
+  /**
+   * Decrement.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var multipleServices = require('@google-cloud/multiple-services');
+   *
+   * var client = multipleServices.v1.decrementer({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.decrement({}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  decrement(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.decrement(request, options, callback);
   };
-  extend(this.decrementerServiceClient, DecrementerServiceClient);
 }
-module.exports = DecrementerServiceClientBuilder;
-module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
-module.exports.ALL_SCOPES = ALL_SCOPES;
+
+
+module.exports = DecrementerServiceClient;
+
 ============== file: src/v1/decrementer_service_client_config.json ==============
 {
   "interfaces": {
@@ -417,177 +316,170 @@ module.exports.ALL_SCOPES = ALL_SCOPES;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * EDITING INSTRUCTIONS
- * This file was generated from the file
- * https://github.com/googleapis/googleapis/blob/master/multiple_services.proto,
- * and updates to that file get reflected here through a refresh process.
- * For the short term, the refresh process will only be runnable by Google
- * engineers.
- *
- * The only allowed edits are to method and file documentation. A 3-way
- * merge preserves those additions if the generated source changes.
  */
+
 'use strict';
 
-var configData = require('./incrementer_service_client_config');
-var extend = require('extend');
-var gax = require('google-gax');
-var path = require('path');
-
-var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
-
-var DEFAULT_SERVICE_PORT = 443;
-
-var CODE_GEN_NAME_VERSION = 'gapic/0.0.5';
-
-/*!
- * The scopes needed to make gRPC calls to all of the methods defined in
- * this service.
- */
-var ALL_SCOPES = [
-];
+const configData = require('./incrementer_service_client_config');
+const gax = require('google-gax');
+const path = require('path');
 
 /**
  *
  * @class
  */
-function IncrementerServiceClient(gaxGrpc, loadedProtos, opts) {
-  opts = extend({
-    servicePath: SERVICE_ADDRESS,
-    port: DEFAULT_SERVICE_PORT,
-    clientConfig: {}
-  }, opts);
+class IncrementerServiceClient {
+  constructor(opts) {
+    // Ensure that options include the service address and port.
+    opts = Object.assign({
+      clientConfig: {},
+      port: this.constructor.port,
+      servicePath: this.constructor.servicePath,
+    }, opts);
 
-  var googleApiClient = [
-    'gl-node/' + process.versions.node
-  ];
-  if (opts.libName && opts.libVersion) {
-    googleApiClient.push(opts.libName + '/' + opts.libVersion);
-  }
-  googleApiClient.push(
-    CODE_GEN_NAME_VERSION,
-    'gax/' + gax.version,
-    'grpc/' + gaxGrpc.grpcVersion
-  );
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    Object.assign(opts, {scopes: this.constructor.scopes});
+    var gaxGrpc = gax.grpc(opts);
 
-  var defaults = gaxGrpc.constructSettings(
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
+
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${this.version}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
+
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
       'google.cloud.example.v1.IncrementerService',
-      configData,
+      gapicConfig,
       opts.clientConfig,
-      {'x-goog-api-client': googleApiClient.join(' ')});
+      {'x-goog-api-client': clientHeader.join(' ')},
+    );
 
-  var self = this;
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', '..', 'protos'),
+        'multiple_services.proto'
+      ),
+    );
 
-  this.auth = gaxGrpc.auth;
-  var incrementerServiceStub = gaxGrpc.createStub(
-      loadedProtos.google.cloud.example.v1.IncrementerService,
-      opts);
-  var incrementerServiceStubMethods = [
-    'increment'
-  ];
-  incrementerServiceStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      incrementerServiceStub.then(function(incrementerServiceStub) {
-        return function() {
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.cloud.example.v1.IncrementerService.
+    var incrementerServiceStub = gaxGrpc.createStub(
+      protos.google.cloud.example.v1.IncrementerService,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var incrementerServiceStubMethods = [
+      'increment',
+    ];
+    for (let methodName of incrementerServiceStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        incrementerServiceStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return incrementerServiceStub[methodName].apply(incrementerServiceStub, args);
-        };
-      }),
-      defaults[methodName],
-      null);
-  });
-}
-
-
-/**
- * Get the project ID used by this class.
- * @param {function(Error, string)} callback - the callback to be called with
- *   the current project Id.
- */
-IncrementerServiceClient.prototype.getProjectId = function(callback) {
-  return this.auth.getProjectId(callback);
-};
-
-// Service calls
-
-/**
- * Increment.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var multipleServices = require('@google-cloud/multiple-services');
- *
- * var client = multipleServices.v1.incrementer({
- *   // optional auth parameters.
- * });
- *
- *
- * client.increment({}).catch(function(err) {
- *     console.error(err);
- * });
- */
-IncrementerServiceClient.prototype.increment = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._increment(request, options, callback);
-};
-
-/**
- * @class
- * @param {*} gaxGrpc
- */
-function IncrementerServiceClientBuilder(gaxGrpc) {
-  if (!(this instanceof IncrementerServiceClientBuilder)) {
-    return new IncrementerServiceClientBuilder(gaxGrpc);
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        null
+      );
+    }
   }
 
-  var incrementerServiceStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', '..', 'protos'), 'multiple_services.proto');
-  extend(this, incrementerServiceStubProtos.google.cloud.example.v1);
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'no-path-templates.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+    ];
+  }
+
 
 
   /**
-   * Build a new instance of {@link IncrementerServiceClient}.
-   *
-   * @method IncrementerServiceClientBuilder#incrementerServiceClient
-   * @param {Object=} opts - The optional parameters.
-   * @param {String=} opts.servicePath
-   *   The domain name of the API remote host.
-   * @param {number=} opts.port
-   *   The port on which to connect to the remote host.
-   * @param {grpc.ClientCredentials=} opts.sslCreds
-   *   A ClientCredentials for use with an SSL-enabled channel.
-   * @param {Object=} opts.clientConfig
-   *   The customized config to build the call settings. See
-   *   {@link gax.constructSettings} for the format.
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
    */
-  this.incrementerServiceClient = function(opts) {
-    return new IncrementerServiceClient(gaxGrpc, incrementerServiceStubProtos, opts);
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
+  }
+
+  // Service calls
+
+  /**
+   * Increment.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var multipleServices = require('@google-cloud/multiple-services');
+   *
+   * var client = multipleServices.v1.incrementer({
+   *   // optional auth parameters.
+   * });
+   *
+   *
+   * client.increment({}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  increment(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.increment(request, options, callback);
   };
-  extend(this.incrementerServiceClient, IncrementerServiceClient);
 }
-module.exports = IncrementerServiceClientBuilder;
-module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
-module.exports.ALL_SCOPES = ALL_SCOPES;
+
+
+module.exports = IncrementerServiceClient;
+
 ============== file: src/v1/incrementer_service_client_config.json ==============
 {
   "interfaces": {
@@ -621,30 +513,12 @@ module.exports.ALL_SCOPES = ALL_SCOPES;
  */
 'use strict';
 
-var incrementerServiceClient = require('./incrementer_service_client');
-var decrementerServiceClient = require('./decrementer_service_client');
-var gax = require('google-gax');
-var extend = require('extend');
-var union = require('lodash.union');
+const IncrementerServiceClient = require('./incrementer_service_client');
+const DecrementerServiceClient = require('./decrementer_service_client');
 
-function v1(options) {
-  options = extend({
-    scopes: v1.ALL_SCOPES
-  }, options);
-  var gaxGrpc = gax.grpc(options);
-  var result = {};
-  extend(result, incrementerServiceClient(gaxGrpc));
-  extend(result, decrementerServiceClient(gaxGrpc));
-  return result;
-}
+module.exports.IncrementerServiceClient = IncrementerServiceClient;
+module.exports.DecrementerServiceClient = DecrementerServiceClient;
 
-v1.SERVICE_ADDRESS = incrementerServiceClient.SERVICE_ADDRESS;
-v1.ALL_SCOPES = union(
-  incrementerServiceClient.ALL_SCOPES,
-  decrementerServiceClient.ALL_SCOPES
-);
-
-module.exports = v1;
 ============== file: test/gapic-v1.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -261,9 +261,9 @@ class DecrementerServiceClient {
    *
    * @example
    *
-   * var multipleServices = require('@google-cloud/multiple-services');
+   * const multipleServices = require('@google-cloud/multiple-services');
    *
-   * var client = multipleServices.v1.decrementer({
+   * var client = new multipleServices.v1.DecrementerServiceClient({
    *   // optional auth parameters.
    * });
    *
@@ -456,9 +456,9 @@ class IncrementerServiceClient {
    *
    * @example
    *
-   * var multipleServices = require('@google-cloud/multiple-services');
+   * const multipleServices = require('@google-cloud/multiple-services');
    *
-   * var client = multipleServices.v1.incrementer({
+   * var client = new multipleServices.v1.IncrementerServiceClient({
    *   // optional auth parameters.
    * });
    *

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -57,7 +57,6 @@ $ npm install --save example
     "Google Fake API"
   ],
   "dependencies": {
-    "extend": "^3.0",
     "google-gax": "^0.14.0",
     "google-some-other-package-v1": "^0.2.1"
   },
@@ -94,22 +93,10 @@ $ npm install --save example
  */
 'use strict';
 
-var noTemplatesApiServiceClient = require('./no_templates_api_service_client');
-var gax = require('google-gax');
-var extend = require('extend');
+const NoTemplatesApiServiceClient = require('./no_templates_api_service_client');
 
-function v1(options) {
-  options = extend({
-    scopes: v1.ALL_SCOPES
-  }, options);
-  var gaxGrpc = gax.grpc(options);
-  return noTemplatesApiServiceClient(gaxGrpc);
-}
+module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
 
-v1.SERVICE_ADDRESS = noTemplatesApiServiceClient.SERVICE_ADDRESS;
-v1.ALL_SCOPES = noTemplatesApiServiceClient.ALL_SCOPES;
-
-module.exports = v1;
 ============== file: src/v1/no_templates_api_service_client.js ==============
 /*
  * Copyright 2017, Google Inc. All rights reserved.
@@ -125,182 +112,175 @@ module.exports = v1;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * EDITING INSTRUCTIONS
- * This file was generated from the file
- * https://github.com/googleapis/googleapis/blob/master/no_path_templates.proto,
- * and updates to that file get reflected here through a refresh process.
- * For the short term, the refresh process will only be runnable by Google
- * engineers.
- *
- * The only allowed edits are to method and file documentation. A 3-way
- * merge preserves those additions if the generated source changes.
  */
+
 'use strict';
 
-var configData = require('./no_templates_api_service_client_config');
-var extend = require('extend');
-var gax = require('google-gax');
-var path = require('path');
-
-var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
-
-var DEFAULT_SERVICE_PORT = 443;
-
-var CODE_GEN_NAME_VERSION = 'gapic/0.0.5';
-
-/*!
- * The scopes needed to make gRPC calls to all of the methods defined in
- * this service.
- */
-var ALL_SCOPES = [
-];
+const configData = require('./no_templates_api_service_client_config');
+const gax = require('google-gax');
+const path = require('path');
 
 /**
  *
  * @class
  */
-function NoTemplatesApiServiceClient(gaxGrpc, loadedProtos, opts) {
-  opts = extend({
-    servicePath: SERVICE_ADDRESS,
-    port: DEFAULT_SERVICE_PORT,
-    clientConfig: {}
-  }, opts);
+class NoTemplatesApiServiceClient {
+  constructor(opts) {
+    // Ensure that options include the service address and port.
+    opts = Object.assign({
+      clientConfig: {},
+      port: this.constructor.port,
+      servicePath: this.constructor.servicePath,
+    }, opts);
 
-  var googleApiClient = [
-    'gl-node/' + process.versions.node
-  ];
-  if (opts.libName && opts.libVersion) {
-    googleApiClient.push(opts.libName + '/' + opts.libVersion);
-  }
-  googleApiClient.push(
-    CODE_GEN_NAME_VERSION,
-    'gax/' + gax.version,
-    'grpc/' + gaxGrpc.grpcVersion
-  );
+    // Create a `gaxGrpc` object, with any grpc-specific options
+    // sent to the client.
+    Object.assign(opts, {scopes: this.constructor.scopes});
+    var gaxGrpc = gax.grpc(opts);
 
-  var defaults = gaxGrpc.constructSettings(
+    // Save the auth object to the client, for use by other methods.
+    this.auth = gaxGrpc.auth;
+
+    // Determine the client header string.
+    var clientHeader = [
+      `gl-node/${process.version.node}`,
+      `grpc/${gaxGrpc.grpcVersion}`,
+      `gax/${gax.version}`,
+      `gapic/${this.version}`,
+    ];
+    if (opts.libName && opts.libVersion) {
+      clientHeader.push(`${opts.libName}/${opts.libVersion}`);
+    }
+
+
+    // Put together the default options sent with requests.
+    var defaults = gaxGrpc.constructSettings(
       'google.cloud.example.v1.NoTemplatesAPIService',
-      configData,
+      gapicConfig,
       opts.clientConfig,
-      {'x-goog-api-client': googleApiClient.join(' ')});
+      {'x-goog-api-client': clientHeader.join(' ')},
+    );
 
-  var self = this;
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', 'protos'),
+        'no_path_templates.proto'
+      ),
+    );
 
-  this.auth = gaxGrpc.auth;
-  var noTemplatesApiServiceStub = gaxGrpc.createStub(
-      loadedProtos.google.cloud.example.v1.NoTemplatesAPIService,
-      opts);
-  var noTemplatesApiServiceStubMethods = [
-    'increment'
-  ];
-  noTemplatesApiServiceStubMethods.forEach(function(methodName) {
-    self['_' + methodName] = gax.createApiCall(
-      noTemplatesApiServiceStub.then(function(noTemplatesApiServiceStub) {
-        return function() {
+    // Set up a dictionary of "inner API calls"; the core implementation
+    // of calling the API is handled in `google-gax`, with this code
+    // merely providing the destination and request information.
+    this._innerApiCalls = {};
+
+    // Put together the "service stub" for
+    // google.cloud.example.v1.NoTemplatesAPIService.
+    var noTemplatesApiServiceStub = gaxGrpc.createStub(
+      protos.google.cloud.example.v1.NoTemplatesAPIService,
+      opts
+    );
+
+    // Iterate over each of the methods that the service provides
+    // and create an API call method for each.
+    var noTemplatesApiServiceStubMethods = [
+      'increment',
+    ];
+    for (let methodName of noTemplatesApiServiceStubMethods) {
+      this._innerApiCalls[methodName] = gax.createApiCall(
+        noTemplatesApiServiceStub.then(stub => function() {
           var args = Array.prototype.slice.call(arguments, 0);
-          return noTemplatesApiServiceStub[methodName].apply(noTemplatesApiServiceStub, args);
-        };
-      }),
-      defaults[methodName],
-      null);
-  });
-}
-
-
-/**
- * Get the project ID used by this class.
- * @param {function(Error, string)} callback - the callback to be called with
- *   the current project Id.
- */
-NoTemplatesApiServiceClient.prototype.getProjectId = function(callback) {
-  return this.auth.getProjectId(callback);
-};
-
-// Service calls
-
-/**
- * Increments something.
- *   Sometimes the comments are indented, but Sphinx doesn't like that. So
- *  in Python we trim all
- *      leading
- *         and trailing
- *    whitespace.
- *
- * @param {Object=} request
- *   The request object that will be sent.
- * @param {Object=} options
- *   Optional parameters. You can override the default settings for this call, e.g, timeout,
- *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
- * @param {function(?Error)=} callback
- *   The function which will be called with the result of the API call.
- * @returns {Promise} - The promise which resolves when API call finishes.
- *   The promise has a method named "cancel" which cancels the ongoing API call.
- *
- * @example
- *
- * var example = require('example');
- *
- * var client = example({
- *    // optional auth parameters.
- * });
- *
- *
- * client.increment({}).catch(function(err) {
- *     console.error(err);
- * });
- */
-NoTemplatesApiServiceClient.prototype.increment = function(request, options, callback) {
-  if (options instanceof Function && callback === undefined) {
-    callback = options;
-    options = {};
-  }
-  if (options === undefined) {
-    options = {};
-  }
-  if (request === undefined) {
-    request = {};
-  }
-  return this._increment(request, options, callback);
-};
-
-/**
- * @class
- * @param {*} gaxGrpc
- */
-function NoTemplatesApiServiceClientBuilder(gaxGrpc) {
-  if (!(this instanceof NoTemplatesApiServiceClientBuilder)) {
-    return new NoTemplatesApiServiceClientBuilder(gaxGrpc);
+          return stub[methodName].apply(stub, args);
+        }),
+        defaults[methodName],
+        null
+      );
+    }
   }
 
-  var noTemplatesApiServiceStubProtos = gaxGrpc.loadProto(
-    path.join(__dirname, '..', 'protos'), 'no_path_templates.proto');
-  extend(this, noTemplatesApiServiceStubProtos.google.cloud.example.v1);
+  /**
+   * The DNS address for this API service.
+   */
+  static get servicePath() {
+    return 'no-path-templates.googleapis.com';
+  }
+
+  /**
+   * The port for this API service.
+   */
+  static get port() {
+    return 443;
+  }
+
+  /**
+   * The scopes needed to make gRPC calls for every method defined
+   * in this service.
+   */
+  static get scopes() {
+    return [
+    ];
+  }
+
 
 
   /**
-   * Build a new instance of {@link NoTemplatesApiServiceClient}.
-   *
-   * @method NoTemplatesApiServiceClientBuilder#noTemplatesApiServiceClient
-   * @param {Object=} opts - The optional parameters.
-   * @param {String=} opts.servicePath
-   *   The domain name of the API remote host.
-   * @param {number=} opts.port
-   *   The port on which to connect to the remote host.
-   * @param {grpc.ClientCredentials=} opts.sslCreds
-   *   A ClientCredentials for use with an SSL-enabled channel.
-   * @param {Object=} opts.clientConfig
-   *   The customized config to build the call settings. See
-   *   {@link gax.constructSettings} for the format.
+   * Return the project ID used by this class.
+   * @param {function(Error, string)} callback - the callback to
+   *   be called with the current project Id.
    */
-  this.noTemplatesApiServiceClient = function(opts) {
-    return new NoTemplatesApiServiceClient(gaxGrpc, noTemplatesApiServiceStubProtos, opts);
+  getProjectId(callback) {
+    return this.auth.getProjectId(callback);
+  }
+
+  // Service calls
+
+  /**
+   * Increments something.
+   *   Sometimes the comments are indented, but Sphinx doesn't like that. So
+   *  in Python we trim all
+   *      leading
+   *         and trailing
+   *    whitespace.
+   *
+   * @param {Object=} request
+   *   The request object that will be sent.
+   * @param {Object=} options
+   *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+   *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+   * @param {function(?Error)=} callback
+   *   The function which will be called with the result of the API call.
+   * @returns {Promise} - The promise which resolves when API call finishes.
+   *   The promise has a method named "cancel" which cancels the ongoing API call.
+   *
+   * @example
+   *
+   * var example = require('example');
+   *
+   * var client = example({
+   *    // optional auth parameters.
+   * });
+   *
+   *
+   * client.increment({}).catch(function(err) {
+   *     console.error(err);
+   * });
+   */
+  increment(request, options, callback) {
+    if (options instanceof Function && callback === undefined) {
+      callback = options;
+      options = {};
+    }
+    options = options || {};
+    if (request === undefined) {
+      request = {};
+    }
+    return this._innerApiCalls.increment(request, options, callback);
   };
-  extend(this.noTemplatesApiServiceClient, NoTemplatesApiServiceClient);
 }
-module.exports = NoTemplatesApiServiceClientBuilder;
-module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
-module.exports.ALL_SCOPES = ALL_SCOPES;
+
+
+module.exports = NoTemplatesApiServiceClient;
+
 ============== file: src/v1/no_templates_api_service_client_config.json ==============
 {
   "interfaces": {
@@ -389,4 +369,3 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     }
   };
 }
-

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -259,12 +259,12 @@ class NoTemplatesApiServiceClient {
    * var example = require('example');
    *
    * var client = example({
-   *    // optional auth parameters.
+   *   // optional auth parameters.
    * });
    *
    *
-   * client.increment({}).catch(function(err) {
-   *     console.error(err);
+   * client.increment({}).catch(err => {
+   *   console.error(err);
    * });
    */
   increment(request, options, callback) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -116,7 +116,7 @@ module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
 
 'use strict';
 
-const configData = require('./no_templates_api_service_client_config');
+const gapicConfig = require('./no_templates_api_service_client_config');
 const gax = require('google-gax');
 const path = require('path');
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -128,6 +128,8 @@ const path = require('path');
  */
 class NoTemplatesApiServiceClient {
   constructor(opts) {
+    this._descriptors = {};
+
     // Ensure that options include the service address and port.
     opts = Object.assign({
       clientConfig: {},
@@ -154,6 +156,13 @@ class NoTemplatesApiServiceClient {
       clientHeader.push(`${opts.libName}/${opts.libVersion}`);
     }
 
+    // Load the applicable protos.
+    var protos = merge({},
+      gaxGrpc.loadProto(
+        path.join(__dirname, '..', 'protos'),
+        'no_path_templates.proto'
+      ),
+    );
 
     // Put together the default options sent with requests.
     var defaults = gaxGrpc.constructSettings(
@@ -161,14 +170,6 @@ class NoTemplatesApiServiceClient {
       gapicConfig,
       opts.clientConfig,
       {'x-goog-api-client': clientHeader.join(' ')},
-    );
-
-    // Load the applicable protos.
-    var protos = merge({},
-      gaxGrpc.loadProto(
-        path.join(__dirname, '..', 'protos'),
-        'no_path_templates.proto'
-      ),
     );
 
     // Set up a dictionary of "inner API calls"; the core implementation

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -58,7 +58,8 @@ $ npm install --save example
   ],
   "dependencies": {
     "google-gax": "^0.14.0",
-    "google-some-other-package-v1": "^0.2.1"
+    "google-some-other-package-v1": "^0.2.1",
+    "lodash.merge": "^4.6.0"
   },
   "devDependencies": {
     "mocha": "^3.2.0",
@@ -118,6 +119,7 @@ module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
 
 const gapicConfig = require('./no_templates_api_service_client_config');
 const gax = require('google-gax');
+const merge = require('lodash.merge');
 const path = require('path');
 
 /**
@@ -135,7 +137,7 @@ class NoTemplatesApiServiceClient {
 
     // Create a `gaxGrpc` object, with any grpc-specific options
     // sent to the client.
-    Object.assign(opts, {scopes: this.constructor.scopes});
+    opts.scopes = this.constructor.scopes;
     var gaxGrpc = gax.grpc(opts);
 
     // Save the auth object to the client, for use by other methods.
@@ -221,8 +223,6 @@ class NoTemplatesApiServiceClient {
     ];
   }
 
-
-
   /**
    * Return the project ID used by this class.
    * @param {function(Error, string)} callback - the callback to
@@ -232,7 +232,9 @@ class NoTemplatesApiServiceClient {
     return this.auth.getProjectId(callback);
   }
 
-  // Service calls
+  // -------------------
+  // -- Service calls --
+  // -------------------
 
   /**
    * Increments something.
@@ -369,3 +371,4 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     }
   };
 }
+

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -256,9 +256,9 @@ class NoTemplatesApiServiceClient {
    *
    * @example
    *
-   * var example = require('example');
+   * const example = require('example');
    *
-   * var client = example({
+   * var client = example.NoTemplatesApiServiceClient({
    *   // optional auth parameters.
    * });
    *

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -316,40 +316,41 @@ module.exports = NoTemplatesApiServiceClient;
  */
 'use strict';
 
-var assert = require('assert');
-var example = require('../src');
+const assert = require('assert');
+
+const exampleModule = require('../src');
 
 var FAKE_STATUS_CODE = 1;
 var error = new Error();
 error.code = FAKE_STATUS_CODE;
 
-describe('NoTemplatesApiServiceClient', function() {
-  describe('increment', function() {
-    it('invokes increment without error', function(done) {
-      var client = example();
+describe('NoTemplatesApiServiceClient', () => {
+  describe('increment', () => {
+    it('invokes increment without error', done => {
+      var client = new exampleModule.NoTemplatesApiServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._increment = mockSimpleGrpcMethod(request);
+      client._innerApiCalls.increment = mockSimpleGrpcMethod(request);
 
-      client.increment(request, function(err) {
+      client.increment(request, err => {
         assert.ifError(err);
         done();
       });
     });
 
-    it('invokes increment with error', function(done) {
-      var client = example();
+    it('invokes increment with error', done => {
+      var client = new exampleModule.NoTemplatesApiServiceClient();
 
       // Mock request
       var request = {};
 
       // Mock Grpc layer
-      client._increment = mockSimpleGrpcMethod(request, null, error);
+      client._innerApiCalls.increment = mockSimpleGrpcMethod(request, null, error);
 
-      client.increment(request, function(err) {
+      client.increment(request, err => {
         assert(err instanceof Error);
         assert.equal(err.code, FAKE_STATUS_CODE);
         done();
@@ -364,9 +365,11 @@ function mockSimpleGrpcMethod(expectedRequest, response, error) {
     assert.deepStrictEqual(actualRequest, expectedRequest);
     if (error) {
       callback(error);
-    } else if (response) {
+    }
+    else if (response) {
       callback(null, response);
-    } else {
+    }
+    else {
       callback(null);
     }
   };

--- a/src/test/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverterTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverterTest.java
@@ -38,6 +38,6 @@ public class NodeJSModelTypeNameConverterTest {
             converter
                 .getEnumValue(type, value)
                 .getValueAndSaveTypeNicknameIn(new JSTypeTable(packageName)))
-        .isEqualTo("library.v1.types.Book.Rating.GOOD");
+        .isEqualTo("'GOOD'");
   }
 }


### PR DESCRIPTION
This ended up being a pretty substantial refactor for the Node.js autogen.

It does the following:

  * Converts clients to ES6 classes with Node 4 syntax.
  * Dramatically changes the interior imports/exports. You now get the client class straight up, and instantiate it straight up (e.g. `new language.v1.LanguageServiceClient()`).
      * The various passes at "builder functions" (e.g. `language.v1()` and `LanguageServiceClientBuilder()`) are completely removed.
      * The explicit version number use is still optional. Same rules as Python.
  * Removes the dependency on `extend` and uses `Object.assign`.
  * _Mostly_ complies with prettier. (There are a couple oddities where line lengths were hard to control, and while prettier-compliant, there are a few really stupidly excessive line breaks also.)
  * Documentation examples got a substantial syntax and style rehash.

To-do:

  * [x] Port auto-generated unit tests.
  * [x] Port auto-generated system ("smoke") tests.
  * [x] Make README/docs use the explicit constructor.

We need to do smoke tests in the following APIs to prove that the autogen still works:

  * [x] Natural language (base case)
  * [x] Pub/Sub (path templates)
  * [x] Speech (streaming)
  * [x] Video Intelligence (LRO)
  * [x] (pagination -- what uses this?)
  * [x] ~(batching -- what uses this?)~ Pub/Sub covers batching.