### PR TITLE
Docs updates

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
@@ -84,6 +84,7 @@ public class GrpcElementDocTransformer {
       doc.name(namer.getEnumTypeName(typeTable, enumElement));
       doc.lines(namer.getDocLines(enumElement));
       doc.values(generateEnumValueDocs(namer, enumElement));
+      doc.packageName(enumElement.getFile().getFullName());
       enumDocs.add(doc.build());
     }
     return enumDocs.build();

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -34,6 +34,7 @@ import com.google.api.codegen.transformer.GapicMethodContext;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
+import com.google.api.codegen.transformer.PackageMetadataNamer;
 import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
 import com.google.api.codegen.transformer.ServiceTransformer;
@@ -265,6 +266,9 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
 
   private List<ViewModel> generateIndexViews(
       Iterable<Interface> apiInterfaces, GapicProductConfig productConfig) {
+    PackageMetadataNamer packageMetadataNamer =
+        new NodeJSPackageMetadataNamer(
+            productConfig.getPackageName(), productConfig.getDomainLayerLocation());
     ArrayList<ViewModel> indexViews = new ArrayList<>();
     NodeJSSurfaceNamer namer =
         new NodeJSSurfaceNamer(productConfig.getPackageName(), NodeJSUtils.isGcloud(productConfig));
@@ -303,7 +307,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
             .fileHeader(
                 fileHeaderTransformer.generateFileHeader(
                     productConfig, ImportSectionView.newBuilder().build(), namer))
-            .apiShortName(packageConfig.shortName());
+            .packageName(packageMetadataNamer.getMetadataIdentifier());
     if (hasVersion) {
       indexViewbuilder.apiVersion(version);
     }
@@ -326,7 +330,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
               .fileHeader(
                   fileHeaderTransformer.generateFileHeader(
                       productConfig, ImportSectionView.newBuilder().build(), namer))
-              .apiShortName(packageConfig.shortName());
+              .packageName(packageMetadataNamer.getMetadataIdentifier());
       indexViews.add(versionIndexViewBuilder.build());
     }
     return indexViews;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -302,7 +302,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
             .toolkitVersion(GeneratorVersionProvider.getGeneratorVersion())
             .fileHeader(
                 fileHeaderTransformer.generateFileHeader(
-                    productConfig, ImportSectionView.newBuilder().build(), namer));
+                    productConfig, ImportSectionView.newBuilder().build(), namer))
+            .apiShortName(packageConfig.shortName());
     if (hasVersion) {
       indexViewbuilder.apiVersion(version);
     }
@@ -324,7 +325,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
               .toolkitVersion(GeneratorVersionProvider.getGeneratorVersion())
               .fileHeader(
                   fileHeaderTransformer.generateFileHeader(
-                      productConfig, ImportSectionView.newBuilder().build(), namer));
+                      productConfig, ImportSectionView.newBuilder().build(), namer))
+              .apiShortName(packageConfig.shortName());
       indexViews.add(versionIndexViewBuilder.build());
     }
     return indexViews;

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -167,6 +167,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.packageVersion(
         packageConfig.generatedPackageVersionBound(TargetLanguage.NODEJS).lower());
 
+    xapiClass.apiVersion(packageConfig.apiVersion());
+
     xapiClass.packageHasMultipleServices(hasMultipleServices);
     xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterface()));
 

--- a/src/main/java/com/google/api/codegen/util/js/JSCommentReformatter.java
+++ b/src/main/java/com/google/api/codegen/util/js/JSCommentReformatter.java
@@ -23,7 +23,10 @@ public class JSCommentReformatter implements CommentReformatter {
 
   private CommentTransformer transformer =
       CommentTransformer.newBuilder()
-          .transform(LinkPattern.PROTO.toFormat("{@link $TITLE}"))
+          // TODO(landrito): Fix the linking semantics to follow the packageName.typeName
+          // links like the getLinkedElementName method below. We will probably need to pass this
+          // class something that can lookup the linked proto and converts that to the correct link.
+          .transform(LinkPattern.PROTO.toFormat("$TITLE"))
           .transform(
               LinkPattern.RELATIVE
                   .withUrlPrefix(CommentTransformer.CLOUD_URL_PREFIX)

--- a/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
@@ -134,6 +134,9 @@ public abstract class DynamicLangXApiView implements ViewModel {
   @Nullable
   public abstract String gapicPackageName();
 
+  @Nullable
+  public abstract String apiVersion();
+
   @Override
   public String resourceRoot() {
     return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
@@ -227,6 +230,8 @@ public abstract class DynamicLangXApiView implements ViewModel {
     public abstract Builder servicePhraseName(String val);
 
     public abstract Builder gapicPackageName(String val);
+
+    public abstract Builder apiVersion(String val);
 
     public abstract DynamicLangXApiView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/GrpcEnumDocView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/GrpcEnumDocView.java
@@ -25,6 +25,8 @@ public abstract class GrpcEnumDocView implements GrpcElementDocView {
 
   public abstract List<GrpcEnumValueDocView> values();
 
+  public abstract String packageName();
+
   public static Builder newBuilder() {
     return new AutoValue_GrpcEnumDocView.Builder();
   }
@@ -40,6 +42,8 @@ public abstract class GrpcEnumDocView implements GrpcElementDocView {
     public abstract Builder lines(List<String> val);
 
     public abstract Builder values(List<GrpcEnumValueDocView> val);
+
+    public abstract Builder packageName(String val);
 
     public abstract GrpcEnumDocView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
@@ -68,6 +68,9 @@ public abstract class VersionIndexView implements ViewModel {
 
   public abstract boolean packageHasEnums();
 
+  @Nullable
+  public abstract String apiShortName();
+
   public boolean hasMultipleServices() {
     return requireViews().size() > 1;
   }
@@ -112,6 +115,8 @@ public abstract class VersionIndexView implements ViewModel {
     public abstract Builder namespace(String val);
 
     public abstract Builder packageHasEnums(boolean val);
+
+    public abstract Builder apiShortName(String val);
 
     public abstract VersionIndexView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
@@ -69,7 +69,7 @@ public abstract class VersionIndexView implements ViewModel {
   public abstract boolean packageHasEnums();
 
   @Nullable
-  public abstract String apiShortName();
+  public abstract String packageName();
 
   public boolean hasMultipleServices() {
     return requireViews().size() > 1;
@@ -116,7 +116,7 @@ public abstract class VersionIndexView implements ViewModel {
 
     public abstract Builder packageHasEnums(boolean val);
 
-    public abstract Builder apiShortName(String val);
+    public abstract Builder packageName(String val);
 
     public abstract VersionIndexView build();
   }

--- a/src/main/resources/com/google/api/codegen/nodejs/common.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/common.snip
@@ -5,3 +5,9 @@
     * {@comment}
   @end
 @end
+
+@snippet lineComments(commentLines)
+  @join comment : commentLines
+    // {@comment}
+  @end
+@end

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -1,11 +1,10 @@
 @extends "nodejs/common.snip"
 
 @snippet generate(index)
-  /*
-   {@comments(index.fileHeader.copyrightLines)}
-   *
-   {@comments(index.fileHeader.licenseLines)}
-   */
+  {@lineComments(index.fileHeader.copyrightLines)}
+  //
+  {@lineComments(index.fileHeader.licenseLines)}
+
   'use strict';
 
   @join client : index.requireViews

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -20,8 +20,7 @@
      *
    @end
    * @@class
-   # FIXME: Figure out how to get the API version here.
-   #* @@memberof {@xapi.apiVersion}
+   * @@memberof {@xapi.apiVersion}
    */
   class {@xapi.name} {
     /**

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -3,11 +3,9 @@
 
 
 @snippet generate(xapi)
-  /**
-   {@comments(xapi.fileHeader.copyrightLines)}
-   *
-   {@comments(xapi.fileHeader.licenseLines)}
-   */
+  {@lineComments(xapi.fileHeader.copyrightLines)}
+  //
+  {@lineComments(xapi.fileHeader.licenseLines)}
 
   /*!
    * @@module {@xapi.name}

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -7,9 +7,6 @@
   //
   {@lineComments(xapi.fileHeader.licenseLines)}
 
-  /*!
-   * @@module {@xapi.name}
-   */
   'use strict';
 
   {@importSection(xapi.fileHeader.importSection)}

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -1,46 +1,29 @@
 @extends "nodejs/common.snip"
 @extends "nodejs/method_sample.snip"
 
+
 @snippet generate(xapi)
-  {@header(xapi.fileHeader, xapi.protoFilename)}
-
-  {@serviceClass(xapi)}
-@end
-
-@private header(fileHeader, protoFilename)
-  /*
-   {@comments(fileHeader.copyrightLines)}
+  /**
+   {@comments(xapi.fileHeader.copyrightLines)}
    *
-   {@comments(fileHeader.licenseLines)}
+   {@comments(xapi.fileHeader.licenseLines)}
    */
 
+  /*!
+   * @@module {@xapi.name}
+   */
   'use strict';
 
-  {@importSection(fileHeader.importSection)}
-@end
+  {@importSection(xapi.fileHeader.importSection)}
 
-@private importSection(imports)
-  {@importGroup(imports.externalImports)}
-@end
-
-@private importGroup(group)
-  @join import : group
-    # Currently there is only one type per import.
-    # This will need to be refactored if changed.
-    @join type : import.types
-      const {@type.nickname} = require('{@import.moduleName}');
-    @end
-  @end
-@end
-
-
-@private serviceClass(xapi)
   /**
    @if xapi.doc.lines
      {@comments(xapi.doc.lines)}
      *
    @end
    * @@class
+   # FIXME: Figure out how to get the API version here.
+   #* @@memberof {@xapi.apiVersion}
    */
   class {@xapi.name} {
     /**
@@ -302,6 +285,21 @@
 
   module.exports = {@xapi.name};
 
+@end
+
+
+@private importSection(imports)
+  {@importGroup(imports.externalImports)}
+@end
+
+@private importGroup(group)
+  @join import : group
+    # Currently there is only one type per import.
+    # This will need to be refactored if changed.
+    @join type : import.types
+      const {@type.nickname} = require('{@import.moduleName}');
+    @end
+  @end
 @end
 
 @private clientsParamName(stubs)

--- a/src/main/resources/com/google/api/codegen/nodejs/message.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/message.snip
@@ -9,16 +9,12 @@
 @end
 
 @private licenseSection(fileHeader)
-  /*
-   {@comments(fileHeader.copyrightLines)}
-   *
-   {@comments(fileHeader.licenseLines)}
-   */
+  {@lineComments(fileHeader.copyrightLines)}
+  //
+  {@lineComments(fileHeader.licenseLines)}
 
-  /*!
-   * Note: this file is purely for documentation. Any contents are not expected
-   * to be loaded as the JS file.
-   */
+  // Note: this file is purely for documentation. Any contents are not expected
+  // to be loaded as the JS file.
 @end
 
 @private toplevelHeader(elementDoc)

--- a/src/main/resources/com/google/api/codegen/nodejs/message.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/message.snip
@@ -15,7 +15,7 @@
    {@comments(fileHeader.licenseLines)}
    */
 
-  /*
+  /*!
    * Note: this file is purely for documentation. Any contents are not expected
    * to be loaded as the JS file.
    */
@@ -49,7 +49,7 @@
      {@properties(message)}
    @end
    * @@typedef {@message.name}
-   * @@member {@message.packageName}
+   * @@memberof {@message.packageName}
    * @@see [{@message.fullName} definition in proto format]{@@link {@message.fileUrl}}
    */
   {@header}
@@ -69,6 +69,8 @@
      *
    @end
    * @@enum {number}
+   # FIXME: Figure out how to get this information here.
+   #* @@memberof {@enum.packageName}
    */
   {@header}
     @join value : enum.values() on ",".add(BREAK)
@@ -110,4 +112,3 @@
     {@unhandledCase()}
   @end
 @end
-

--- a/src/main/resources/com/google/api/codegen/nodejs/message.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/message.snip
@@ -65,8 +65,7 @@
      *
    @end
    * @@enum {number}
-   # FIXME: Figure out how to get this information here.
-   #* @@memberof {@enum.packageName}
+   * @@memberof {@enum.packageName}
    */
   {@header}
     @join value : enum.values() on ",".add(BREAK)

--- a/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/smoke_test.snip
@@ -7,11 +7,10 @@
 @end
 
 @private header(fileHeader)
-  /*
-   {@comments(fileHeader.copyrightLines)}
-   *
-   {@comments(fileHeader.licenseLines)}
-   */
+  {@lineComments(fileHeader.copyrightLines)}
+  //
+  {@lineComments(fileHeader.licenseLines)}
+
   'use strict';
 @end
 

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -2,11 +2,10 @@
 @extends "nodejs/common.snip"
 
 @snippet generate(apiTest)
-  /*
-   {@comments(apiTest.fileHeader.copyrightLines)}
-   *
-   {@comments(apiTest.fileHeader.licenseLines)}
-   */
+  {@lineComments(apiTest.fileHeader.copyrightLines)}
+  //
+  {@lineComments(apiTest.fileHeader.licenseLines)}
+  
   'use strict';
 
   {@header(apiTest)}

--- a/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
@@ -6,7 +6,7 @@
   {@lineComments(index.fileHeader.licenseLines)}
 
   /**
-   #* @@module {@index.apiName}
+   * @@module {@index.apiShortName}
    */
 
   'use strict';

--- a/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
@@ -6,7 +6,7 @@
   {@lineComments(index.fileHeader.licenseLines)}
 
   /**
-   * @@module {@index.apiShortName}
+   * @@module {@index.packageName}
    */
 
   'use strict';

--- a/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
@@ -5,6 +5,10 @@
   //
   {@lineComments(index.fileHeader.licenseLines)}
 
+  /**
+   #* @@module {@index.apiName}
+   */
+
   'use strict';
 
   const VERSION = require('../package.json').version;

--- a/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/version_index.snip
@@ -1,11 +1,9 @@
 @extends "nodejs/common.snip"
 
 @snippet generate(index)
-  /**
-   {@comments(index.fileHeader.copyrightLines)}
-   *
-   {@comments(index.fileHeader.licenseLines)}
-   */
+  {@lineComments(index.fileHeader.copyrightLines)}
+  //
+  {@lineComments(index.fileHeader.licenseLines)}
 
   'use strict';
 

--- a/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
+++ b/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
@@ -92,9 +92,9 @@ public class ProtoDocumentLinkTest {
   public void testJSCommentReformatter() {
     JSCommentReformatter commentReformatter = new JSCommentReformatter();
     Truth.assertThat(commentReformatter.reformat("[Shelf][google.example.library.v1.Shelf]"))
-        .isEqualTo("{@link Shelf}");
+        .isEqualTo("Shelf");
     Truth.assertThat(commentReformatter.reformat("[$Shelf][google.example.library.v1.Shelf]"))
-        .isEqualTo("{@link $Shelf}");
+        .isEqualTo("$Shelf");
 
     // Cloud link may contain special character '$'
     Truth.assertThat(commentReformatter.reformat("[cloud docs!](/library/example/link)"))

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -106,21 +106,20 @@ $ npm install --save @google-cloud/library
 }
 
 ============== file: smoke-test/library_service_smoke_test.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 describe('LibraryServiceSmokeTest', () => {
@@ -155,21 +154,19 @@ describe('LibraryServiceSmokeTest', () => {
   });
 });
 ============== file: src/index.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 'use strict';
 
@@ -185,26 +182,22 @@ module.exports.v1 = gapic.v1;
 module.exports.default = Object.assign({}, module.exports);
 
 ============== file: src/v1/doc/google/example/library/v1/doc_field_mask.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * @property {number[]} materials
@@ -229,26 +222,22 @@ var FieldMask = {
   }
 };
 ============== file: src/v1/doc/google/example/library/v1/doc_library.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * A single book in the library.
@@ -1232,26 +1221,22 @@ var TestOptionalRequiredFlatteningParamsResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/protobuf/doc_any.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * `Any` contains an arbitrary serialized protocol buffer message along with a
@@ -1368,26 +1353,22 @@ var Any = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/protobuf/doc_duration.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * A Duration represents a signed, fixed-length span of time represented
@@ -1470,26 +1451,22 @@ var Duration = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/protobuf/doc_field_mask.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * `FieldMask` represents a set of symbolic field paths, for example:
@@ -1705,26 +1682,22 @@ var FieldMask = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/protobuf/doc_struct.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * `Struct` represents a structured data value, consisting of fields
@@ -1821,26 +1794,22 @@ var NullValue = {
   NULL_VALUE: 0
 };
 ============== file: src/v1/doc/google/protobuf/doc_timestamp.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * A Timestamp represents a point in time independent of any time zone
@@ -1939,26 +1908,22 @@ var Timestamp = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/protobuf/doc_wrappers.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * Wrapper message for `double`.
@@ -2104,26 +2069,22 @@ var BytesValue = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/rpc/doc_status.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * The `Status` type defines a logical error model that is suitable for different
@@ -2201,26 +2162,22 @@ var Status = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/doc/google/test/shared/data/doc_shared_type.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-/*!
- * Note: this file is purely for documentation. Any contents are not expected
- * to be loaded as the JS file.
- */
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
 
 /**
  * This message is used by the library service and does not reference
@@ -2251,21 +2208,20 @@ var Unused = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 ============== file: src/v1/index.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const LibraryServiceClient = require('./library_service_client');
@@ -2273,21 +2229,19 @@ const LibraryServiceClient = require('./library_service_client');
 module.exports.LibraryServiceClient = LibraryServiceClient;
 
 ============== file: src/v1/library_service_client.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*!
  * @module LibraryServiceClient
@@ -4891,21 +4845,20 @@ module.exports = LibraryServiceClient;
 }
 
 ============== file: test/gapic-v1.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -168,6 +168,9 @@ describe('LibraryServiceSmokeTest', () => {
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ */
+
 'use strict';
 
 const VERSION = require('../package.json').version;
@@ -2251,9 +2254,6 @@ module.exports.LibraryServiceClient = LibraryServiceClient;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*!
- * @module LibraryServiceClient
- */
 'use strict';
 
 const gapicConfig = require('./library_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -169,6 +169,7 @@ describe('LibraryServiceSmokeTest', () => {
 // limitations under the License.
 
 /**
+ * @module library
  */
 
 'use strict';
@@ -557,7 +558,7 @@ var StringBuilder = {
  * @property {string} pageToken
  *   A token identifying a page of results the server should return.
  *   Typically, this is the value of
- *   {@link ListShelvesResponse.next_page_token}
+ *   ListShelvesResponse.next_page_token
  *   returned from the previous call to `ListShelves` method.
  *
  * @typedef ListShelvesRequest
@@ -579,7 +580,7 @@ var ListShelvesRequest = {
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
  *   Pass this value in the
- *   {@link ListShelvesRequest.page_token}
+ *   ListShelvesRequest.page_token
  *   field in the subsequent call to `ListShelves` method to retrieve the next
  *   page of results.
  *
@@ -754,7 +755,7 @@ var GetBookRequest = {
  * @property {string} pageToken
  *   A token identifying a page of results the server should return.
  *   Typically, this is the value of
- *   {@link ListBooksResponse.next_page_token}.
+ *   ListBooksResponse.next_page_token.
  *   returned from the previous call to `ListBooks` method.
  *
  * @property {string} filter
@@ -779,7 +780,7 @@ var ListBooksRequest = {
  * @property {string} nextPageToken
  *   A token to retrieve next page of results.
  *   Pass this value in the
- *   {@link ListBooksRequest.page_token}
+ *   ListBooksRequest.page_token
  *   field in the subsequent call to `ListBooks` method to retrieve the next
  *   page of results.
  *
@@ -1322,7 +1323,7 @@ var TestOptionalRequiredFlatteningParamsResponse = {
  * If the embedded message type is well-known and has a custom JSON
  * representation, that representation will be embedded adding a field
  * `value` which holds the custom JSON in addition to the `@type`
- * field. Example (for message {@link google.protobuf.Duration}):
+ * field. Example (for message google.protobuf.Duration):
  *
  *     {
  *       "@type": "type.googleapis.com/google.protobuf.Duration",
@@ -1341,7 +1342,7 @@ var TestOptionalRequiredFlatteningParamsResponse = {
  *     qualified name of the type (as in `path/google.protobuf.Duration`).
  *     The name should be in a canonical form (e.g., leading "." is
  *     not accepted).
- *   * An HTTP GET on the URL must yield a {@link google.protobuf.Type}
+ *   * An HTTP GET on the URL must yield a google.protobuf.Type
  *     value in binary format, or produce an error.
  *   * Applications are allowed to cache lookup results based on the
  *     URL, or have them precompiled into a binary to avoid any
@@ -2109,7 +2110,7 @@ var BytesValue = {
  *
  * The `Status` message contains three pieces of data: error code, error message,
  * and error details. The error code should be an enum value of
- * {@link google.rpc.Code}, but it may accept additional error codes if needed.  The
+ * google.rpc.Code, but it may accept additional error codes if needed.  The
  * error message should be a developer-facing English message that helps
  * developers *understand* and *resolve* the error. If a localized user-facing
  * error message is needed, put the localized message in the error details or
@@ -2152,12 +2153,12 @@ var BytesValue = {
  *     be used directly after any stripping needed for security/privacy reasons.
  *
  * @property {number} code
- *   The status code, which should be an enum value of {@link google.rpc.Code}.
+ *   The status code, which should be an enum value of google.rpc.Code.
  *
  * @property {string} message
  *   A developer-facing error message, which should be in English. Any
  *   user-facing error message should be localized and sent in the
- *   {@link google.rpc.Status.details} field, or localized by the client.
+ *   google.rpc.Status.details field, or localized by the client.
  *
  * @property {Object[]} details
  *   A list of messages that carry the error details.  There will be a
@@ -2267,10 +2268,10 @@ const protobuf = require('protobufjs');
  * resources and Book resources in the library. It defines the following
  * resource model:
  *
- * - The API has a collection of {@link Shelf}
+ * - The API has a collection of Shelf
  *   resources, named ``bookShelves/*``
  *
- * - Each Shelf has a collection of {@link Book}
+ * - Each Shelf has a collection of Book
  *   resources, named `bookShelves/*/books/*`
  *
  * Check out [cloud docs!](https://cloud.google.com/library/example/link).

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -212,6 +212,7 @@ var FieldMask = {
 
   /**
    * @enum {number}
+   * @memberof google.example.library.v1
    */
   Material: {
     PAPIER_MACHE: 0,
@@ -343,6 +344,7 @@ var Book = {
 
   /**
    * @enum {number}
+   * @memberof google.example.library.v1
    */
   Rating: {
 
@@ -402,6 +404,7 @@ var SomeMessage = {
    * Tests service with two enums of the same simple name
    *
    * @enum {number}
+   * @memberof google.example.library.v1
    */
   Alignment: {
     GOOD: 0,
@@ -435,6 +438,7 @@ var SomeMessage2 = {
      * Tests Python nested enums
      *
      * @enum {number}
+     * @memberof google.example.library.v1
      */
     Alignment: {
 
@@ -459,6 +463,7 @@ var SomeMessage2 = {
    * Another enum with duplicated simple name
    *
    * @enum {number}
+   * @memberof google.example.library.v1
    */
   Alignment: {
     FLUSH_LEFT: 0,
@@ -926,6 +931,7 @@ var Comment = {
 
   /**
    * @enum {number}
+   * @memberof google.example.library.v1
    */
   Stage: {
     UNSET: 0,
@@ -1205,6 +1211,7 @@ var TestOptionalRequiredFlatteningParamsRequest = {
    * For testing all types, plus resource-names, as required and optional.
    *
    * @enum {number}
+   * @memberof google.example.library.v1
    */
   InnerEnum: {
     ZERO: 0,
@@ -1785,6 +1792,7 @@ var ListValue = {
  *  The JSON representation for `NullValue` is JSON `null`.
  *
  * @enum {number}
+ * @memberof google.protobuf
  */
 var NullValue = {
 
@@ -2271,6 +2279,7 @@ const protobuf = require('protobufjs');
  * Service comment may include special characters: <>&"`'@.
  *
  * @class
+ * @memberof v1
  */
 class LibraryServiceClient {
   /**

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -169,7 +169,7 @@ describe('LibraryServiceSmokeTest', () => {
 // limitations under the License.
 
 /**
- * @module library
+ * @module @google-cloud/library
  */
 
 'use strict';

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -201,7 +201,7 @@ module.exports.default = Object.assign({}, module.exports);
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -211,7 +211,7 @@ module.exports.default = Object.assign({}, module.exports);
  *   The number should be among the values of [Material]{@link google.example.library.v1.Material}
  *
  * @typedef FieldMask
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.FieldMask definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/field_mask.proto}
  */
 var FieldMask = {
@@ -245,7 +245,7 @@ var FieldMask = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -346,7 +346,7 @@ var FieldMask = {
  *   This object should have the same structure as [Used]{@link google.test.shared.data.Used}
  *
  * @typedef Book
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.Book definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var Book = {
@@ -386,7 +386,7 @@ var Book = {
  *   Value indicating whether the book has been read.
  *
  * @typedef BookFromArchive
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.BookFromArchive definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var BookFromArchive = {
@@ -403,7 +403,7 @@ var BookFromArchive = {
  *   The number should be among the values of [Alignment]{@link google.example.library.v1.Alignment}
  *
  * @typedef SomeMessage
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.SomeMessage definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SomeMessage = {
@@ -428,7 +428,7 @@ var SomeMessage = {
  *   The number should be among the values of [Alignment]{@link google.example.library.v1.Alignment}
  *
  * @typedef SomeMessage2
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.SomeMessage2 definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SomeMessage2 = {
@@ -436,7 +436,7 @@ var SomeMessage2 = {
 
   /**
    * @typedef SomeMessage3
-   * @member google.example.library.v1
+   * @memberof google.example.library.v1
    * @see [google.example.library.v1.SomeMessage2.SomeMessage3 definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
    */
   SomeMessage3: {
@@ -493,7 +493,7 @@ var SomeMessage2 = {
  *   Internal theme that is visible to trusted testers only.
  *
  * @typedef Shelf
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.Shelf definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var Shelf = {
@@ -509,7 +509,7 @@ var Shelf = {
  *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @typedef CreateShelfRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.CreateShelfRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var CreateShelfRequest = {
@@ -534,7 +534,7 @@ var CreateShelfRequest = {
  *   To test 'options' parameter name conflict.
  *
  * @typedef GetShelfRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.GetShelfRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetShelfRequest = {
@@ -547,7 +547,7 @@ var GetShelfRequest = {
  * @property {string} name
  *
  * @typedef StringBuilder
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.StringBuilder definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StringBuilder = {
@@ -564,7 +564,7 @@ var StringBuilder = {
  *   returned from the previous call to `ListShelves` method.
  *
  * @typedef ListShelvesRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.ListShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListShelvesRequest = {
@@ -587,7 +587,7 @@ var ListShelvesRequest = {
  *   page of results.
  *
  * @typedef ListShelvesResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.ListShelvesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListShelvesResponse = {
@@ -597,7 +597,7 @@ var ListShelvesResponse = {
 /**
  * Request message for LibraryService.StreamShelves.
  * @typedef StreamShelvesRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.StreamShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StreamShelvesRequest = {
@@ -613,7 +613,7 @@ var StreamShelvesRequest = {
  *   This object should have the same structure as [Shelf]{@link google.example.library.v1.Shelf}
  *
  * @typedef StreamShelvesResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.StreamShelvesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StreamShelvesResponse = {
@@ -627,7 +627,7 @@ var StreamShelvesResponse = {
  *   The name of the shelf to delete.
  *
  * @typedef DeleteShelfRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.DeleteShelfRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var DeleteShelfRequest = {
@@ -645,7 +645,7 @@ var DeleteShelfRequest = {
  *   The name of the shelf we're removing books from and deleting.
  *
  * @typedef MergeShelvesRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.MergeShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var MergeShelvesRequest = {
@@ -664,7 +664,7 @@ var MergeShelvesRequest = {
  *   This object should have the same structure as [Book]{@link google.example.library.v1.Book}
  *
  * @typedef CreateBookRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.CreateBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var CreateBookRequest = {
@@ -696,7 +696,7 @@ var CreateBookRequest = {
  *   This object should have the same structure as [SeriesUuid]{@link google.example.library.v1.SeriesUuid}
  *
  * @typedef PublishSeriesRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.PublishSeriesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var PublishSeriesRequest = {
@@ -709,7 +709,7 @@ var PublishSeriesRequest = {
  * @property {string} seriesString
  *
  * @typedef SeriesUuid
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.SeriesUuid definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SeriesUuid = {
@@ -723,7 +723,7 @@ var SeriesUuid = {
  *   The names of the books in the series that were published
  *
  * @typedef PublishSeriesResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.PublishSeriesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var PublishSeriesResponse = {
@@ -737,7 +737,7 @@ var PublishSeriesResponse = {
  *   The name of the book to retrieve.
  *
  * @typedef GetBookRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.GetBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookRequest = {
@@ -764,7 +764,7 @@ var GetBookRequest = {
  *   To test python built-in wrapping.
  *
  * @typedef ListBooksRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.ListBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListBooksRequest = {
@@ -787,7 +787,7 @@ var ListBooksRequest = {
  *   page of results.
  *
  * @typedef ListBooksResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.ListBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListBooksResponse = {
@@ -801,7 +801,7 @@ var ListBooksResponse = {
  *   The name of the shelf whose books we'd like to list.
  *
  * @typedef StreamBooksRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.StreamBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var StreamBooksRequest = {
@@ -830,7 +830,7 @@ var StreamBooksRequest = {
  *   This object should have the same structure as [FieldMask]{@link google.example.library.v1.FieldMask}
  *
  * @typedef UpdateBookRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.UpdateBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var UpdateBookRequest = {
@@ -844,7 +844,7 @@ var UpdateBookRequest = {
  *   The name of the book to delete.
  *
  * @typedef DeleteBookRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.DeleteBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var DeleteBookRequest = {
@@ -862,7 +862,7 @@ var DeleteBookRequest = {
  *   The name of the destination shelf.
  *
  * @typedef MoveBookRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.MoveBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var MoveBookRequest = {
@@ -877,7 +877,7 @@ var MoveBookRequest = {
  * @property {string} pageToken
  *
  * @typedef ListStringsRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.ListStringsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListStringsRequest = {
@@ -890,7 +890,7 @@ var ListStringsRequest = {
  * @property {string} nextPageToken
  *
  * @typedef ListStringsResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.ListStringsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListStringsResponse = {
@@ -904,7 +904,7 @@ var ListStringsResponse = {
  *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  *
  * @typedef AddCommentsRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.AddCommentsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var AddCommentsRequest = {
@@ -929,7 +929,7 @@ var AddCommentsRequest = {
  *   The number should be among the values of [Alignment]{@link google.example.library.v1.Alignment}
  *
  * @typedef Comment
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.Comment definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var Comment = {
@@ -953,7 +953,7 @@ var Comment = {
  *   The name of the book to retrieve.
  *
  * @typedef GetBookFromArchiveRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.GetBookFromArchiveRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookFromArchiveRequest = {
@@ -971,7 +971,7 @@ var GetBookFromArchiveRequest = {
  *   single resource name type in a oneof.
  *
  * @typedef GetBookFromAnywhereRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.GetBookFromAnywhereRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookFromAnywhereRequest = {
@@ -985,7 +985,7 @@ var GetBookFromAnywhereRequest = {
  *   The name of the book to retrieve.
  *
  * @typedef GetBookFromAbsolutelyAnywhereRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.GetBookFromAbsolutelyAnywhereRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBookFromAbsolutelyAnywhereRequest = {
@@ -1005,7 +1005,7 @@ var GetBookFromAbsolutelyAnywhereRequest = {
  *   The index to update the book with
  *
  * @typedef UpdateBookIndexRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.UpdateBookIndexRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var UpdateBookIndexRequest = {
@@ -1024,7 +1024,7 @@ var UpdateBookIndexRequest = {
  *   This object should have the same structure as [Comment]{@link google.example.library.v1.Comment}
  *
  * @typedef DiscussBookRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.DiscussBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var DiscussBookRequest = {
@@ -1043,7 +1043,7 @@ var DiscussBookRequest = {
  * @property {string} pageToken
  *
  * @typedef FindRelatedBooksRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.FindRelatedBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var FindRelatedBooksRequest = {
@@ -1058,7 +1058,7 @@ var FindRelatedBooksRequest = {
  * @property {string} nextPageToken
  *
  * @typedef FindRelatedBooksResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.FindRelatedBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var FindRelatedBooksResponse = {
@@ -1072,7 +1072,7 @@ var FindRelatedBooksResponse = {
  *   Approximate percentage of the book processed thus far.
  *
  * @typedef GetBigBookMetadata
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.GetBigBookMetadata definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var GetBigBookMetadata = {
@@ -1197,7 +1197,7 @@ var GetBigBookMetadata = {
  * @property {Object.<number, string>} optionalMap
  *
  * @typedef TestOptionalRequiredFlatteningParamsRequest
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var TestOptionalRequiredFlatteningParamsRequest = {
@@ -1205,7 +1205,7 @@ var TestOptionalRequiredFlatteningParamsRequest = {
 
   /**
    * @typedef InnerMessage
-   * @member google.example.library.v1
+   * @memberof google.example.library.v1
    * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest.InnerMessage definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
    */
   InnerMessage: {
@@ -1225,7 +1225,7 @@ var TestOptionalRequiredFlatteningParamsRequest = {
 
 /**
  * @typedef TestOptionalRequiredFlatteningParamsResponse
- * @member google.example.library.v1
+ * @memberof google.example.library.v1
  * @see [google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var TestOptionalRequiredFlatteningParamsResponse = {
@@ -1248,7 +1248,7 @@ var TestOptionalRequiredFlatteningParamsResponse = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -1361,7 +1361,7 @@ var TestOptionalRequiredFlatteningParamsResponse = {
  *   Must be a valid serialized protocol buffer of the above specified type.
  *
  * @typedef Any
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
  */
 var Any = {
@@ -1384,7 +1384,7 @@ var Any = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -1463,7 +1463,7 @@ var Any = {
  *   to +999,999,999 inclusive.
  *
  * @typedef Duration
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Duration definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/duration.proto}
  */
 var Duration = {
@@ -1486,7 +1486,7 @@ var Duration = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -1698,7 +1698,7 @@ var Duration = {
  *   The set of field mask paths.
  *
  * @typedef FieldMask
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
  */
 var FieldMask = {
@@ -1721,7 +1721,7 @@ var FieldMask = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -1740,7 +1740,7 @@ var FieldMask = {
  *   Unordered map of dynamically typed values.
  *
  * @typedef Struct
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Struct definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
  */
 var Struct = {
@@ -1780,7 +1780,7 @@ var Struct = {
  *   This object should have the same structure as [ListValue]{@link google.protobuf.ListValue}
  *
  * @typedef Value
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
  */
 var Value = {
@@ -1798,7 +1798,7 @@ var Value = {
  *   This object should have the same structure as [Value]{@link google.protobuf.Value}
  *
  * @typedef ListValue
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.ListValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
  */
 var ListValue = {
@@ -1837,7 +1837,7 @@ var NullValue = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -1932,7 +1932,7 @@ var NullValue = {
  *   inclusive.
  *
  * @typedef Timestamp
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Timestamp definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/timestamp.proto}
  */
 var Timestamp = {
@@ -1955,7 +1955,7 @@ var Timestamp = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -1969,7 +1969,7 @@ var Timestamp = {
  *   The double value.
  *
  * @typedef DoubleValue
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.DoubleValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var DoubleValue = {
@@ -1985,7 +1985,7 @@ var DoubleValue = {
  *   The float value.
  *
  * @typedef FloatValue
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.FloatValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var FloatValue = {
@@ -2001,7 +2001,7 @@ var FloatValue = {
  *   The int64 value.
  *
  * @typedef Int64Value
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Int64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var Int64Value = {
@@ -2017,7 +2017,7 @@ var Int64Value = {
  *   The uint64 value.
  *
  * @typedef UInt64Value
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.UInt64Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var UInt64Value = {
@@ -2033,7 +2033,7 @@ var UInt64Value = {
  *   The int32 value.
  *
  * @typedef Int32Value
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.Int32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var Int32Value = {
@@ -2049,7 +2049,7 @@ var Int32Value = {
  *   The uint32 value.
  *
  * @typedef UInt32Value
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.UInt32Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var UInt32Value = {
@@ -2065,7 +2065,7 @@ var UInt32Value = {
  *   The bool value.
  *
  * @typedef BoolValue
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.BoolValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var BoolValue = {
@@ -2081,7 +2081,7 @@ var BoolValue = {
  *   The string value.
  *
  * @typedef StringValue
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.StringValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var StringValue = {
@@ -2097,7 +2097,7 @@ var StringValue = {
  *   The bytes value.
  *
  * @typedef BytesValue
- * @member google.protobuf
+ * @memberof google.protobuf
  * @see [google.protobuf.BytesValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
 var BytesValue = {
@@ -2120,7 +2120,7 @@ var BytesValue = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -2194,7 +2194,7 @@ var BytesValue = {
  *   This object should have the same structure as [Any]{@link google.protobuf.Any}
  *
  * @typedef Status
- * @member google.rpc
+ * @memberof google.rpc
  * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
  */
 var Status = {
@@ -2217,7 +2217,7 @@ var Status = {
  * limitations under the License.
  */
 
-/*
+/*!
  * Note: this file is purely for documentation. Any contents are not expected
  * to be loaded as the JS file.
  */
@@ -2229,7 +2229,7 @@ var Status = {
  * @property {number} timesUsed
  *
  * @typedef Used
- * @member google.test.shared.data
+ * @memberof google.test.shared.data
  * @see [google.test.shared.data.Used definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
  */
 var Used = {
@@ -2244,7 +2244,7 @@ var Used = {
  *   This object should have the same structure as [OtherType]{@link google.test.shared.data.OtherType}
  *
  * @typedef Unused
- * @member google.test.shared.data
+ * @memberof google.test.shared.data
  * @see [google.test.shared.data.Unused definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/shared_type.proto}
  */
 var Unused = {
@@ -2273,7 +2273,7 @@ const LibraryServiceClient = require('./library_service_client');
 module.exports.LibraryServiceClient = LibraryServiceClient;
 
 ============== file: src/v1/library_service_client.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2289,6 +2289,9 @@ module.exports.LibraryServiceClient = LibraryServiceClient;
  * limitations under the License.
  */
 
+/*!
+ * @module LibraryServiceClient
+ */
 'use strict';
 
 const gapicConfig = require('./library_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -245,6 +245,7 @@ const protobuf = require('protobufjs');
  * Service comment may include special characters: <>&"`'@.
  *
  * @class
+ * @memberof v1
  */
 class LibraryServiceClient {
   /**

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -207,7 +207,7 @@ const LibraryServiceClient = require('./library_service_client');
 module.exports.LibraryServiceClient = LibraryServiceClient;
 
 ============== file: src/v1/library_service_client.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -223,6 +223,9 @@ module.exports.LibraryServiceClient = LibraryServiceClient;
  * limitations under the License.
  */
 
+/*!
+ * @module LibraryServiceClient
+ */
 'use strict';
 
 const gapicConfig = require('./library_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -106,21 +106,20 @@ $ npm install --save @google-cloud/library
 }
 
 ============== file: smoke-test/library_service_smoke_test.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 describe('LibraryServiceSmokeTest', () => {
@@ -155,21 +154,19 @@ describe('LibraryServiceSmokeTest', () => {
   });
 });
 ============== file: src/index.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 'use strict';
 
@@ -185,21 +182,20 @@ module.exports.v1 = gapic.v1;
 module.exports.default = Object.assign({}, module.exports);
 
 ============== file: src/v1/index.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const LibraryServiceClient = require('./library_service_client');
@@ -207,21 +203,19 @@ const LibraryServiceClient = require('./library_service_client');
 module.exports.LibraryServiceClient = LibraryServiceClient;
 
 ============== file: src/v1/library_service_client.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*!
  * @module LibraryServiceClient
@@ -2825,21 +2819,20 @@ module.exports = LibraryServiceClient;
 }
 
 ============== file: test/gapic-v1.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -168,6 +168,9 @@ describe('LibraryServiceSmokeTest', () => {
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ */
+
 'use strict';
 
 const VERSION = require('../package.json').version;
@@ -217,9 +220,6 @@ module.exports.LibraryServiceClient = LibraryServiceClient;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*!
- * @module LibraryServiceClient
- */
 'use strict';
 
 const gapicConfig = require('./library_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -169,7 +169,7 @@ describe('LibraryServiceSmokeTest', () => {
 // limitations under the License.
 
 /**
- * @module library
+ * @module @google-cloud/library
  */
 
 'use strict';

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -169,6 +169,7 @@ describe('LibraryServiceSmokeTest', () => {
 // limitations under the License.
 
 /**
+ * @module library
  */
 
 'use strict';
@@ -233,10 +234,10 @@ const protobuf = require('protobufjs');
  * resources and Book resources in the library. It defines the following
  * resource model:
  *
- * - The API has a collection of {@link Shelf}
+ * - The API has a collection of Shelf
  *   resources, named ``bookShelves/*``
  *
- * - Each Shelf has a collection of {@link Book}
+ * - Each Shelf has a collection of Book
  *   resources, named `bookShelves/*/books/*`
  *
  * Check out [cloud docs!](https://cloud.google.com/library/example/link).

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -94,6 +94,7 @@ $ npm install --save @google-cloud/multiple-services
 // limitations under the License.
 
 /**
+ * @module multiple_services
  */
 
 'use strict';

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -133,6 +133,7 @@ const path = require('path');
 
 /**
  * @class
+ * @memberof v1
  */
 class DecrementerServiceClient {
   /**
@@ -356,6 +357,7 @@ const path = require('path');
 
 /**
  * @class
+ * @memberof v1
  */
 class IncrementerServiceClient {
   /**

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -79,21 +79,19 @@ $ npm install --save @google-cloud/multiple-services
 }
 
 ============== file: src/index.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 'use strict';
 
@@ -109,21 +107,19 @@ module.exports.v1 = gapic.v1;
 module.exports.default = Object.assign({}, module.exports);
 
 ============== file: src/v1/decrementer_service_client.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*!
  * @module DecrementerServiceClient
@@ -334,21 +330,19 @@ module.exports = DecrementerServiceClient;
 }
 
 ============== file: src/v1/incrementer_service_client.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*!
  * @module IncrementerServiceClient
@@ -559,21 +553,20 @@ module.exports = IncrementerServiceClient;
 }
 
 ============== file: src/v1/index.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const IncrementerServiceClient = require('./incrementer_service_client');
@@ -583,21 +576,20 @@ module.exports.IncrementerServiceClient = IncrementerServiceClient;
 module.exports.DecrementerServiceClient = DecrementerServiceClient;
 
 ============== file: test/gapic-v1.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -93,6 +93,9 @@ $ npm install --save @google-cloud/multiple-services
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ */
+
 'use strict';
 
 const VERSION = require('../package.json').version;
@@ -121,9 +124,6 @@ module.exports.default = Object.assign({}, module.exports);
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*!
- * @module DecrementerServiceClient
- */
 'use strict';
 
 const gapicConfig = require('./decrementer_service_client_config');
@@ -345,9 +345,6 @@ module.exports = DecrementerServiceClient;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*!
- * @module IncrementerServiceClient
- */
 'use strict';
 
 const gapicConfig = require('./incrementer_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -94,7 +94,7 @@ $ npm install --save @google-cloud/multiple-services
 // limitations under the License.
 
 /**
- * @module multiple_services
+ * @module @google-cloud/multiple-services
  */
 
 'use strict';

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -109,7 +109,7 @@ module.exports.v1 = gapic.v1;
 module.exports.default = Object.assign({}, module.exports);
 
 ============== file: src/v1/decrementer_service_client.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -125,6 +125,9 @@ module.exports.default = Object.assign({}, module.exports);
  * limitations under the License.
  */
 
+/*!
+ * @module DecrementerServiceClient
+ */
 'use strict';
 
 const gapicConfig = require('./decrementer_service_client_config');
@@ -331,7 +334,7 @@ module.exports = DecrementerServiceClient;
 }
 
 ============== file: src/v1/incrementer_service_client.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -347,6 +350,9 @@ module.exports = DecrementerServiceClient;
  * limitations under the License.
  */
 
+/*!
+ * @module IncrementerServiceClient
+ */
 'use strict';
 
 const gapicConfig = require('./incrementer_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -112,9 +112,6 @@ module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/*!
- * @module NoTemplatesApiServiceClient
- */
 'use strict';
 
 const gapicConfig = require('./no_templates_api_service_client_config');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -124,6 +124,7 @@ const path = require('path');
 
 /**
  * @class
+ * @memberof v1
  */
 class NoTemplatesApiServiceClient {
   /**

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -77,21 +77,20 @@ $ npm install --save example
 }
 
 ============== file: src/index.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const NoTemplatesApiServiceClient = require('./no_templates_api_service_client');
@@ -99,21 +98,19 @@ const NoTemplatesApiServiceClient = require('./no_templates_api_service_client')
 module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
 
 ============== file: src/v1/no_templates_api_service_client.js ==============
-/**
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /*!
  * @module NoTemplatesApiServiceClient
@@ -329,21 +326,20 @@ module.exports = NoTemplatesApiServiceClient;
 }
 
 ============== file: test/gapic.js ==============
-/*
- * Copyright 2017, Google Inc. All rights reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2017, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 'use strict';
 
 const assert = require('assert');

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -99,7 +99,7 @@ const NoTemplatesApiServiceClient = require('./no_templates_api_service_client')
 module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
 
 ============== file: src/v1/no_templates_api_service_client.js ==============
-/*
+/**
  * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,6 +115,9 @@ module.exports.NoTemplatesApiServiceClient = NoTemplatesApiServiceClient;
  * limitations under the License.
  */
 
+/*!
+ * @module NoTemplatesApiServiceClient
+ */
 'use strict';
 
 const gapicConfig = require('./no_templates_api_service_client_config');


### PR DESCRIPTION
This makes docs updates pointed out by @jmdobry in googleapis/nodejs-language#2:

  * [x] Changing `@member` to `@memberof`
  * [x] Namespacing the service client classes
  * [x] Providing `@memberof` on enums.
  * [x] Fixing enum links.
  * [x] Providing `@module` on index.js (currently wrong).

It also changes the license documentation to `//` comments.