### PR TITLE
Add bogus credentials in Node.js unit tests.

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -358,9 +358,15 @@
 
 @private clientInit(testClass, apiTest)
   @if apiTest.fileHeader.hasVersion
-    var client = new {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}();
+    var client = new {@apiTest.localPackageName}Module.{@apiTest.fileHeader.version}.{@testClass.apiClassName}({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
   @else
-    var client = new {@apiTest.localPackageName}Module.{@testClass.apiClassName}();
+    var client = new {@apiTest.localPackageName}Module.{@testClass.apiClassName}({
+      credentials: {client_email: 'bogus', private_key: 'bogus'},
+      projectId: 'bogus',
+    });
   @end
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -4949,7 +4949,10 @@ error.code = FAKE_STATUS_CODE;
 describe('LibraryServiceClient', () => {
   describe('createShelf', () => {
     it('invokes createShelf without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -4981,7 +4984,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes createShelf with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -5007,7 +5013,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getShelf', () => {
     it('invokes getShelf without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5041,7 +5050,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getShelf with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5069,7 +5081,10 @@ describe('LibraryServiceClient', () => {
 
   describe('listShelves', () => {
     it('invokes listShelves without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -5097,7 +5112,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes listShelves with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -5120,7 +5138,10 @@ describe('LibraryServiceClient', () => {
 
   describe('deleteShelf', () => {
     it('invokes deleteShelf without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5138,7 +5159,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes deleteShelf with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5163,7 +5187,10 @@ describe('LibraryServiceClient', () => {
 
   describe('mergeShelves', () => {
     it('invokes mergeShelves without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5197,7 +5224,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes mergeShelves with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5225,7 +5255,10 @@ describe('LibraryServiceClient', () => {
 
   describe('createBook', () => {
     it('invokes createBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5261,7 +5294,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes createBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5289,7 +5325,10 @@ describe('LibraryServiceClient', () => {
 
   describe('publishSeries', () => {
     it('invokes publishSeries without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -5325,7 +5364,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes publishSeries with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -5358,7 +5400,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBook', () => {
     it('invokes getBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5392,7 +5437,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5418,7 +5466,10 @@ describe('LibraryServiceClient', () => {
 
   describe('listBooks', () => {
     it('invokes listBooks without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5449,7 +5500,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes listBooks with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -5475,7 +5529,10 @@ describe('LibraryServiceClient', () => {
 
   describe('deleteBook', () => {
     it('invokes deleteBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5493,7 +5550,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes deleteBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5518,7 +5578,10 @@ describe('LibraryServiceClient', () => {
 
   describe('updateBook', () => {
     it('invokes updateBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5554,7 +5617,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes updateBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5582,7 +5648,10 @@ describe('LibraryServiceClient', () => {
 
   describe('moveBook', () => {
     it('invokes moveBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5618,7 +5687,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes moveBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5646,7 +5718,10 @@ describe('LibraryServiceClient', () => {
 
   describe('listStrings', () => {
     it('invokes listStrings without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -5674,7 +5749,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes listStrings with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -5697,7 +5775,10 @@ describe('LibraryServiceClient', () => {
 
   describe('addComments', () => {
     it('invokes addComments without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5725,7 +5806,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes addComments with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5760,7 +5844,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBookFromArchive', () => {
     it('invokes getBookFromArchive without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
@@ -5794,7 +5881,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBookFromArchive with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
@@ -5820,7 +5910,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBookFromAnywhere', () => {
     it('invokes getBookFromAnywhere without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5856,7 +5949,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBookFromAnywhere with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5884,7 +5980,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBookFromAbsolutelyAnywhere', () => {
     it('invokes getBookFromAbsolutelyAnywhere without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5918,7 +6017,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBookFromAbsolutelyAnywhere with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5944,7 +6046,10 @@ describe('LibraryServiceClient', () => {
 
   describe('updateBookIndex', () => {
     it('invokes updateBookIndex without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5967,7 +6072,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes updateBookIndex with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -5997,7 +6105,10 @@ describe('LibraryServiceClient', () => {
 
   describe('streamShelves', () => {
     it('invokes streamShelves without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -6025,7 +6136,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes streamShelves with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -6049,7 +6163,10 @@ describe('LibraryServiceClient', () => {
 
   describe('streamBooks', () => {
     it('invokes streamBooks without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -6085,7 +6202,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes streamBooks with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -6112,7 +6232,10 @@ describe('LibraryServiceClient', () => {
 
   describe('discussBook', () => {
     it('invokes discussBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -6142,7 +6265,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes discussBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -6167,7 +6293,10 @@ describe('LibraryServiceClient', () => {
 
   describe('findRelatedBooks', () => {
     it('invokes findRelatedBooks without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -6201,7 +6330,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes findRelatedBooks with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -6230,7 +6362,10 @@ describe('LibraryServiceClient', () => {
 
   describe('addTag', () => {
     it('invokes addTag without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6257,7 +6392,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes addTag with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6285,7 +6423,10 @@ describe('LibraryServiceClient', () => {
 
   describe('addLabel', () => {
     it('invokes addLabel without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6312,7 +6453,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes addLabel with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6340,7 +6484,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBigBook', function() {
     it('invokes getBigBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6375,7 +6522,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBigBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6399,7 +6549,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('has longrunning decoder functions', () => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
       assert(client._descriptors.longrunning.getBigBook.responseDecoder instanceof Function);
       assert(client._descriptors.longrunning.getBigBook.metadataDecoder instanceof Function);
     });
@@ -6407,7 +6560,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBigNothing', function() {
     it('invokes getBigNothing without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6433,7 +6589,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBigNothing with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -6457,7 +6616,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('has longrunning decoder functions', () => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
       assert(client._descriptors.longrunning.getBigNothing.responseDecoder instanceof Function);
       assert(client._descriptors.longrunning.getBigNothing.metadataDecoder instanceof Function);
     });
@@ -6465,7 +6627,10 @@ describe('LibraryServiceClient', () => {
 
   describe('testOptionalRequiredFlatteningParams', () => {
     it('invokes testOptionalRequiredFlatteningParams without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var requiredSingularInt32 = -72313594;
@@ -6542,7 +6707,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes testOptionalRequiredFlatteningParams with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var requiredSingularInt32 = -72313594;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -2915,7 +2915,10 @@ error.code = FAKE_STATUS_CODE;
 describe('LibraryServiceClient', () => {
   describe('createShelf', () => {
     it('invokes createShelf without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -2947,7 +2950,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes createShelf with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -2973,7 +2979,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getShelf', () => {
     it('invokes getShelf without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3007,7 +3016,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getShelf with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3035,7 +3047,10 @@ describe('LibraryServiceClient', () => {
 
   describe('listShelves', () => {
     it('invokes listShelves without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -3063,7 +3078,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes listShelves with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -3086,7 +3104,10 @@ describe('LibraryServiceClient', () => {
 
   describe('deleteShelf', () => {
     it('invokes deleteShelf without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3104,7 +3125,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes deleteShelf with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3129,7 +3153,10 @@ describe('LibraryServiceClient', () => {
 
   describe('mergeShelves', () => {
     it('invokes mergeShelves without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3163,7 +3190,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes mergeShelves with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3191,7 +3221,10 @@ describe('LibraryServiceClient', () => {
 
   describe('createBook', () => {
     it('invokes createBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3227,7 +3260,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes createBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3255,7 +3291,10 @@ describe('LibraryServiceClient', () => {
 
   describe('publishSeries', () => {
     it('invokes publishSeries without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -3291,7 +3330,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes publishSeries with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var shelf = {};
@@ -3324,7 +3366,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBook', () => {
     it('invokes getBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3358,7 +3403,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3384,7 +3432,10 @@ describe('LibraryServiceClient', () => {
 
   describe('listBooks', () => {
     it('invokes listBooks without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3415,7 +3466,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes listBooks with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.shelfPath('[SHELF_ID]');
@@ -3441,7 +3495,10 @@ describe('LibraryServiceClient', () => {
 
   describe('deleteBook', () => {
     it('invokes deleteBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3459,7 +3516,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes deleteBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3484,7 +3544,10 @@ describe('LibraryServiceClient', () => {
 
   describe('updateBook', () => {
     it('invokes updateBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3520,7 +3583,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes updateBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3548,7 +3614,10 @@ describe('LibraryServiceClient', () => {
 
   describe('moveBook', () => {
     it('invokes moveBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3584,7 +3653,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes moveBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3612,7 +3684,10 @@ describe('LibraryServiceClient', () => {
 
   describe('listStrings', () => {
     it('invokes listStrings without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -3640,7 +3715,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes listStrings with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -3663,7 +3741,10 @@ describe('LibraryServiceClient', () => {
 
   describe('addComments', () => {
     it('invokes addComments without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3691,7 +3772,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes addComments with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3726,7 +3810,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBookFromArchive', () => {
     it('invokes getBookFromArchive without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
@@ -3760,7 +3847,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBookFromArchive with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.archivedBookPath('[ARCHIVE_PATH]', '[BOOK_ID]');
@@ -3786,7 +3876,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBookFromAnywhere', () => {
     it('invokes getBookFromAnywhere without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3822,7 +3915,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBookFromAnywhere with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3850,7 +3946,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBookFromAbsolutelyAnywhere', () => {
     it('invokes getBookFromAbsolutelyAnywhere without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3884,7 +3983,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBookFromAbsolutelyAnywhere with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3910,7 +4012,10 @@ describe('LibraryServiceClient', () => {
 
   describe('updateBookIndex', () => {
     it('invokes updateBookIndex without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3933,7 +4038,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes updateBookIndex with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -3963,7 +4071,10 @@ describe('LibraryServiceClient', () => {
 
   describe('streamShelves', () => {
     it('invokes streamShelves without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -3991,7 +4102,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes streamShelves with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -4015,7 +4129,10 @@ describe('LibraryServiceClient', () => {
 
   describe('streamBooks', () => {
     it('invokes streamBooks without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -4051,7 +4168,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes streamBooks with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -4078,7 +4198,10 @@ describe('LibraryServiceClient', () => {
 
   describe('discussBook', () => {
     it('invokes discussBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -4108,7 +4231,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes discussBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var name = 'name3373707';
@@ -4133,7 +4259,10 @@ describe('LibraryServiceClient', () => {
 
   describe('findRelatedBooks', () => {
     it('invokes findRelatedBooks without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -4167,7 +4296,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes findRelatedBooks with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var namesElement = 'namesElement-249113339';
@@ -4196,7 +4328,10 @@ describe('LibraryServiceClient', () => {
 
   describe('addTag', () => {
     it('invokes addTag without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4223,7 +4358,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes addTag with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4251,7 +4389,10 @@ describe('LibraryServiceClient', () => {
 
   describe('addLabel', () => {
     it('invokes addLabel without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4278,7 +4419,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes addLabel with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedResource = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4306,7 +4450,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBigBook', function() {
     it('invokes getBigBook without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4341,7 +4488,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBigBook with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4365,7 +4515,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('has longrunning decoder functions', () => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
       assert(client._descriptors.longrunning.getBigBook.responseDecoder instanceof Function);
       assert(client._descriptors.longrunning.getBigBook.metadataDecoder instanceof Function);
     });
@@ -4373,7 +4526,10 @@ describe('LibraryServiceClient', () => {
 
   describe('getBigNothing', function() {
     it('invokes getBigNothing without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4399,7 +4555,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes getBigNothing with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var formattedName = client.bookPath('[SHELF_ID]', '[BOOK_ID]');
@@ -4423,7 +4582,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('has longrunning decoder functions', () => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
       assert(client._descriptors.longrunning.getBigNothing.responseDecoder instanceof Function);
       assert(client._descriptors.longrunning.getBigNothing.metadataDecoder instanceof Function);
     });
@@ -4431,7 +4593,10 @@ describe('LibraryServiceClient', () => {
 
   describe('testOptionalRequiredFlatteningParams', () => {
     it('invokes testOptionalRequiredFlatteningParams without error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var requiredSingularInt32 = -72313594;
@@ -4508,7 +4673,10 @@ describe('LibraryServiceClient', () => {
     });
 
     it('invokes testOptionalRequiredFlatteningParams with error', done => {
-      var client = new libraryModule.v1.LibraryServiceClient();
+      var client = new libraryModule.v1.LibraryServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var requiredSingularInt32 = -72313594;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_multiple_services.baseline
@@ -682,7 +682,10 @@ error.code = FAKE_STATUS_CODE;
 describe('IncrementerServiceClient', () => {
   describe('increment', () => {
     it('invokes increment without error', done => {
-      var client = new multipleServicesModule.v1.IncrementerServiceClient();
+      var client = new multipleServicesModule.v1.IncrementerServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -697,7 +700,10 @@ describe('IncrementerServiceClient', () => {
     });
 
     it('invokes increment with error', done => {
-      var client = new multipleServicesModule.v1.IncrementerServiceClient();
+      var client = new multipleServicesModule.v1.IncrementerServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -721,7 +727,10 @@ describe('IncrementerServiceClient', () => {
 describe('DecrementerServiceClient', () => {
   describe('decrement', () => {
     it('invokes decrement without error', done => {
-      var client = new multipleServicesModule.v1.DecrementerServiceClient();
+      var client = new multipleServicesModule.v1.DecrementerServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -736,7 +745,10 @@ describe('DecrementerServiceClient', () => {
     });
 
     it('invokes decrement with error', done => {
-      var client = new multipleServicesModule.v1.DecrementerServiceClient();
+      var client = new multipleServicesModule.v1.DecrementerServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_no_path_templates.baseline
@@ -359,7 +359,10 @@ error.code = FAKE_STATUS_CODE;
 describe('NoTemplatesApiServiceClient', () => {
   describe('increment', () => {
     it('invokes increment without error', done => {
-      var client = new exampleModule.NoTemplatesApiServiceClient();
+      var client = new exampleModule.NoTemplatesApiServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};
@@ -374,7 +377,10 @@ describe('NoTemplatesApiServiceClient', () => {
     });
 
     it('invokes increment with error', done => {
-      var client = new exampleModule.NoTemplatesApiServiceClient();
+      var client = new exampleModule.NoTemplatesApiServiceClient({
+        credentials: {client_email: 'bogus', private_key: 'bogus'},
+        projectId: 'bogus',
+      });
 
       // Mock request
       var request = {};


### PR DESCRIPTION
This stops the [promise rejections](https://circleci.com/gh/googleapis/nodejs-language/223) (click in to the actual test run to see them) in environments without ADC.