### PR TITLE
Ruby: Disambiguate mock credentials classes in tests.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -43,6 +43,7 @@ import com.google.api.codegen.viewmodel.ServiceMethodType;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.model.EnumType;
 import com.google.api.tools.framework.model.Field;
+import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.ProtoFile;
@@ -1087,6 +1088,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   public String getStreamTypeName(GrpcStreamingConfig.GrpcStreamingType type) {
     return getNotImplementedString("SurfaceNamer.getStreamTypeName");
+  }
+
+  public String getMockCredentialsClassName(Interface anInterface) {
+    return getNotImplementedString("SurfaceNamer.getMockCredentialsClassName");
   }
 
   public String getFullyQualifiedCredentialsClassName() {

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
@@ -144,6 +144,7 @@ public class RubyGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .apiHasLongRunningMethods(context.getInterfaceConfig().hasLongRunningOperations())
         .missingDefaultServiceAddress(!context.getInterfaceConfig().hasDefaultServiceAddress())
         .missingDefaultServiceScopes(!context.getInterfaceConfig().hasDefaultServiceScopes())
+        .mockCredentialsClassName(namer.getMockCredentialsClassName(context.getInterface()))
         .fullyQualifiedCredentialsClassName(namer.getFullyQualifiedCredentialsClassName())
         .clientInitOptionalParams(clientInitOptionalParams.build())
         .mockServices(ImmutableList.<MockServiceUsageView>of())

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -40,6 +40,7 @@ import com.google.api.codegen.util.VersionMatcher;
 import com.google.api.codegen.util.ruby.RubyCommentReformatter;
 import com.google.api.codegen.util.ruby.RubyNameFormatter;
 import com.google.api.codegen.util.ruby.RubyTypeTable;
+import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Joiner;
@@ -221,6 +222,11 @@ public class RubySurfaceNamer extends SurfaceNamer {
   @Override
   public String getRequestTypeName(ImportTypeTable typeTable, TypeRef type) {
     return ((ModelTypeTable) typeTable).getFullNameFor(type);
+  }
+
+  @Override
+  public String getMockCredentialsClassName(Interface anInterface) {
+    return String.format("Mock%sCredentials", anInterface.getSimpleName());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
@@ -50,6 +50,9 @@ public abstract class ClientTestClassView {
   public abstract String apiVersion();
 
   @Nullable
+  public abstract String mockCredentialsClassName();
+
+  @Nullable
   public abstract String fullyQualifiedCredentialsClassName();
 
   @Nullable
@@ -86,6 +89,8 @@ public abstract class ClientTestClassView {
     public abstract Builder missingDefaultServiceScopes(boolean val);
 
     public abstract Builder apiVersion(String val);
+
+    public abstract Builder mockCredentialsClassName(String val);
 
     public abstract Builder fullyQualifiedCredentialsClassName(String val);
 

--- a/src/main/resources/com/google/api/codegen/ruby/test.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/test.snip
@@ -5,7 +5,7 @@
 @snippet generate(apiTest)
   {@header(apiTest.fileHeader)}
 
-  {@helpers(apiTest.testClass.fullyQualifiedCredentialsClassName)}
+  {@helpers(apiTest.testClass)}
 
   {@testClass(apiTest.apiVersion, apiTest.testClass)}
 @end
@@ -20,7 +20,7 @@
   {@importList(fileHeader.importSection.appImports)}
 @end
 
-@private helpers(credentialsClassName)
+@private helpers(testClass)
   class CustomTestError < StandardError; end
 
   @# Mock for the GRPC::ClientStub class.
@@ -52,7 +52,7 @@
     end
   end
   
-  class MockCredentialsClass < {@credentialsClassName}
+  class {@testClass.mockCredentialsClassName} < {@testClass.fullyQualifiedCredentialsClassName}
     def initialize(method_name)
       @@method_name = method_name
     end
@@ -140,7 +140,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -176,7 +176,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -220,7 +220,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -256,7 +256,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -289,7 +289,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -322,7 +322,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -356,7 +356,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -385,7 +385,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -413,7 +413,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     @# Mock auth layer
-    {@mockAuth(test.clientMethodName)}
+    {@mockAuth(test.clientMethodName, testClass.mockCredentialsClassName)}
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
       {@testClass.fullyQualifiedCredentialsClassName}.stub(:default, mock_credentials) do
@@ -529,8 +529,8 @@
   end
 @end
 
-@private mockAuth(methodName)
-  mock_credentials = MockCredentialsClass.new("{@methodName}")
+@private mockAuth(methodName, mockCredentialsClassName)
+  mock_credentials = {@mockCredentialsClassName}.new("{@methodName}")
 @end
 
 @private requestAsserts(test)

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -4252,7 +4252,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockCredentialsClass < Library::Credentials
+class MockLibraryServiceCredentials < Library::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -4294,7 +4294,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("create_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4322,7 +4322,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("create_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4369,7 +4369,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("get_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4399,7 +4399,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("get_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4435,7 +4435,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("list_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4461,7 +4461,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("list_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4495,7 +4495,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4523,7 +4523,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4570,7 +4570,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("merge_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("merge_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4600,7 +4600,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("merge_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("merge_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4649,7 +4649,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_book")
+      mock_credentials = MockLibraryServiceCredentials.new("create_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4679,7 +4679,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_book")
+      mock_credentials = MockLibraryServiceCredentials.new("create_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4727,7 +4727,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("publish_series")
+      mock_credentials = MockLibraryServiceCredentials.new("publish_series")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4767,7 +4767,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("publish_series")
+      mock_credentials = MockLibraryServiceCredentials.new("publish_series")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4818,7 +4818,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4846,7 +4846,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4887,7 +4887,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_books")
+      mock_credentials = MockLibraryServiceCredentials.new("list_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4918,7 +4918,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_books")
+      mock_credentials = MockLibraryServiceCredentials.new("list_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4952,7 +4952,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_book")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4980,7 +4980,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_book")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5029,7 +5029,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5059,7 +5059,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5108,7 +5108,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("move_book")
+      mock_credentials = MockLibraryServiceCredentials.new("move_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5138,7 +5138,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("move_book")
+      mock_credentials = MockLibraryServiceCredentials.new("move_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5174,7 +5174,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_strings")
+      mock_credentials = MockLibraryServiceCredentials.new("list_strings")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5200,7 +5200,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_strings")
+      mock_credentials = MockLibraryServiceCredentials.new("list_strings")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5247,7 +5247,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_comments")
+      mock_credentials = MockLibraryServiceCredentials.new("add_comments")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5288,7 +5288,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_comments")
+      mock_credentials = MockLibraryServiceCredentials.new("add_comments")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5335,7 +5335,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_archive")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5363,7 +5363,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_archive")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5412,7 +5412,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5442,7 +5442,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5489,7 +5489,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_absolutely_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5517,7 +5517,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_absolutely_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5556,7 +5556,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book_index")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book_index")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5593,7 +5593,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book_index")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book_index")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5632,7 +5632,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5656,7 +5656,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5703,7 +5703,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_books")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5732,7 +5732,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_books")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5774,7 +5774,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("discuss_book")
+      mock_credentials = MockLibraryServiceCredentials.new("discuss_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5805,7 +5805,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("discuss_book")
+      mock_credentials = MockLibraryServiceCredentials.new("discuss_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5847,7 +5847,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+      mock_credentials = MockLibraryServiceCredentials.new("monolog_about_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5877,7 +5877,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+      mock_credentials = MockLibraryServiceCredentials.new("monolog_about_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5921,7 +5921,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("find_related_books")
+      mock_credentials = MockLibraryServiceCredentials.new("find_related_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5955,7 +5955,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("find_related_books")
+      mock_credentials = MockLibraryServiceCredentials.new("find_related_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -5995,7 +5995,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_tag")
+      mock_credentials = MockLibraryServiceCredentials.new("add_tag")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6025,7 +6025,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_tag")
+      mock_credentials = MockLibraryServiceCredentials.new("add_tag")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6065,7 +6065,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_label")
+      mock_credentials = MockLibraryServiceCredentials.new("add_label")
 
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6095,7 +6095,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_label")
+      mock_credentials = MockLibraryServiceCredentials.new("add_label")
 
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6149,7 +6149,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6187,7 +6187,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6216,7 +6216,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6261,7 +6261,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_nothing")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6299,7 +6299,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_nothing")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6328,7 +6328,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_nothing")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6421,7 +6421,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+      mock_credentials = MockLibraryServiceCredentials.new("test_optional_required_flattening_params")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -6532,7 +6532,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+      mock_credentials = MockLibraryServiceCredentials.new("test_optional_required_flattening_params")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -2706,7 +2706,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockCredentialsClass < Library::Credentials
+class MockLibraryServiceCredentials < Library::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -2748,7 +2748,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("create_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2776,7 +2776,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("create_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2823,7 +2823,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("get_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2853,7 +2853,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("get_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2889,7 +2889,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("list_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2915,7 +2915,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("list_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2949,7 +2949,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -2977,7 +2977,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_shelf")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_shelf")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3024,7 +3024,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("merge_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("merge_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3054,7 +3054,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("merge_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("merge_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3103,7 +3103,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_book")
+      mock_credentials = MockLibraryServiceCredentials.new("create_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3133,7 +3133,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("create_book")
+      mock_credentials = MockLibraryServiceCredentials.new("create_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3181,7 +3181,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("publish_series")
+      mock_credentials = MockLibraryServiceCredentials.new("publish_series")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3221,7 +3221,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("publish_series")
+      mock_credentials = MockLibraryServiceCredentials.new("publish_series")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3272,7 +3272,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3300,7 +3300,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3341,7 +3341,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_books")
+      mock_credentials = MockLibraryServiceCredentials.new("list_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3372,7 +3372,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_books")
+      mock_credentials = MockLibraryServiceCredentials.new("list_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3406,7 +3406,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_book")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3434,7 +3434,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_book")
+      mock_credentials = MockLibraryServiceCredentials.new("delete_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3483,7 +3483,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3513,7 +3513,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3562,7 +3562,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("move_book")
+      mock_credentials = MockLibraryServiceCredentials.new("move_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3592,7 +3592,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("move_book")
+      mock_credentials = MockLibraryServiceCredentials.new("move_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3628,7 +3628,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_strings")
+      mock_credentials = MockLibraryServiceCredentials.new("list_strings")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3654,7 +3654,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_strings")
+      mock_credentials = MockLibraryServiceCredentials.new("list_strings")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3701,7 +3701,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_comments")
+      mock_credentials = MockLibraryServiceCredentials.new("add_comments")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3742,7 +3742,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_comments")
+      mock_credentials = MockLibraryServiceCredentials.new("add_comments")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3789,7 +3789,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_archive")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3817,7 +3817,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_archive")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3866,7 +3866,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3896,7 +3896,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3943,7 +3943,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_absolutely_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -3971,7 +3971,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+      mock_credentials = MockLibraryServiceCredentials.new("get_book_from_absolutely_anywhere")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4010,7 +4010,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book_index")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book_index")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4047,7 +4047,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("update_book_index")
+      mock_credentials = MockLibraryServiceCredentials.new("update_book_index")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4086,7 +4086,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4110,7 +4110,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_shelves")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_shelves")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4157,7 +4157,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_books")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4186,7 +4186,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("stream_books")
+      mock_credentials = MockLibraryServiceCredentials.new("stream_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4228,7 +4228,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("discuss_book")
+      mock_credentials = MockLibraryServiceCredentials.new("discuss_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4259,7 +4259,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("discuss_book")
+      mock_credentials = MockLibraryServiceCredentials.new("discuss_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4301,7 +4301,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+      mock_credentials = MockLibraryServiceCredentials.new("monolog_about_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4331,7 +4331,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+      mock_credentials = MockLibraryServiceCredentials.new("monolog_about_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4375,7 +4375,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("find_related_books")
+      mock_credentials = MockLibraryServiceCredentials.new("find_related_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4409,7 +4409,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("find_related_books")
+      mock_credentials = MockLibraryServiceCredentials.new("find_related_books")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4449,7 +4449,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_tag")
+      mock_credentials = MockLibraryServiceCredentials.new("add_tag")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4479,7 +4479,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_tag")
+      mock_credentials = MockLibraryServiceCredentials.new("add_tag")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4519,7 +4519,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_label")
+      mock_credentials = MockLibraryServiceCredentials.new("add_label")
 
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4549,7 +4549,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("add_label")
+      mock_credentials = MockLibraryServiceCredentials.new("add_label")
 
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4603,7 +4603,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4641,7 +4641,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4670,7 +4670,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_book")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_book")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4715,7 +4715,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_nothing")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4753,7 +4753,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_nothing")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4782,7 +4782,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+      mock_credentials = MockLibraryServiceCredentials.new("get_big_nothing")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4875,7 +4875,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+      mock_credentials = MockLibraryServiceCredentials.new("test_optional_required_flattening_params")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do
@@ -4986,7 +4986,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+      mock_credentials = MockLibraryServiceCredentials.new("test_optional_required_flattening_params")
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
         Library::Credentials.stub(:default, mock_credentials) do

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -1120,7 +1120,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockCredentialsClass < Google::Auth::Credentials
+class MockOperationsCredentials < Google::Auth::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -1157,7 +1157,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:get_operation, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_operation")
+      mock_credentials = MockOperationsCredentials.new("get_operation")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1185,7 +1185,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:get_operation, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("get_operation")
+      mock_credentials = MockOperationsCredentials.new("get_operation")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1228,7 +1228,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:list_operations, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_operations")
+      mock_credentials = MockOperationsCredentials.new("list_operations")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1261,7 +1261,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:list_operations, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("list_operations")
+      mock_credentials = MockOperationsCredentials.new("list_operations")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1295,7 +1295,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:cancel_operation, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("cancel_operation")
+      mock_credentials = MockOperationsCredentials.new("cancel_operation")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1323,7 +1323,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:cancel_operation, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("cancel_operation")
+      mock_credentials = MockOperationsCredentials.new("cancel_operation")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1357,7 +1357,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:delete_operation, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_operation")
+      mock_credentials = MockOperationsCredentials.new("delete_operation")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do
@@ -1385,7 +1385,7 @@ describe Google::Longrunning::OperationsClient do
       mock_stub = MockGrpcClientStub.new(:delete_operation, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("delete_operation")
+      mock_credentials = MockOperationsCredentials.new("delete_operation")
 
       Google::Longrunning::Operations::Stub.stub(:new, mock_stub) do
         Google::Auth::Credentials.stub(:default, mock_credentials) do

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -1299,7 +1299,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockCredentialsClass < Google::Example::Credentials
+class MockDecrementerServiceCredentials < Google::Example::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -1326,7 +1326,7 @@ describe Google::Example::V1::DecrementerServiceClient do
       mock_stub = MockGrpcClientStub.new(:decrement, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("decrement")
+      mock_credentials = MockDecrementerServiceCredentials.new("decrement")
 
       Google::Cloud::Example::V1::DecrementerService::Stub.stub(:new, mock_stub) do
         Google::Example::Credentials.stub(:default, mock_credentials) do
@@ -1349,7 +1349,7 @@ describe Google::Example::V1::DecrementerServiceClient do
       mock_stub = MockGrpcClientStub.new(:decrement, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("decrement")
+      mock_credentials = MockDecrementerServiceCredentials.new("decrement")
 
       Google::Cloud::Example::V1::DecrementerService::Stub.stub(:new, mock_stub) do
         Google::Example::Credentials.stub(:default, mock_credentials) do
@@ -1422,7 +1422,7 @@ class MockGrpcClientStub
   end
 end
 
-class MockCredentialsClass < Google::Example::Credentials
+class MockIncrementerServiceCredentials < Google::Example::Credentials
   def initialize(method_name)
     @method_name = method_name
   end
@@ -1449,7 +1449,7 @@ describe Google::Example::V1::IncrementerServiceClient do
       mock_stub = MockGrpcClientStub.new(:increment, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("increment")
+      mock_credentials = MockIncrementerServiceCredentials.new("increment")
 
       Google::Cloud::Example::V1::IncrementerService::Stub.stub(:new, mock_stub) do
         Google::Example::Credentials.stub(:default, mock_credentials) do
@@ -1472,7 +1472,7 @@ describe Google::Example::V1::IncrementerServiceClient do
       mock_stub = MockGrpcClientStub.new(:increment, mock_method)
 
       # Mock auth layer
-      mock_credentials = MockCredentialsClass.new("increment")
+      mock_credentials = MockIncrementerServiceCredentials.new("increment")
 
       Google::Cloud::Example::V1::IncrementerService::Stub.stub(:new, mock_stub) do
         Google::Example::Credentials.stub(:default, mock_credentials) do


### PR DESCRIPTION
Fixes #1643 