### PR TITLE
all: make SurfaceNamer use InterfaceConfig more

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -127,7 +127,7 @@ public class DynamicLangApiMethodTransformer {
 
     apiMethod.packageName(namer.getPackageName());
     apiMethod.packageHasMultipleServices(packageHasMultipleServices);
-    apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()));
+    apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()));
     apiMethod.apiVersion(namer.getApiWrapperModuleVersion());
     apiMethod.longRunningView(
         context.getMethodConfig().isLongRunningOperation()

--- a/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
@@ -41,7 +41,7 @@ public class IamResourceTransformer {
               .exampleName(
                   context
                       .getNamer()
-                      .getIamResourceGetterFunctionExampleName(context.getInterfaceModel(), field))
+                      .getIamResourceGetterFunctionExampleName(context.getInterfaceConfig(), field))
               .fieldName(context.getNamer().publicFieldName(Name.from(field.getSimpleName())))
               .resourceTypeName(resourceTypeName)
               .resourceConstructorName(context.getNamer().getTypeConstructor(resourceTypeName))

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -485,7 +485,7 @@ public class InitCodeTransformer {
             context
                 .getNamer()
                 .getFormatFunctionName(
-                    context.getInterfaceModel(), initValueConfig.getSingleResourceNameConfig()));
+                    context.getInterfaceConfig(), initValueConfig.getSingleResourceNameConfig()));
 
         List<String> varList =
             Lists.newArrayList(

--- a/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/MockServiceTransformer.java
@@ -42,7 +42,7 @@ public class MockServiceTransformer {
       interfaces.putAll(getGrpcInterfacesForService(model, productConfig, apiInterface));
     }
 
-    return new ArrayList(interfaces.values());
+    return new ArrayList<>(interfaces.values());
   }
 
   public Map<String, InterfaceModel> getGrpcInterfacesForService(

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -64,7 +64,7 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateView.Builder pathTemplate = PathTemplateView.newBuilder();
       pathTemplate.name(
-          context.getNamer().getPathTemplateName(context.getInterfaceModel(), resourceNameConfig));
+          context.getNamer().getPathTemplateName(context.getInterfaceConfig(), resourceNameConfig));
       pathTemplate.pattern(resourceNameConfig.getNamePattern());
       pathTemplates.add(pathTemplate.build());
     }
@@ -233,10 +233,10 @@ public class PathTemplateTransformer {
       FormatResourceFunctionView.Builder function =
           FormatResourceFunctionView.newBuilder()
               .entityName(resourceNameConfig.getEntityName())
-              .name(namer.getFormatFunctionName(apiInterface, resourceNameConfig))
-              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+              .name(namer.getFormatFunctionName(interfaceConfig, resourceNameConfig))
+              .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
               .pathTemplateGetterName(
-                  namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+                  namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
       List<ResourceIdParamView> resourceIdParams = new ArrayList<>();
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
@@ -272,9 +272,9 @@ public class PathTemplateTransformer {
             ParseResourceFunctionView.newBuilder()
                 .entityName(resourceNameConfig.getEntityName())
                 .name(namer.getParseFunctionName(var, resourceNameConfig))
-                .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+                .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
                 .pathTemplateGetterName(
-                    namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+                    namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
                 .entityNameParamName(namer.getEntityNameParamName(resourceNameConfig))
                 .outputResourceId(var);
         functions.add(function.build());
@@ -295,10 +295,10 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateGetterFunctionView.Builder function =
           PathTemplateGetterFunctionView.newBuilder()
-              .name(namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+              .name(namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
               .resourceName(namer.getPathTemplateResourcePhraseName(resourceNameConfig))
               .entityName(namer.getEntityName(resourceNameConfig))
-              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+              .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
 
       List<PathTemplateArgumentView> args = new ArrayList<>();

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -72,7 +72,7 @@ public class StaticLangApiMethodTransformer {
         namer.getApiMethodName(
             context.getMethodModel(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel(), context.getMethodModel()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethodModel()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
 
@@ -109,7 +109,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel(), method));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), method));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
@@ -223,7 +223,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel(), method));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), method));
     methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     setStaticLangReturnTypeName(context, methodViewBuilder);
@@ -245,7 +245,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel(), method));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), method));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(method),
@@ -312,7 +312,7 @@ public class StaticLangApiMethodTransformer {
         context
             .getNamer()
             .getGrpcStreamingApiMethodExampleName(
-                context.getInterfaceModel(), context.getMethodModel()));
+                context.getInterfaceConfig(), context.getMethodModel()));
     setRequestObjectMethodFields(
         context, namer.getCallableMethodName(method), Synchronicity.Sync, methodViewBuilder);
     setStaticLangGrpcStreamingReturnTypeName(context, methodViewBuilder);
@@ -335,7 +335,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel(), method));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), method));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(method),
@@ -362,7 +362,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(method, context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterfaceModel(), method));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), method));
     methodViewBuilder.callableName(namer.getCallableName(method));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
@@ -815,7 +815,7 @@ public class StaticLangApiMethodTransformer {
         check.pathTemplateName(
             context
                 .getNamer()
-                .getPathTemplateName(context.getInterfaceModel(), resourceNameConfig));
+                .getPathTemplateName(context.getInterfaceConfig(), resourceNameConfig));
         check.paramName(context.getNamer().getVariableName(field));
         check.allowEmptyString(shouldAllowEmpty(context, field));
         check.validationMessageContext(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -165,23 +165,24 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Returns the service name exported by the package */
-  public String getPackageServiceName(InterfaceModel apiInterface) {
+  public String getPackageServiceName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getPackageServiceName");
   }
 
   /** Human-friendly name of this API interface */
-  public String getServicePhraseName(InterfaceModel apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).toPhrase();
+  public String getServicePhraseName(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName()).toPhrase();
   }
 
   /////////////////////////////////////// Constructors /////////////////////////////////////////////
 
   /**
-   * The name of the constructor for the apiInterface client. The client is VKit generated, not
-   * GRPC.
+   * The name of the constructor for the interfaceConfig.getInterfaceModel() client. The client is
+   * VKit generated, not GRPC.
    */
-  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
+    return publicClassName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "Client"));
   }
 
   /** Constructor name for the type with the given nickname. */
@@ -421,7 +422,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   ///////////////////////////////// Function & Callable names /////////////////////////////////////
 
   /** The function name to retrieve default client option */
-  public String getDefaultApiSettingsFunctionName(InterfaceModel apiInterface) {
+  public String getDefaultApiSettingsFunctionName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getDefaultClientOptionFunctionName");
   }
 
@@ -581,8 +582,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to retrieve default call option */
-  public String getDefaultCallSettingsFunctionName(InterfaceModel apiInterface) {
-    return publicMethodName(Name.upperCamel(apiInterface.getSimpleName(), "Settings"));
+  public String getDefaultCallSettingsFunctionName(InterfaceConfig interfaceConfig) {
+    return publicMethodName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "Settings"));
   }
 
   /** The name of the IAM resource getter function. */
@@ -726,8 +728,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the class that implements snippets for a particular proto interface. */
-  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ApiSnippets"));
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
+    return publicClassName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "ApiSnippets"));
   }
 
   /**
@@ -833,7 +836,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The imported name of the default client config. */
-  public String getClientConfigName(InterfaceModel apiInterface) {
+  public String getClientConfigName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getClientConfigName");
   }
 
@@ -952,8 +955,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The type name of call options */
-  public String getCallSettingsTypeName(InterfaceModel apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Settings"));
+  public String getCallSettingsTypeName(InterfaceConfig interfaceConfig) {
+    return publicClassName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "Settings"));
   }
 
   /** The name of the return type of the given grpc streaming method. */
@@ -1124,13 +1128,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * class.
    */
   public String getPathTemplateName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   /** The name of a getter function to get a particular path template for the given collection. */
   public String getPathTemplateNameGetter(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
         Name.from("get", resourceNameConfig.getEntityName(), "name", "template"));
   }
@@ -1142,7 +1146,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to format the entity for the given collection. */
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from("format", resourceNameConfig.getEntityName(), "name"));
   }
 
@@ -1210,7 +1214,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The path to the client config for the given interface. */
-  public String getClientConfigPath(InterfaceModel apiInterface) {
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getClientConfigPath");
   }
 
@@ -1463,8 +1467,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of example of the constructor for the service client. The client is VKit generated,
    * not GRPC.
    */
-  public String getApiWrapperClassConstructorExampleName(InterfaceModel apiInterface) {
-    return getApiWrapperClassConstructorName(apiInterface);
+  public String getApiWrapperClassConstructorExampleName(InterfaceConfig interfaceConfig) {
+    return getApiWrapperClassConstructorName(interfaceConfig);
   }
 
   /** The name of the example for the paged callable variant. */
@@ -1483,8 +1487,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the example for the method. */
-  public String getApiMethodExampleName(InterfaceModel apiInterface, MethodModel method) {
-    return getApiMethodName(Name.anyCamel(apiInterface.getSimpleName()), VisibilityConfig.PUBLIC);
+  public String getApiMethodExampleName(InterfaceConfig interfaceConfig, MethodModel method) {
+    return getApiMethodName(
+        Name.anyCamel(interfaceConfig.getInterfaceModel().getSimpleName()),
+        VisibilityConfig.PUBLIC);
   }
 
   /** The name of the example for the async variant of the given method. */
@@ -1497,18 +1503,18 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * method.
    */
   public String getGrpcStreamingApiMethodExampleName(
-      InterfaceModel apiInterface, MethodModel method) {
+      InterfaceConfig interfaceConfig, MethodModel method) {
     return getGrpcStreamingApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
   /** The example name of the IAM resource getter function. */
   public String getIamResourceGetterFunctionExampleName(
-      InterfaceModel apiInterface, FieldModel field) {
+      InterfaceConfig interfaceConfig, FieldModel field) {
     return getIamResourceGetterFunctionName(field);
   }
 
   /** The file name for the example of an API interface. */
-  public String getExampleFileName(InterfaceModel apiInterface) {
+  public String getExampleFileName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getExampleFileName");
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -168,7 +168,7 @@ public class TestCaseTransformer {
         .fullyQualifiedRequestTypeName(method.getInputTypeName(typeTable).getFullName())
         .fullyQualifiedResponseTypeName(fullyQualifiedResponseTypeName)
         .serviceConstructorName(
-            namer.getApiWrapperClassConstructorName(methodContext.getInterfaceModel()))
+            namer.getApiWrapperClassConstructorName(methodContext.getInterfaceConfig()))
         .fullyQualifiedServiceClassName(
             namer.getFullyQualifiedApiWrapperClassName(methodContext.getInterfaceConfig()))
         .fullyQualifiedAliasedServiceClassName(

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -91,7 +91,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
 
   private SnippetsFileView generateSnippets(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    String name = namer.getApiSnippetsClassName(context.getInterfaceModel());
+    String name = namer.getApiSnippetsClassName(context.getInterfaceConfig());
     SnippetsFileView.Builder snippetsBuilder = SnippetsFileView.newBuilder();
 
     snippetsBuilder.templateFileName(SNIPPETS_TEMPLATE_FILENAME);

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -210,9 +210,10 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
     return publicClassName(
-        Name.upperCamel("Generated", apiInterface.getSimpleName(), "ClientSnippets"));
+        Name.upperCamel(
+            "Generated", interfaceConfig.getInterfaceModel().getSimpleName(), "ClientSnippets"));
   }
 
   @Override
@@ -233,7 +234,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "template"));
   }
 
@@ -311,7 +312,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return getResourceTypeName(resourceNameConfig);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -133,17 +133,18 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     ApiModel model = context.getApiModel();
     ProtoInterfaceModel apiInterface = context.getInterfaceModel();
     GapicProductConfig productConfig = context.getProductConfig();
+    GapicInterfaceConfig interfaceConfig = context.getInterfaceConfig();
 
     view.templateFileName(API_TEMPLATE_FILENAME);
     view.serviceDoc(serviceTransformer.generateServiceDoc(context, null));
     view.domainLayerLocation(productConfig.getDomainLayerLocation());
     view.clientTypeName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    view.clientConstructorName(namer.getApiWrapperClassConstructorName(apiInterface));
-    view.defaultClientOptionFunctionName(namer.getDefaultApiSettingsFunctionName(apiInterface));
-    view.defaultCallOptionFunctionName(namer.getDefaultCallSettingsFunctionName(apiInterface));
-    view.callOptionsTypeName(namer.getCallSettingsTypeName(apiInterface));
+    view.clientConstructorName(namer.getApiWrapperClassConstructorName(interfaceConfig));
+    view.defaultClientOptionFunctionName(namer.getDefaultApiSettingsFunctionName(interfaceConfig));
+    view.defaultCallOptionFunctionName(namer.getDefaultCallSettingsFunctionName(interfaceConfig));
+    view.callOptionsTypeName(namer.getCallSettingsTypeName(interfaceConfig));
     view.serviceOriginalName(model.getTitle());
-    view.servicePhraseName(namer.getServicePhraseName(apiInterface));
+    view.servicePhraseName(namer.getServicePhraseName(interfaceConfig));
 
     String outputPath = pathMapper.getOutputPath(apiInterface.getFullName(), productConfig);
     String fileName = namer.getServiceFileName(context.getInterfaceConfig());
@@ -205,16 +206,18 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
     InterfaceModel apiInterface = context.getInterfaceModel();
     ProductConfig productConfig = context.getProductConfig();
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
 
     view.templateFileName(SAMPLE_TEMPLATE_FILENAME);
 
     String outputPath = pathMapper.getOutputPath(apiInterface.getFullName(), productConfig);
-    String fileName = namer.getExampleFileName(context.getInterfaceModel());
+    String fileName = namer.getExampleFileName(context.getInterfaceConfig());
     view.outputPath(outputPath + File.separator + fileName);
 
     view.clientTypeName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    view.clientConstructorName(namer.getApiWrapperClassConstructorName(apiInterface));
-    view.clientConstructorExampleName(namer.getApiWrapperClassConstructorExampleName(apiInterface));
+    view.clientConstructorName(namer.getApiWrapperClassConstructorName(interfaceConfig));
+    view.clientConstructorExampleName(
+        namer.getApiWrapperClassConstructorExampleName(interfaceConfig));
     view.apiMethods(generateApiMethods(context, context.getPublicMethods()));
     view.iamResources(iamResourceTransformer.generateIamResources(context));
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -64,9 +64,9 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(
-        getReducedServiceName(apiInterface.getSimpleName())
+        getReducedServiceName(interfaceConfig.getInterfaceModel().getSimpleName())
             .join(resourceNameConfig.getEntityName())
             .join("path")
             .join("template"));
@@ -74,15 +74,15 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateNameGetter(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
-    return getFormatFunctionName(apiInterface, resourceNameConfig);
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
+    return getFormatFunctionName(interfaceConfig, resourceNameConfig);
   }
 
   @Override
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
-        clientNamePrefix(apiInterface.getSimpleName())
+        clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName())
             .join(resourceNameConfig.getEntityName())
             .join("path"));
   }
@@ -190,25 +190,27 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getCallSettingsTypeName(InterfaceModel apiInterface) {
+  public String getCallSettingsTypeName(InterfaceConfig interfaceConfig) {
     return publicClassName(
-        clientNamePrefix(apiInterface.getSimpleName()).join("call").join("options"));
+        clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName())
+            .join("call")
+            .join("options"));
   }
 
   @Override
-  public String getDefaultApiSettingsFunctionName(InterfaceModel apiInterface) {
+  public String getDefaultApiSettingsFunctionName(InterfaceConfig interfaceConfig) {
     return privateMethodName(
         Name.from("default")
-            .join(clientNamePrefix(apiInterface.getSimpleName()))
+            .join(clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName()))
             .join("client")
             .join("options"));
   }
 
   @Override
-  public String getDefaultCallSettingsFunctionName(InterfaceModel apiInterface) {
+  public String getDefaultCallSettingsFunctionName(InterfaceConfig interfaceConfig) {
     return privateMethodName(
         Name.from("default")
-            .join(clientNamePrefix(apiInterface.getSimpleName()))
+            .join(clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName()))
             .join("call")
             .join("options"));
   }
@@ -224,29 +226,31 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
     return publicMethodName(
-        Name.from("new").join(clientNamePrefix(apiInterface.getSimpleName())).join("client"));
-  }
-
-  @Override
-  public String getApiWrapperClassConstructorExampleName(InterfaceModel apiInterface) {
-    return publicMethodName(
-        Name.from("example")
-            .join("new")
-            .join(clientNamePrefix(apiInterface.getSimpleName()))
+        Name.from("new")
+            .join(clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName()))
             .join("client"));
   }
 
   @Override
-  public String getApiMethodExampleName(InterfaceModel apiInterface, MethodModel method) {
-    return exampleFunction(apiInterface, getApiMethodName(method, VisibilityConfig.PUBLIC));
+  public String getApiWrapperClassConstructorExampleName(InterfaceConfig interfaceConfig) {
+    return publicMethodName(
+        Name.from("example")
+            .join("new")
+            .join(clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName()))
+            .join("client"));
+  }
+
+  @Override
+  public String getApiMethodExampleName(InterfaceConfig interfaceConfig, MethodModel method) {
+    return exampleFunction(interfaceConfig, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
   public String getGrpcStreamingApiMethodExampleName(
-      InterfaceModel apiInterface, MethodModel method) {
-    return exampleFunction(apiInterface, getApiMethodName(method, VisibilityConfig.PUBLIC));
+      InterfaceConfig interfaceConfig, MethodModel method) {
+    return exampleFunction(interfaceConfig, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
@@ -308,9 +312,9 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getExampleFileName(InterfaceModel apiInterface) {
+  public String getExampleFileName(InterfaceConfig interfaceConfig) {
     return classFileNameBase(
-        getReducedServiceName(apiInterface.getSimpleName())
+        getReducedServiceName(interfaceConfig.getInterfaceModel().getSimpleName())
             .join("client")
             .join("example")
             .join("test"));
@@ -355,8 +359,8 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getIamResourceGetterFunctionExampleName(
-      InterfaceModel apiInterface, FieldModel field) {
-    return exampleFunction(apiInterface, getIamResourceGetterFunctionName(field));
+      InterfaceConfig interfaceConfig, FieldModel field) {
+    return exampleFunction(interfaceConfig, getIamResourceGetterFunctionName(field));
   }
 
   @Override
@@ -364,13 +368,13 @@ public class GoSurfaceNamer extends SurfaceNamer {
     return publicFieldName(Name.upperCamel(method.getSimpleName()));
   }
 
-  private String exampleFunction(InterfaceModel apiInterface, String functionName) {
+  private String exampleFunction(InterfaceConfig interfaceConfig, String functionName) {
     // We use "unsafe" string concatenation here.
     // Godoc expects the name to be in format "ExampleMyType_MyMethod";
     // it is the only place we have mixed camel and underscore names.
     return publicMethodName(
             Name.from("example")
-                .join(clientNamePrefix(apiInterface.getSimpleName()))
+                .join(clientNamePrefix(interfaceConfig.getInterfaceModel().getSimpleName()))
                 .join("client"))
         + "_"
         + functionName;

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -18,7 +18,6 @@ import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
 import com.google.api.codegen.config.InterfaceConfig;
-import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.MethodModel;
 import com.google.api.codegen.config.ResourceNameType;
@@ -90,8 +89,9 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientSnippets"));
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
+    return publicClassName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "ClientSnippets"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -138,7 +138,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
                       "NodeJSGapicSurfaceTestTransformer.generateTestView - name"))
               .testCases(createTestCaseViews(context))
               .apiHasLongRunningMethods(context.getInterfaceConfig().hasLongRunningOperations())
-              .packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()))
+              .packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()))
               .missingDefaultServiceAddress(
                   !context.getInterfaceConfig().hasDefaultServiceAddress())
               .missingDefaultServiceScopes(!context.getInterfaceConfig().hasDefaultServiceScopes())

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -156,7 +156,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
             context.getImportTypeTable(), context.getInterfaceModel()));
@@ -171,10 +171,11 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.apiVersion(packageConfig.apiVersion());
 
     xapiClass.packageHasMultipleServices(hasMultipleServices);
-    xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterfaceModel()));
+    xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()));
 
     xapiClass.validDescriptorsNames(generateValidDescriptorsNames(context));
-    xapiClass.constructorName(namer.getApiWrapperClassConstructorName(context.getInterfaceModel()));
+    xapiClass.constructorName(
+        namer.getApiWrapperClassConstructorName(context.getInterfaceConfig()));
     xapiClass.isGcloud(NodeJSUtils.isGcloud(context.getProductConfig()));
 
     return xapiClass.build();
@@ -285,12 +286,12 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
           VersionIndexRequireView.newBuilder()
               .clientName(
                   namer.getApiWrapperClassName(productConfig.getInterfaceConfig(apiInterface)))
-              .serviceName(namer.getPackageServiceName(apiInterface))
+              .serviceName(namer.getPackageServiceName(context.getInterfaceConfig()))
               .localName(localName)
               .doc(
                   serviceTransformer.generateServiceDoc(
                       context, generateApiMethods(context, packageHasMultipleServices).get(0)))
-              .fileName(namer.getClientFileName(context.getInterfaceModel()))
+              .fileName(namer.getClientFileName(context.getInterfaceConfig()))
               .build();
       requireViews.add(require);
     }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer.nodejs;
 
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.InterfaceModel;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.transformer.GapicInterfaceContext;
@@ -46,7 +47,8 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
   private List<ImportFileView> generateExternalImports(InterfaceContext context) {
     ImmutableList.Builder<ImportFileView> imports = ImmutableList.builder();
     InterfaceModel apiInterface = context.getInterfaceModel();
-    String configModule = context.getNamer().getClientConfigPath(apiInterface);
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    String configModule = context.getNamer().getClientConfigPath(interfaceConfig);
     imports.add(createImport("gapicConfig", "./" + configModule));
     imports.add(createImport("gax", "google-gax"));
     imports.add(createImport("merge", "lodash.merge"));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -99,13 +99,15 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getPackageServiceName(InterfaceModel apiInterface) {
-    return getReducedServiceName(apiInterface.getSimpleName()).toLowerCamel();
+  public String getPackageServiceName(InterfaceConfig interfaceConfig) {
+    return getReducedServiceName(interfaceConfig.getInterfaceModel().getSimpleName())
+        .toLowerCamel();
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
-    return publicFieldName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
+    return publicFieldName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "Client"));
   }
 
   @Override
@@ -119,7 +121,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicFieldName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
@@ -131,17 +133,21 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 
   @Override
-  public String getClientConfigPath(InterfaceModel apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore();
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName())
+        .join("client_config")
+        .toLowerUnderscore();
   }
 
-  public String getClientFileName(InterfaceModel apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).join("client").toLowerUnderscore();
+  public String getClientFileName(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName())
+        .join("client")
+        .toLowerUnderscore();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -148,7 +148,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
     apiImplClass.grpcStreamingDescriptors(createGrpcStreamingDescriptors(context));
 
     apiImplClass.methodKeys(generateMethodKeys(context));
-    apiImplClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
+    apiImplClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
     apiImplClass.interfaceKey(context.getInterface().getFullName());
     String grpcClientTypeName =
         namer.getAndSaveNicknameForGrpcClientTypeName(

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -94,20 +94,22 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   /** The function name to format the entity for the given collection. */
   @Override
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(Name.from(resourceNameConfig.getEntityName(), "name"));
   }
 
   @Override
   public String getPathTemplateName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "name", "template"));
   }
 
   @Override
-  public String getClientConfigPath(InterfaceModel apiInterface) {
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
     return "../resources/"
-        + Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore()
+        + Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName())
+            .join("client_config")
+            .toLowerUnderscore()
         + ".json";
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonGapicSurfaceTransformer.java
@@ -186,7 +186,7 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.outputPath(namer.getSourceFilePath(subPath, name));
 
     xapiClass.protoFilename(context.getInterface().getFile().getSimpleName());
-    xapiClass.servicePhraseName(namer.getServicePhraseName(context.getInterfaceModel()));
+    xapiClass.servicePhraseName(namer.getServicePhraseName(context.getInterfaceConfig()));
 
     xapiClass.name(name);
     xapiClass.doc(serviceTransformer.generateServiceDoc(context, methods.get(0)));
@@ -217,8 +217,8 @@ public class PythonGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
-    xapiClass.clientConfigName(namer.getClientConfigName(context.getInterfaceModel()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
+    xapiClass.clientConfigName(namer.getClientConfigName(context.getInterfaceConfig()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
             context.getImportTypeTable(), context.getInterfaceModel()));

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
@@ -128,7 +128,7 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
     SurfaceNamer namer = context.getNamer();
     imports.add(
         createImport(
-            namer.getPackageName(), namer.getClientConfigName(context.getInterfaceModel())));
+            namer.getPackageName(), namer.getClientConfigName(context.getInterfaceConfig())));
 
     Collections.sort(imports, importFileViewComparator());
     return imports;

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -73,13 +73,16 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getServicePhraseName(InterfaceModel apiInterface) {
-    return apiInterface.getParentFullName() + " " + apiInterface.getSimpleName() + " API";
+  public String getServicePhraseName(InterfaceConfig interfaceConfig) {
+    return interfaceConfig.getInterfaceModel().getParentFullName()
+        + " "
+        + interfaceConfig.getInterfaceModel().getSimpleName()
+        + " API";
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(InterfaceModel apiInterface) {
-    return getApiWrapperClassName(apiInterface.getSimpleName());
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
+    return getApiWrapperClassName(interfaceConfig.getInterfaceModel().getSimpleName());
   }
 
   @Override
@@ -221,14 +224,14 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return "_"
         + inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   @Override
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 
@@ -245,13 +248,14 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getClientConfigPath(InterfaceModel apiInterface) {
-    return String.format("%s.%s", getPackageName(), getClientConfigName(apiInterface));
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
+    return String.format("%s.%s", getPackageName(), getClientConfigName(interfaceConfig));
   }
 
   @Override
-  public String getClientConfigName(InterfaceModel apiInterface) {
-    return classFileNameBase(Name.upperCamel(apiInterface.getSimpleName()).join("client_config"));
+  public String getClientConfigName(InterfaceConfig interfaceConfig) {
+    return classFileNameBase(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName()).join("client_config"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -176,7 +176,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceModel()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
             context.getImportTypeTable(), context.getInterfaceModel()));
@@ -215,7 +215,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
           VersionIndexRequireView.newBuilder()
               .clientName(namer.getFullyQualifiedApiWrapperClassName(interfaceConfig))
               .fileName(namer.getServiceFileName(interfaceConfig))
-              .serviceName(namer.getPackageServiceName(context.getInterfaceModel()))
+              .serviceName(namer.getPackageServiceName(context.getInterfaceConfig()))
               .doc(
                   serviceTransformer.generateServiceDoc(
                       context, generateApiMethods(context).get(0)))
@@ -302,7 +302,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     for (InterfaceModel apiInterface : interfaces) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
       String clientName = namer.getPackageName();
-      String serviceName = namer.getPackageServiceName(context.getInterfaceModel());
+      String serviceName = namer.getPackageServiceName(context.getInterfaceConfig());
       if (hasMultipleServices) {
         clientName += "::" + serviceName;
       }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -69,8 +69,9 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   /** The name of the class that implements snippets for a particular proto interface. */
   @Override
-  public String getApiSnippetsClassName(InterfaceModel apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientSnippets"));
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
+    return publicClassName(
+        Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName(), "ClientSnippets"));
   }
 
   /** The function name to set a field. */
@@ -88,7 +89,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   /** The function name to format the entity for the given collection. */
   @Override
   public String getFormatFunctionName(
-      InterfaceModel apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 
@@ -99,8 +100,10 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getClientConfigPath(InterfaceModel apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore()
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getInterfaceModel().getSimpleName())
+            .join("client_config")
+            .toLowerUnderscore()
         + ".json";
   }
 
@@ -297,7 +300,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
       return getVersionAliasedApiClassName(interfaceConfig, packageHasMultipleServices);
     }
     return packageHasMultipleServices
-        ? getTopLevelNamespace() + "::" + getPackageServiceName(interfaceConfig.getInterfaceModel())
+        ? getTopLevelNamespace() + "::" + getPackageServiceName(interfaceConfig)
         : getTopLevelNamespace();
   }
 
@@ -305,7 +308,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   public String getVersionAliasedApiClassName(
       InterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return packageHasMultipleServices
-        ? getPackageName() + "::" + getPackageServiceName(interfaceConfig.getInterfaceModel())
+        ? getPackageName() + "::" + getPackageServiceName(interfaceConfig)
         : getPackageName();
   }
 
@@ -428,7 +431,8 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getPackageServiceName(InterfaceModel apiInterface) {
-    return publicClassName(getReducedServiceName(apiInterface.getSimpleName()));
+  public String getPackageServiceName(InterfaceConfig interfaceConfig) {
+    return publicClassName(
+        getReducedServiceName(interfaceConfig.getInterfaceModel().getSimpleName()));
   }
 }


### PR DESCRIPTION
Go needs InterfaceConfig in a bunch of places to get surface renaming
right.
This commit makes SurfaceNamer use InterfaceConfig instead of
InterfaceModel where possible.
The two places where this isn't possible are

- grpc stubs
- grpc clients

because they might refer to rerouted interfaces that we don't
have configs for.