### PR TITLE
Node.js: Do not declare unused arguments.

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -197,7 +197,7 @@
       client.{@test.clientMethodName}(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(responses => {
+      }).then(() => {
         assert.fail();
       }).catch(err => {
         {@assertError()}
@@ -298,7 +298,7 @@
       @switch test.grpcStreamingType
       @case "ServerStreaming"
         var stream = client.{@test.clientMethodName}(request);
-        stream.on('data', response => {
+        stream.on('data', () => {
           assert.fail();
         });
         stream.on('error', err =>){
@@ -308,7 +308,7 @@
 
         stream.write();
       @case "BidiStreaming"
-        var stream = client.{@test.clientMethodName}().on('data', response => {
+        var stream = client.{@test.clientMethodName}().on('data', () => {
           assert.fail();
         }).on('error', err => {
           {@assertError()}

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -6177,7 +6177,7 @@ describe('LibraryServiceClient', () => {
       client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamShelves(request);
-      stream.on('data', response => {
+      stream.on('data', () => {
         assert.fail();
       });
       stream.on('error', err =>){
@@ -6246,7 +6246,7 @@ describe('LibraryServiceClient', () => {
       client._innerApiCalls.streamBooks = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamBooks(request);
-      stream.on('data', response => {
+      stream.on('data', () => {
         assert.fail();
       });
       stream.on('error', err =>){
@@ -6308,7 +6308,7 @@ describe('LibraryServiceClient', () => {
       // Mock Grpc layer
       client._innerApiCalls.discussBook = mockBidiStreamingGrpcMethod(request, null, error);
 
-      var stream = client.discussBook().on('data', response => {
+      var stream = client.discussBook().on('data', () => {
         assert.fail();
       }).on('error', err => {
         assert(err instanceof Error);
@@ -6568,7 +6568,7 @@ describe('LibraryServiceClient', () => {
       client.getBigBook(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(responses => {
+      }).then(() => {
         assert.fail();
       }).catch(err => {
         assert(err instanceof Error);
@@ -6635,7 +6635,7 @@ describe('LibraryServiceClient', () => {
       client.getBigNothing(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(responses => {
+      }).then(() => {
         assert.fail();
       }).catch(err => {
         assert(err instanceof Error);

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -4140,7 +4140,7 @@ describe('LibraryServiceClient', () => {
       client._innerApiCalls.streamShelves = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamShelves(request);
-      stream.on('data', response => {
+      stream.on('data', () => {
         assert.fail();
       });
       stream.on('error', err =>){
@@ -4209,7 +4209,7 @@ describe('LibraryServiceClient', () => {
       client._innerApiCalls.streamBooks = mockServerStreamingGrpcMethod(request, null, error);
 
       var stream = client.streamBooks(request);
-      stream.on('data', response => {
+      stream.on('data', () => {
         assert.fail();
       });
       stream.on('error', err =>){
@@ -4271,7 +4271,7 @@ describe('LibraryServiceClient', () => {
       // Mock Grpc layer
       client._innerApiCalls.discussBook = mockBidiStreamingGrpcMethod(request, null, error);
 
-      var stream = client.discussBook().on('data', response => {
+      var stream = client.discussBook().on('data', () => {
         assert.fail();
       }).on('error', err => {
         assert(err instanceof Error);
@@ -4531,7 +4531,7 @@ describe('LibraryServiceClient', () => {
       client.getBigBook(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(responses => {
+      }).then(() => {
         assert.fail();
       }).catch(err => {
         assert(err instanceof Error);
@@ -4598,7 +4598,7 @@ describe('LibraryServiceClient', () => {
       client.getBigNothing(request).then(responses => {
         var operation = responses[0];
         return operation.promise();
-      }).then(responses => {
+      }).then(() => {
         assert.fail();
       }).catch(err => {
         assert(err instanceof Error);


### PR DESCRIPTION
Fixes a minor linting issue in Node.js