### PR TITLE
Various small Ruby GAPIC fixes

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/Gemfile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Gemfile.snip
@@ -1,5 +1,5 @@
 @snippet generate(metadata)
-  source 'https://rubygems.org'
+  source "https://rubygems.org"
 
   gemspec
 
@@ -8,7 +8,12 @@
       git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
       branch: "gcloud-jsondoc"
 
+  @# WORKAROUND: builds are having problems since the release of 3.0.0
+  @# pin to the last known good version
+  gem "public_suffix", "~> 2.0"
+
   @# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
   @# so pinning to 2.1 for now.
   gem "rainbow", "~> 2.1.0"
+
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/README.md.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/README.md.snip
@@ -3,6 +3,7 @@
 
 @snippet generate(metadata)
   {@generateReadme(metadata.readmeMetadata)}
+
 @end
 
 @private generateReadme(metadata)

--- a/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
@@ -18,6 +18,7 @@
   task :default => :test
 
   {@helpers()}
+
 @end
 
 @private header(fileHeader)
@@ -171,14 +172,14 @@
   @if metadata.hasSmokeTests
     namespace :ci do
       desc "Run the CI build, with smoke_tests."
-      task :smoke_test do
+      task :acceptance do
         Rake::Task["ci"].invoke
         header "{@metadata.identifier} smoke_test", "*"
         sh "bundle exec rake smoke_test -v"
       end
       task :a do
         @# This is a handy shortcut to save typing
-        Rake::Task["ci:smoke_test"].invoke
+        Rake::Task["ci:acceptance"].invoke
       end
     end
   @end

--- a/src/main/resources/com/google/api/codegen/ruby/credentials.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/credentials.snip
@@ -4,6 +4,7 @@
   {@header(view.fileHeader)}
 
   {@body(view)}
+
 @end
 
 @private header(fileHeader)

--- a/src/main/resources/com/google/api/codegen/ruby/gitignore.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/gitignore.snip
@@ -12,4 +12,5 @@
   @# IDE settings
   .idea
   *.iml
+
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/rubocop.yml.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/rubocop.yml.snip
@@ -2,9 +2,8 @@
   AllCops:
     Exclude:
       - "{@metadata.identifier}.gemspec"
-      - "lib/{@metadata.protoPath}/**/*"
-      # This should be removed in the future after we are sanitizing client files.
-      - "lib/{@metadata.versionPath}/**/*"
+      # This should be removed in the future once GAPIC files conform more closely to rubocop checks.
+      - "lib/google/**/*"
       - "Rakefile"
       - "test/**/*"
 
@@ -53,4 +52,5 @@
     Enabled: false
   Style/FileName:
     Enabled: false
+
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/smoke_test.snip
@@ -5,6 +5,7 @@
   {@header(smokeTest.fileHeader)}
 
   {@testBody(smokeTest)}
+
 @end
 
 @private header(fileHeader)

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -162,7 +162,7 @@
   @# @@param version [Symbol, String]
   @#   The major version of the service to be used. By default :{@index.apiVersion}
   @#   is used.
-  @# @@overload
+  @# @@overload new(version:, credentials:, scopes:, client_config:, timeout:)
   {@toComments(util.getDocLines(initMethodComments()), util.toInt(3))}
   def self.new(*args, version: :{@index.apiVersion}, **kwargs)
     # Check if the version provided is available.

--- a/src/main/resources/com/google/api/codegen/ruby/yardopts.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/yardopts.snip
@@ -7,4 +7,5 @@
   ./lib/**/*.rb
   -
   README.md
+
 @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -12,12 +12,12 @@ jsondoc/*
 # IDE settings
 .idea
 *.iml
+
 ============== file: .rubocop.yml ==============
 AllCops:
   Exclude:
     - "library.gemspec"
-    - "lib/google/library/**/*"
-    - "lib/library/v1/**/*"
+    - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
 
@@ -66,6 +66,7 @@ Style/TrivialAccessors:
   Enabled: false
 Style/FileName:
   Enabled: false
+
 ============== file: .yardopts ==============
 --no-private
 --title=Google Example Library API
@@ -75,8 +76,9 @@ Style/FileName:
 ./lib/**/*.rb
 -
 README.md
+
 ============== file: Gemfile ==============
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
@@ -85,9 +87,14 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
+# WORKAROUND: builds are having problems since the release of 3.0.0
+# pin to the last known good version
+gem "public_suffix", "~> 2.0"
+
 # TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
 # so pinning to 2.1 for now.
 gem "rainbow", "~> 2.1.0"
+
 ============== file: LICENSE ==============
                             Apache License
                            Version 2.0, January 2004
@@ -337,6 +344,7 @@ response = library_service_client.update_book(formatted_name, book, optional_foo
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/library/latest/google/library
 [Product Documentation]: https://cloud.google.com/library
+
 ============== file: Rakefile ==============
 # Copyright 2017, Google Inc. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -486,14 +494,14 @@ end
 
 namespace :ci do
   desc "Run the CI build, with smoke_tests."
-  task :smoke_test do
+  task :acceptance do
     Rake::Task["ci"].invoke
     header "library smoke_test", "*"
     sh "bundle exec rake smoke_test -v"
   end
   task :a do
     # This is a handy shortcut to save typing
-    Rake::Task["ci:smoke_test"].invoke
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 
@@ -520,6 +528,7 @@ def header str, token = "#"
   puts token * line_length
   puts ""
 end
+
 ============== file: lib/library.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
@@ -609,7 +618,7 @@ module Library
   # @param version [Symbol, String]
   #   The major version of the service to be used. By default :v1
   #   is used.
-  # @overload
+  # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
   #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
   #     Provides the means for authenticating requests made by the client. This parameter can
   #     be many types.
@@ -677,6 +686,7 @@ module Library
     DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
   end
 end
+
 ============== file: lib/library/v1.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -12,12 +12,12 @@ jsondoc/*
 # IDE settings
 .idea
 *.iml
+
 ============== file: .rubocop.yml ==============
 AllCops:
   Exclude:
     - "library.gemspec"
-    - "lib/google/library/**/*"
-    - "lib/library/v1/**/*"
+    - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
 
@@ -66,6 +66,7 @@ Style/TrivialAccessors:
   Enabled: false
 Style/FileName:
   Enabled: false
+
 ============== file: .yardopts ==============
 --no-private
 --title=Google Example Library API
@@ -75,8 +76,9 @@ Style/FileName:
 ./lib/**/*.rb
 -
 README.md
+
 ============== file: Gemfile ==============
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
@@ -85,9 +87,14 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
+# WORKAROUND: builds are having problems since the release of 3.0.0
+# pin to the last known good version
+gem "public_suffix", "~> 2.0"
+
 # TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
 # so pinning to 2.1 for now.
 gem "rainbow", "~> 2.1.0"
+
 ============== file: LICENSE ==============
                             Apache License
                            Version 2.0, January 2004
@@ -337,6 +344,7 @@ response = library_service_client.update_book(formatted_name, book, optional_foo
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/library/latest/google/library
 [Product Documentation]: https://cloud.google.com/library
+
 ============== file: Rakefile ==============
 # Copyright 2017, Google Inc. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -486,14 +494,14 @@ end
 
 namespace :ci do
   desc "Run the CI build, with smoke_tests."
-  task :smoke_test do
+  task :acceptance do
     Rake::Task["ci"].invoke
     header "library smoke_test", "*"
     sh "bundle exec rake smoke_test -v"
   end
   task :a do
     # This is a handy shortcut to save typing
-    Rake::Task["ci:smoke_test"].invoke
+    Rake::Task["ci:acceptance"].invoke
   end
 end
 
@@ -520,6 +528,7 @@ def header str, token = "#"
   puts token * line_length
   puts ""
 end
+
 ============== file: lib/library.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
@@ -609,7 +618,7 @@ module Library
   # @param version [Symbol, String]
   #   The major version of the service to be used. By default :v1
   #   is used.
-  # @overload
+  # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
   #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
   #     Provides the means for authenticating requests made by the client. This parameter can
   #     be many types.
@@ -677,6 +686,7 @@ module Library
     DEFAULT_PATHS = ["~/.config/gcloud/application_default_credentials.json"]
   end
 end
+
 ============== file: lib/library/v1.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -12,12 +12,12 @@ jsondoc/*
 # IDE settings
 .idea
 *.iml
+
 ============== file: .rubocop.yml ==============
 AllCops:
   Exclude:
     - "google.gemspec"
-    - "lib/google/longrunning/**/*"
-    - "lib/google/longrunning/**/*"
+    - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
 
@@ -66,6 +66,7 @@ Style/TrivialAccessors:
   Enabled: false
 Style/FileName:
   Enabled: false
+
 ============== file: .yardopts ==============
 --no-private
 --title=Google Long Running Operations API
@@ -75,8 +76,9 @@ Style/FileName:
 ./lib/**/*.rb
 -
 README.md
+
 ============== file: Gemfile ==============
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
@@ -85,9 +87,14 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
+# WORKAROUND: builds are having problems since the release of 3.0.0
+# pin to the last known good version
+gem "public_suffix", "~> 2.0"
+
 # TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
 # so pinning to 2.1 for now.
 gem "rainbow", "~> 2.1.0"
+
 ============== file: LICENSE ==============
                             Apache License
                            Version 2.0, January 2004
@@ -322,6 +329,7 @@ $ gem install google
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google/latest/google/longrunning
 [Product Documentation]: https://cloud.google.com/longrunning
+
 ============== file: Rakefile ==============
 # Copyright 2017, Google Inc. All rights reserved.
 # Redistribution and use in source and binary forms, with or without
@@ -482,6 +490,7 @@ def header str, token = "#"
   puts token * line_length
   puts ""
 end
+
 ============== file: google.gemspec ==============
 # -*- ruby -*-
 # encoding: utf-8

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -12,12 +12,12 @@ jsondoc/*
 # IDE settings
 .idea
 *.iml
+
 ============== file: .rubocop.yml ==============
 AllCops:
   Exclude:
     - "google-example.gemspec"
-    - "lib/google/multiple_services/**/*"
-    - "lib/google/example/v1/**/*"
+    - "lib/google/**/*"
     - "Rakefile"
     - "test/**/*"
 
@@ -66,6 +66,7 @@ Style/TrivialAccessors:
   Enabled: false
 Style/FileName:
   Enabled: false
+
 ============== file: .yardopts ==============
 --no-private
 --title=Google Example API
@@ -75,8 +76,9 @@ Style/FileName:
 ./lib/**/*.rb
 -
 README.md
+
 ============== file: Gemfile ==============
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 
@@ -85,9 +87,14 @@ gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
 
+# WORKAROUND: builds are having problems since the release of 3.0.0
+# pin to the last known good version
+gem "public_suffix", "~> 2.0"
+
 # TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
 # so pinning to 2.1 for now.
 gem "rainbow", "~> 2.1.0"
+
 ============== file: LICENSE ==============
                             Apache License
                            Version 2.0, January 2004
@@ -323,6 +330,7 @@ $ gem install google-example
 
 [Client Library Documentation]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-example/latest/google/multiple_services
 [Product Documentation]: https://cloud.google.com/multiple_services
+
 ============== file: Rakefile ==============
 # Copyright 2017, Google Inc. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -469,6 +477,7 @@ def header str, token = "#"
   puts token * line_length
   puts ""
 end
+
 ============== file: google-example.gemspec ==============
 # -*- ruby -*-
 # encoding: utf-8
@@ -564,7 +573,7 @@ module Google
       # @param version [Symbol, String]
       #   The major version of the service to be used. By default :v1
       #   is used.
-      # @overload
+      # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
       #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #     Provides the means for authenticating requests made by the client. This parameter can
       #     be many types.
@@ -609,7 +618,7 @@ module Google
       # @param version [Symbol, String]
       #   The major version of the service to be used. By default :v1
       #   is used.
-      # @overload
+      # @overload new(version:, credentials:, scopes:, client_config:, timeout:)
       #   @param credentials [Google::Auth::Credentials, String, Hash, GRPC::Core::Channel, GRPC::Core::ChannelCredentials, Proc]
       #     Provides the means for authenticating requests made by the client. This parameter can
       #     be many types.
@@ -679,6 +688,7 @@ module Google
     end
   end
 end
+
 ============== file: lib/google/example/v1.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #


### PR DESCRIPTION
- Ensure files end in newline 
- Style fix (double quotes) in Gemfile
- A workaround where a newer version of `public_suffix` breaks the google-cloud-ruby build
- Rename `ci:smoke_test` Rake task to `ci:acceptance` so that it runs correctly in google-cloud-ruby CI
- Exclude all generated files from rubocop due to numerous autogen style violations ("real" fixes tracked in #1536, #1120)
- YARD `@overloads` tag requires a method signature


Fixes #1559, #1652