### PR TITLE
go: add support for header-based routing

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -354,7 +354,7 @@ public class ApiCallableTransformer {
     return callableBuilder.build();
   }
 
-  private List<HeaderRequestParamView> getHeaderRequestParams(MethodContext context) {
+  public static List<HeaderRequestParamView> getHeaderRequestParams(MethodContext context) {
     if (!context.getProductConfig().getTransportProtocol().equals(TransportProtocol.GRPC)) {
       return ImmutableList.of();
     }
@@ -374,7 +374,7 @@ public class ApiCallableTransformer {
     return headerRequestParams.build();
   }
 
-  private HeaderRequestParamView getHeaderRequestParam(
+  private static HeaderRequestParamView getHeaderRequestParam(
       String headerRequestParam, MessageType inputMessageType, SurfaceNamer namer) {
     String[] fieldNameTokens = headerRequestParam.split("\\.");
     ImmutableList.Builder<String> gettersChain = ImmutableList.builder();

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -489,6 +489,7 @@ public class StaticLangApiMethodTransformer {
     } else {
       methodViewBuilder.hasReturnValue(method.hasReturnValue());
     }
+    methodViewBuilder.headerRequestParams(ApiCallableTransformer.getHeaderRequestParams(context));
   }
 
   protected void setServiceResponseTypeName(

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -158,6 +158,10 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     List<StaticLangApiMethodView> apiMethods =
         generateApiMethods(context, context.getSupportedMethods());
     view.apiMethods(apiMethods);
+    // If any methods have header request params, "fmt" is needed for `fmt.Sprintf` calls.
+    if (apiMethods.stream().anyMatch(m -> !m.headerRequestParams().isEmpty())) {
+      context.getImportTypeTable().saveNicknameFor("fmt;;;");
+    }
 
     view.iamResources(iamResourceTransformer.generateIamResources(context));
     if (!((GapicInterfaceConfig) productConfig.getInterfaceConfig(apiInterface.getFullName()))
@@ -329,6 +333,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("github.com/googleapis/gax-go;gax;;");
     typeTable.saveNicknameFor("google.golang.org/api/option;;;");
     typeTable.saveNicknameFor("google.golang.org/api/transport;;;");
+    typeTable.saveNicknameFor("google.golang.org/grpc/metadata;;;");
     typeTable.getImports().remove(EMPTY_PROTO_PKG);
     addContextImports(context, ImportContext.CLIENT, methods);
   }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.transformer.go;
 
-import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.ApiModel;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicProductConfig;
@@ -92,7 +91,6 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
   private final IamResourceTransformer iamResourceTransformer = new IamResourceTransformer();
   private final PageStreamingTransformer pageStreamingTransformer = new PageStreamingTransformer();
   private final PathTemplateTransformer pathTemplateTransformer = new PathTemplateTransformer();
-  private final ServiceMessages serviceMessages = new ServiceMessages();
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();
 
   private final GapicCodePathMapper pathMapper;
@@ -175,8 +173,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
         pageStreamingTransformer.generateDescriptorClasses(context)) {
       iterators.put(desc.typeName(), desc);
     }
-    view.pageStreamingDescriptorClasses(
-        new ArrayList<PageStreamingDescriptorClassView>(iterators.values()));
+    view.pageStreamingDescriptorClasses(new ArrayList<>(iterators.values()));
 
     // Same with long running operations.
     Map<String, LongRunningOperationDetailView> lros = new TreeMap<>();
@@ -186,7 +183,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
         lros.put(lro.clientReturnTypeName(), lro);
       }
     }
-    view.lroDetailViews(new ArrayList<LongRunningOperationDetailView>(lros.values()));
+    view.lroDetailViews(new ArrayList<>(lros.values()));
 
     view.serviceAddress(context.getApiModel().getServiceAddress());
     view.servicePort(model.getServicePort());

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMethodView.java
@@ -92,6 +92,8 @@ public abstract class StaticLangApiMethodView
 
   public abstract String releaseLevelAnnotation();
 
+  public abstract List<HeaderRequestParamView> headerRequestParams();
+
   public static Builder newBuilder() {
     return new AutoValue_StaticLangApiMethodView.Builder();
   }
@@ -153,6 +155,8 @@ public abstract class StaticLangApiMethodView
     public abstract Builder grpcStreamingType(GrpcStreamingType val);
 
     public abstract Builder releaseLevelAnnotation(String value);
+
+    public abstract Builder headerRequestParams(List<HeaderRequestParamView> val);
 
     public abstract StaticLangApiMethodView build();
   }

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -21,12 +21,9 @@
         "google.golang.org/grpc/metadata"
     )
 
-    func insertMetadata(ctx context.Context, md map[string][]string) context.Context {
+    func insertMetadata(ctx context.Context, md metadata.MD) context.Context {
         out, _ := metadata.FromOutgoingContext(ctx)
-        out = out.Copy()
-        for k, v := range md {
-            out[k] = v
-        }
+        out = metadata.Join(out, md)
         return metadata.NewOutgoingContext(ctx, out)
     }
 

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -21,11 +21,13 @@
         "google.golang.org/grpc/metadata"
     )
 
-    func insertXGoog(ctx context.Context, val []string) context.Context {
-        md, _ := metadata.FromOutgoingContext(ctx)
-        md = md.Copy()
-        md["x-goog-api-client"] = val
-        return metadata.NewOutgoingContext(ctx, md)
+    func insertMetadata(ctx context.Context, md map[string][]string) context.Context {
+        out, _ := metadata.FromOutgoingContext(ctx)
+        out = out.Copy()
+        for k, v := range md {
+            out[k] = v
+        }
+        return metadata.NewOutgoingContext(ctx, out)
     }
 
     // DefaultAuthScopes reports the default set of authentication scopes to use with this package.

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -21,9 +21,9 @@
         "google.golang.org/grpc/metadata"
     )
 
-    func insertMetadata(ctx context.Context, md metadata.MD) context.Context {
+    func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
         out, _ := metadata.FromOutgoingContext(ctx)
-        out = metadata.Join(out, md)
+        out = metadata.Join(append([]metadata.MD{out}, mds...)...)
         return metadata.NewOutgoingContext(ctx, out)
     }
 

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -23,7 +23,12 @@
 
     func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
         out, _ := metadata.FromOutgoingContext(ctx)
-        out = metadata.Join(append([]metadata.MD{out}, mds...)...)
+        out = out.Copy()
+        for _, md := range mds {
+            for k, v := range md {
+                out[k] = append(out[k], v...)
+            }
+        }
         return metadata.NewOutgoingContext(ctx, out)
     }
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -462,14 +462,15 @@
 @end
 
 @private mergeMetadata(method)
-    ctx = insertMetadata(ctx, c.Metadata)
     @if method.headerRequestParams
         md := metadata.Pairs(
             @join headerRequestParam : method.headerRequestParams
                 "x-goog-request-params", fmt.Sprintf("%s=%v", "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)})
             @end
         )
-        ctx = insertMetadata(ctx, md)
+        ctx = insertMetadata(ctx, c.Metadata, md)
+    @else
+        ctx = insertMetadata(ctx, c.Metadata)
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -461,13 +461,24 @@
     @end
 @end
 
+@private headerRequestParamString(headerRequestParams) horizontal on EMPTY
+    # This if block prevents a space from being printed after '"'.
+    @if TRUE
+        fmt.Sprintf("
+    @end
+    @join headerRequestParam : headerRequestParams on "&"
+        %s=%v
+    @end
+    ",
+    @join headerRequestParam : headerRequestParams on ", "
+        "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)}
+    @end
+    )
+@end
+
 @private mergeMetadata(method)
     @if method.headerRequestParams
-        md := metadata.Pairs(
-            @join headerRequestParam : method.headerRequestParams
-                "x-goog-request-params", fmt.Sprintf("%s=%v", "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)})
-            @end
-        )
+        md := metadata.Pairs("x-goog-request-params", {@headerRequestParamString(method.headerRequestParams)})
         ctx = insertMetadata(ctx, c.Metadata, md)
     @else
         ctx = insertMetadata(ctx, c.Metadata)

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -69,7 +69,7 @@
         CallOptions *{@view.callOptionsTypeName}
 
         // The metadata to be sent with each request.
-        xGoogHeader []string
+        Metadata metadata.MD
     }
 
     // {@view.clientConstructorName} creates a new {@view.servicePhraseName} client.
@@ -124,7 +124,7 @@
     func (c *{@view.clientTypeName}) {@setClientInfoFunc(view)}(keyval ...string) {
         kv := append([]string{"gl-go", version.Go()}, keyval...)
         kv = append(kv, "gapic", version.Repo, "gax", gax.Version, "grpc", grpc.Version)
-        c.xGoogHeader = []string{gax.XGoogHeader(kv...)}
+        c.Metadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
     }
 
     @join getter : view.pathTemplateGetters
@@ -462,20 +462,15 @@
 @end
 
 @private mergeMetadata(method)
+    ctx = insertMetadata(ctx, c.Metadata)
     @if method.headerRequestParams
-        vals = []string{}
-        @join headerRequestParam : method.headerRequestParams
-            vals = append(vals, fmt.Sprintf("%s=%v", "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)}))
-        @end
-
+        md := metadata.Pairs(
+            @join headerRequestParam : method.headerRequestParams
+                "x-goog-request-params", fmt.Sprintf("%s=%v", "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)})
+            @end
+        )
+        ctx = insertMetadata(ctx, md)
     @end
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-        @if method.headerRequestParams
-            "x-goog-request-params": vals,
-        @end
-    }
-    ctx = insertMetadata(ctx, md)
 @end
 
 @private mergeOptions(getterName)

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -191,7 +191,7 @@
 
 @private simpleMethod(view, method)
     func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) ({@method.responseTypeName}, error) {
-        {@mergeMetadata()}
+        {@mergeMetadata(method)}
         opts = {@mergeOptions(method.settingsGetterName)}
         var resp {@method.serviceResponseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -208,7 +208,7 @@
 
 @private lroMethod(view, method)
     func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) (*{@method.operationMethod.clientReturnTypeName}, error) {
-        {@mergeMetadata()}
+        {@mergeMetadata(method)}
         opts = {@mergeOptions(method.settingsGetterName)}
         var resp {@method.serviceResponseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -229,7 +229,7 @@
 # The function is not accept a request, but otherwise the same with simpleMethod.
 @private noRequestStreamMethod(view, method)
     func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, opts ...gax.CallOption) ({@method.responseTypeName}, error) {
-        {@mergeMetadata()}
+        {@mergeMetadata(method)}
         opts = {@mergeOptions(method.settingsGetterName)}
         var resp {@method.serviceResponseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -246,7 +246,7 @@
 
 @private emptyReturnMethod(view, method)
     func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) error {
-        {@mergeMetadata()}
+        {@mergeMetadata(method)}
         opts = {@mergeOptions(method.settingsGetterName)}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
             var err error
@@ -259,7 +259,7 @@
 
 @private pageStreamingMethod(view, method)
     func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) *{@method.responseTypeName} {
-        {@mergeMetadata()}
+        {@mergeMetadata(method)}
         opts = {@mergeOptions(method.settingsGetterName)}
         it := &{@method.responseTypeName}{}
         it.InternalFetch = func(pageSize int, pageToken string) ([]{@method.listMethod.resourceTypeName}, string, error) {
@@ -455,8 +455,27 @@
     @end
 @end
 
-@private mergeMetadata()
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+@private requestParamGetter(gettersChain)
+    @join getter : gettersChain on "."
+        Get{@getter}()
+    @end
+@end
+
+@private mergeMetadata(method)
+    @if method.headerRequestParams
+        vals = []string{}
+        @join headerRequestParam : method.headerRequestParams
+            vals = append(vals, fmt.Sprintf("%s=%v", "{@headerRequestParam.fullyQualifiedName}", req.{@requestParamGetter(headerRequestParam.gettersChain)}))
+        @end
+
+    @end
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+        @if method.headerRequestParams
+            "x-goog-request-params": vals,
+        @end
+    }
+    ctx = insertMetadata(ctx, md)
 @end
 
 @private mergeOptions(getterName)

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -465,10 +465,7 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs(
-        "x-goog-request-params", fmt.Sprintf("%s=%v", "name", req.GetName())
-        "x-goog-request-params", fmt.Sprintf("%s=%v", "book.read", req.GetBook().GetRead())
-    )
+    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "name", req.GetName(), "book.read", req.GetBook().GetRead()))
     ctx = insertMetadata(ctx, c.Metadata, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -100,12 +100,9 @@ import (
     "google.golang.org/grpc/metadata"
 )
 
-func insertMetadata(ctx context.Context, md map[string][]string) context.Context {
+func insertMetadata(ctx context.Context, md metadata.MD) context.Context {
     out, _ := metadata.FromOutgoingContext(ctx)
-    out = out.Copy()
-    for k, v := range md {
-        out[k] = v
-    }
+    out = metadata.Join(out, md)
     return metadata.NewOutgoingContext(ctx, out)
 }
 
@@ -136,6 +133,7 @@ func DefaultAuthScopes() []string {
 package library
 
 import (
+    "fmt"
     "math"
     "time"
 
@@ -153,6 +151,7 @@ import (
     taggerpb "google.golang.org/genproto/googleapis/tagger/v1"
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"
+    "google.golang.org/grpc/metadata"
 )
 
 // CallOptions contains the retry settings for each method of Client.
@@ -257,7 +256,7 @@ type Client struct {
     CallOptions *CallOptions
 
     // The metadata to be sent with each request.
-    xGoogHeader []string
+    Metadata metadata.MD
 }
 
 // NewClient creates a new library service client.
@@ -322,7 +321,7 @@ func (c *Client) Close() error {
 func (c *Client) SetGoogleClientInfo(keyval ...string) {
     kv := append([]string{"gl-go", version.Go()}, keyval...)
     kv = append(kv, "gapic", version.Repo, "gax", gax.Version, "grpc", grpc.Version)
-    c.xGoogHeader = []string{gax.XGoogHeader(kv...)}
+    c.Metadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
 // ShelfPath returns the path for the shelf resource.
@@ -364,10 +363,7 @@ func (c *Client) BookIAM(book *librarypb.Book) *iam.Handle {
 // CreateShelf creates a shelf, and returns the new Shelf.
 // RPC method comment may include special characters: <>&"`'@.
 func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.CreateShelf[0:len(c.CallOptions.CreateShelf):len(c.CallOptions.CreateShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -383,10 +379,7 @@ func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequ
 
 // GetShelf gets a shelf.
 func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetShelf[0:len(c.CallOptions.GetShelf):len(c.CallOptions.GetShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -402,10 +395,7 @@ func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, o
 
 // ListShelves lists shelves.
 func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequest, opts ...gax.CallOption) *ShelfIterator {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.ListShelves[0:len(c.CallOptions.ListShelves):len(c.CallOptions.ListShelves)], opts...)
     it := &ShelfIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Shelf, string, error) {
@@ -440,10 +430,7 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
 
 // DeleteShelf deletes a shelf.
 func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest, opts ...gax.CallOption) error {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.DeleteShelf[0:len(c.CallOptions.DeleteShelf):len(c.CallOptions.DeleteShelf)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -457,10 +444,7 @@ func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequ
 // other_shelf_name to shelf name, and deletes
 // other_shelf_name. Returns the updated shelf.
 func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.MergeShelves[0:len(c.CallOptions.MergeShelves):len(c.CallOptions.MergeShelves)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -476,13 +460,11 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    vals = []string{}
-    vals = append(vals, fmt.Sprintf("%s=%v", "name", req.GetName()))
-    vals = append(vals, fmt.Sprintf("%s=%v", "book.read", req.GetBook().GetRead()))
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-        "x-goog-request-params": vals,
-    }
+    ctx = insertMetadata(ctx, c.Metadata)
+    md := metadata.Pairs(
+        "x-goog-request-params", fmt.Sprintf("%s=%v", "name", req.GetName())
+        "x-goog-request-params", fmt.Sprintf("%s=%v", "book.read", req.GetBook().GetRead())
+    )
     ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
@@ -499,10 +481,7 @@ func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookReques
 
 // PublishSeries creates a series of books.
 func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -518,10 +497,7 @@ func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeries
 
 // GetBook gets a book.
 func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetBook[0:len(c.CallOptions.GetBook):len(c.CallOptions.GetBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -537,10 +513,7 @@ func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opt
 
 // ListBooks lists books in a shelf.
 func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest, opts ...gax.CallOption) *BookIterator {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Book, string, error) {
@@ -575,10 +548,7 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest,
 
 // DeleteBook deletes a book.
 func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest, opts ...gax.CallOption) error {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.DeleteBook[0:len(c.CallOptions.DeleteBook):len(c.CallOptions.DeleteBook)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -590,10 +560,7 @@ func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookReques
 
 // UpdateBook updates a book.
 func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.UpdateBook[0:len(c.CallOptions.UpdateBook):len(c.CallOptions.UpdateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -609,10 +576,7 @@ func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReques
 
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.MoveBook[0:len(c.CallOptions.MoveBook):len(c.CallOptions.MoveBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -628,10 +592,7 @@ func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, o
 
 // ListStrings lists a primitive resource. To test go page streaming.
 func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequest, opts ...gax.CallOption) *StringIterator {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.ListStrings[0:len(c.CallOptions.ListStrings):len(c.CallOptions.ListStrings)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
@@ -666,10 +627,7 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
 
 // AddComments adds comments to a book
 func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest, opts ...gax.CallOption) error {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.AddComments[0:len(c.CallOptions.AddComments):len(c.CallOptions.AddComments)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -681,10 +639,7 @@ func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequ
 
 // GetBookFromArchive gets a book from an archive.
 func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookFromArchiveRequest, opts ...gax.CallOption) (*librarypb.BookFromArchive, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetBookFromArchive[0:len(c.CallOptions.GetBookFromArchive):len(c.CallOptions.GetBookFromArchive)], opts...)
     var resp *librarypb.BookFromArchive
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -700,10 +655,7 @@ func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookF
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
 func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetBookFromAnywhere[0:len(c.CallOptions.GetBookFromAnywhere):len(c.CallOptions.GetBookFromAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -719,10 +671,7 @@ func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBook
 
 // GetBookFromAbsolutelyAnywhere test proper OneOf-Any resource name mapping
 func (c *Client) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *librarypb.GetBookFromAbsolutelyAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetBookFromAbsolutelyAnywhere[0:len(c.CallOptions.GetBookFromAbsolutelyAnywhere):len(c.CallOptions.GetBookFromAbsolutelyAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -738,10 +687,7 @@ func (c *Client) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *library
 
 // UpdateBookIndex updates the index of a book.
 func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest, opts ...gax.CallOption) error {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.UpdateBookIndex[0:len(c.CallOptions.UpdateBookIndex):len(c.CallOptions.UpdateBookIndex)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -754,10 +700,7 @@ func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookI
 // StreamShelves test server streaming
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelvesRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamShelvesClient, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.StreamShelves[0:len(c.CallOptions.StreamShelves):len(c.CallOptions.StreamShelves)], opts...)
     var resp librarypb.LibraryService_StreamShelvesClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -774,10 +717,7 @@ func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelves
 // StreamBooks test server streaming, non-paged responses.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamBooksClient, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.StreamBooks[0:len(c.CallOptions.StreamBooks):len(c.CallOptions.StreamBooks)], opts...)
     var resp librarypb.LibraryService_StreamBooksClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -794,10 +734,7 @@ func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequ
 // DiscussBook test bidi-streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_DiscussBookClient, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.DiscussBook[0:len(c.CallOptions.DiscussBook):len(c.CallOptions.DiscussBook)], opts...)
     var resp librarypb.LibraryService_DiscussBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -814,10 +751,7 @@ func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (libra
 // MonologAboutBook test client streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_MonologAboutBookClient, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.MonologAboutBook[0:len(c.CallOptions.MonologAboutBook):len(c.CallOptions.MonologAboutBook)], opts...)
     var resp librarypb.LibraryService_MonologAboutBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -833,10 +767,7 @@ func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (
 
 // FindRelatedBooks
 func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest, opts ...gax.CallOption) *StringIterator {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.FindRelatedBooks[0:len(c.CallOptions.FindRelatedBooks):len(c.CallOptions.FindRelatedBooks)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
@@ -871,10 +802,7 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 
 // addLabel adds a label to the entity.
 func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, opts ...gax.CallOption) (*taggerpb.AddLabelResponse, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.AddLabel[0:len(c.CallOptions.AddLabel):len(c.CallOptions.AddLabel)], opts...)
     var resp *taggerpb.AddLabelResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -890,10 +818,7 @@ func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, op
 
 // GetBigBook test long-running operations
 func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigBookOperation, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetBigBook[0:len(c.CallOptions.GetBigBook):len(c.CallOptions.GetBigBook)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -911,10 +836,7 @@ func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, 
 
 // GetBigNothing test long-running operations with empty return type.
 func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigNothingOperation, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.GetBigNothing[0:len(c.CallOptions.GetBigNothing):len(c.CallOptions.GetBigNothing)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -932,10 +854,7 @@ func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookReques
 
 // TestOptionalRequiredFlatteningParams test optional flattening parameters of all types
 func (c *Client) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest, opts ...gax.CallOption) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
-    md := map[string][]string{
-        "x-goog-api-client": c.xGoogHeader,
-    }
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata)
     opts = append(c.CallOptions.TestOptionalRequiredFlatteningParams[0:len(c.CallOptions.TestOptionalRequiredFlatteningParams):len(c.CallOptions.TestOptionalRequiredFlatteningParams)], opts...)
     var resp *librarypb.TestOptionalRequiredFlatteningParamsResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -100,11 +100,13 @@ import (
     "google.golang.org/grpc/metadata"
 )
 
-func insertXGoog(ctx context.Context, val []string) context.Context {
-    md, _ := metadata.FromOutgoingContext(ctx)
-    md = md.Copy()
-    md["x-goog-api-client"] = val
-    return metadata.NewOutgoingContext(ctx, md)
+func insertMetadata(ctx context.Context, md map[string][]string) context.Context {
+    out, _ := metadata.FromOutgoingContext(ctx)
+    out = out.Copy()
+    for k, v := range md {
+        out[k] = v
+    }
+    return metadata.NewOutgoingContext(ctx, out)
 }
 
 // DefaultAuthScopes reports the default set of authentication scopes to use with this package.
@@ -362,7 +364,10 @@ func (c *Client) BookIAM(book *librarypb.Book) *iam.Handle {
 // CreateShelf creates a shelf, and returns the new Shelf.
 // RPC method comment may include special characters: <>&"`'@.
 func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.CreateShelf[0:len(c.CallOptions.CreateShelf):len(c.CallOptions.CreateShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -378,7 +383,10 @@ func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequ
 
 // GetShelf gets a shelf.
 func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetShelf[0:len(c.CallOptions.GetShelf):len(c.CallOptions.GetShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -394,7 +402,10 @@ func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, o
 
 // ListShelves lists shelves.
 func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequest, opts ...gax.CallOption) *ShelfIterator {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.ListShelves[0:len(c.CallOptions.ListShelves):len(c.CallOptions.ListShelves)], opts...)
     it := &ShelfIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Shelf, string, error) {
@@ -429,7 +440,10 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
 
 // DeleteShelf deletes a shelf.
 func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest, opts ...gax.CallOption) error {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.DeleteShelf[0:len(c.CallOptions.DeleteShelf):len(c.CallOptions.DeleteShelf)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -443,7 +457,10 @@ func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequ
 // other_shelf_name to shelf name, and deletes
 // other_shelf_name. Returns the updated shelf.
 func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.MergeShelves[0:len(c.CallOptions.MergeShelves):len(c.CallOptions.MergeShelves)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -459,7 +476,14 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    vals = []string{}
+    vals = append(vals, fmt.Sprintf("%s=%v", "name", req.GetName()))
+    vals = append(vals, fmt.Sprintf("%s=%v", "book.read", req.GetBook().GetRead()))
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+        "x-goog-request-params": vals,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -475,7 +499,10 @@ func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookReques
 
 // PublishSeries creates a series of books.
 func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -491,7 +518,10 @@ func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeries
 
 // GetBook gets a book.
 func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetBook[0:len(c.CallOptions.GetBook):len(c.CallOptions.GetBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -507,7 +537,10 @@ func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opt
 
 // ListBooks lists books in a shelf.
 func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest, opts ...gax.CallOption) *BookIterator {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Book, string, error) {
@@ -542,7 +575,10 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest,
 
 // DeleteBook deletes a book.
 func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest, opts ...gax.CallOption) error {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.DeleteBook[0:len(c.CallOptions.DeleteBook):len(c.CallOptions.DeleteBook)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -554,7 +590,10 @@ func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookReques
 
 // UpdateBook updates a book.
 func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.UpdateBook[0:len(c.CallOptions.UpdateBook):len(c.CallOptions.UpdateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -570,7 +609,10 @@ func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReques
 
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.MoveBook[0:len(c.CallOptions.MoveBook):len(c.CallOptions.MoveBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -586,7 +628,10 @@ func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, o
 
 // ListStrings lists a primitive resource. To test go page streaming.
 func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequest, opts ...gax.CallOption) *StringIterator {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.ListStrings[0:len(c.CallOptions.ListStrings):len(c.CallOptions.ListStrings)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
@@ -621,7 +666,10 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
 
 // AddComments adds comments to a book
 func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest, opts ...gax.CallOption) error {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.AddComments[0:len(c.CallOptions.AddComments):len(c.CallOptions.AddComments)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -633,7 +681,10 @@ func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequ
 
 // GetBookFromArchive gets a book from an archive.
 func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookFromArchiveRequest, opts ...gax.CallOption) (*librarypb.BookFromArchive, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetBookFromArchive[0:len(c.CallOptions.GetBookFromArchive):len(c.CallOptions.GetBookFromArchive)], opts...)
     var resp *librarypb.BookFromArchive
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -649,7 +700,10 @@ func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookF
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
 func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetBookFromAnywhere[0:len(c.CallOptions.GetBookFromAnywhere):len(c.CallOptions.GetBookFromAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -665,7 +719,10 @@ func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBook
 
 // GetBookFromAbsolutelyAnywhere test proper OneOf-Any resource name mapping
 func (c *Client) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *librarypb.GetBookFromAbsolutelyAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetBookFromAbsolutelyAnywhere[0:len(c.CallOptions.GetBookFromAbsolutelyAnywhere):len(c.CallOptions.GetBookFromAbsolutelyAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -681,7 +738,10 @@ func (c *Client) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *library
 
 // UpdateBookIndex updates the index of a book.
 func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest, opts ...gax.CallOption) error {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.UpdateBookIndex[0:len(c.CallOptions.UpdateBookIndex):len(c.CallOptions.UpdateBookIndex)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -694,7 +754,10 @@ func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookI
 // StreamShelves test server streaming
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelvesRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamShelvesClient, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.StreamShelves[0:len(c.CallOptions.StreamShelves):len(c.CallOptions.StreamShelves)], opts...)
     var resp librarypb.LibraryService_StreamShelvesClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -711,7 +774,10 @@ func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelves
 // StreamBooks test server streaming, non-paged responses.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamBooksClient, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.StreamBooks[0:len(c.CallOptions.StreamBooks):len(c.CallOptions.StreamBooks)], opts...)
     var resp librarypb.LibraryService_StreamBooksClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -728,7 +794,10 @@ func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequ
 // DiscussBook test bidi-streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_DiscussBookClient, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.DiscussBook[0:len(c.CallOptions.DiscussBook):len(c.CallOptions.DiscussBook)], opts...)
     var resp librarypb.LibraryService_DiscussBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -745,7 +814,10 @@ func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (libra
 // MonologAboutBook test client streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_MonologAboutBookClient, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.MonologAboutBook[0:len(c.CallOptions.MonologAboutBook):len(c.CallOptions.MonologAboutBook)], opts...)
     var resp librarypb.LibraryService_MonologAboutBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -761,7 +833,10 @@ func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (
 
 // FindRelatedBooks
 func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest, opts ...gax.CallOption) *StringIterator {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.FindRelatedBooks[0:len(c.CallOptions.FindRelatedBooks):len(c.CallOptions.FindRelatedBooks)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
@@ -796,7 +871,10 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 
 // addLabel adds a label to the entity.
 func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, opts ...gax.CallOption) (*taggerpb.AddLabelResponse, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.AddLabel[0:len(c.CallOptions.AddLabel):len(c.CallOptions.AddLabel)], opts...)
     var resp *taggerpb.AddLabelResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -812,7 +890,10 @@ func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, op
 
 // GetBigBook test long-running operations
 func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigBookOperation, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetBigBook[0:len(c.CallOptions.GetBigBook):len(c.CallOptions.GetBigBook)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -830,7 +911,10 @@ func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, 
 
 // GetBigNothing test long-running operations with empty return type.
 func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigNothingOperation, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.GetBigNothing[0:len(c.CallOptions.GetBigNothing):len(c.CallOptions.GetBigNothing)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -848,7 +932,10 @@ func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookReques
 
 // TestOptionalRequiredFlatteningParams test optional flattening parameters of all types
 func (c *Client) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest, opts ...gax.CallOption) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
-    ctx = insertXGoog(ctx, c.xGoogHeader)
+    md := map[string][]string{
+        "x-goog-api-client": c.xGoogHeader,
+    }
+    ctx = insertMetadata(ctx, md)
     opts = append(c.CallOptions.TestOptionalRequiredFlatteningParams[0:len(c.CallOptions.TestOptionalRequiredFlatteningParams):len(c.CallOptions.TestOptionalRequiredFlatteningParams)], opts...)
     var resp *librarypb.TestOptionalRequiredFlatteningParamsResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -100,9 +100,9 @@ import (
     "google.golang.org/grpc/metadata"
 )
 
-func insertMetadata(ctx context.Context, md metadata.MD) context.Context {
+func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
     out, _ := metadata.FromOutgoingContext(ctx)
-    out = metadata.Join(out, md)
+    out = metadata.Join(append([]metadata.MD{out}, mds...)...)
     return metadata.NewOutgoingContext(ctx, out)
 }
 
@@ -460,12 +460,11 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
     md := metadata.Pairs(
         "x-goog-request-params", fmt.Sprintf("%s=%v", "name", req.GetName())
         "x-goog-request-params", fmt.Sprintf("%s=%v", "book.read", req.GetBook().GetRead())
     )
-    ctx = insertMetadata(ctx, md)
+    ctx = insertMetadata(ctx, c.Metadata, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -102,7 +102,12 @@ import (
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
     out, _ := metadata.FromOutgoingContext(ctx)
-    out = metadata.Join(append([]metadata.MD{out}, mds...)...)
+    out = out.Copy()
+    for _, md := range mds {
+        for k, v := range md {
+            out[k] = append(out[k], v...)
+        }
+    }
     return metadata.NewOutgoingContext(ctx, out)
 }
 


### PR DESCRIPTION
Configure "x-goog-request-params" before performing a request.