### PR TITLE
Auto generate config_schema_version field.

### DIFF
--- a/src/main/java/com/google/api/codegen/configgen/transformer/ConfigTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/ConfigTransformer.java
@@ -42,6 +42,7 @@ public class ConfigTransformer {
   private static final String CONFIG_DEFAULT_COPYRIGHT_FILE = "copyright-google.txt";
   private static final String CONFIG_DEFAULT_LICENSE_FILE = "license-header-apache-2.0.txt";
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
+  private static final String DEFAULT_CONFIG_SCHEMA_VERSION = "1.0.0";
 
   private final LanguageTransformer languageTransformer = new LanguageTransformer();
   private final RetryTransformer retryTransformer = new RetryTransformer();
@@ -54,6 +55,7 @@ public class ConfigTransformer {
         .templateFileName(CONFIG_TEMPLATE_FILE)
         .outputPath(outputPath)
         .type(CONFIG_PROTO_TYPE)
+        .configSchemaVersion(DEFAULT_CONFIG_SCHEMA_VERSION)
         .languageSettings(generateLanguageSettings(model))
         .license(generateLicense())
         .interfaces(generateInterfaces(model))

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoConfigTransformer.java
@@ -46,6 +46,7 @@ public class DiscoConfigTransformer {
   private static final String CONFIG_DEFAULT_COPYRIGHT_FILE = "copyright-google.txt";
   private static final String CONFIG_DEFAULT_LICENSE_FILE = "license-header-apache-2.0.txt";
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
+  private static final String DEFAULT_CONFIG_SCHEMA_VERSION = "1.0.0";
 
   private final LanguageTransformer languageTransformer = new LanguageTransformer();
   private final RetryTransformer retryTransformer = new RetryTransformer();
@@ -75,6 +76,7 @@ public class DiscoConfigTransformer {
         .templateFileName(CONFIG_TEMPLATE_FILE)
         .outputPath(outputPath)
         .type(CONFIG_PROTO_TYPE)
+        .configSchemaVersion(DEFAULT_CONFIG_SCHEMA_VERSION)
         .languageSettings(generateLanguageSettings(model))
         .license(generateLicense())
         .interfaces(generateInterfaces(model, resourceToNamePatternMap, methodToNamePatternMap))

--- a/src/main/java/com/google/api/codegen/configgen/viewmodel/ConfigView.java
+++ b/src/main/java/com/google/api/codegen/configgen/viewmodel/ConfigView.java
@@ -32,6 +32,9 @@ public abstract class ConfigView implements ViewModel {
   /** The type of the config's proto. */
   public abstract String type();
 
+  /** The version of the config schema. */
+  public abstract String configSchemaVersion();
+
   /** The settings of generated code in a specific language. */
   public abstract List<LanguageSettingView> languageSettings();
 
@@ -61,6 +64,8 @@ public abstract class ConfigView implements ViewModel {
     public abstract Builder outputPath(String val);
 
     public abstract Builder type(String val);
+
+    public abstract Builder configSchemaVersion(String val);
 
     public abstract Builder languageSettings(List<LanguageSettingView> val);
 

--- a/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
+++ b/src/main/resources/com/google/api/codegen/configgen/gapic_config.snip
@@ -1,6 +1,7 @@
 @snippet generate(config)
   {@renderTopLevelTodo()}
   {@renderType(config.type)}
+  {@renderConfigSchemaVersion(config.configSchemaVersion)}
   {@renderLanguageSettings(config.languageSettings)}
   {@renderLicense(config.license)}
   {@renderInterfaces(config.interfaces)}
@@ -17,6 +18,10 @@
 
 @private renderType(type)
   type: {@type}
+@end
+
+@private renderConfigSchemaVersion(config_schema_version)
+  config_schema_version: {@config_schema_version}
 @end
 
 @private renderLanguageSettings(languageSettings)

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -4,6 +4,7 @@
 # properties cannot be precisely decided by the tooling and may require some
 # configuration.
 type: com.google.api.codegen.ConfigProto
+config_schema_version: 1.0.0
 # The settings of generated code in a specific language.
 language_settings:
   java:
@@ -699,4 +700,3 @@ interfaces:
     retry_params_name: default
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-

--- a/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/longrunning_config.baseline
@@ -4,6 +4,7 @@
 # properties cannot be precisely decided by the tooling and may require some
 # configuration.
 type: com.google.api.codegen.ConfigProto
+config_schema_version: 1.0.0
 # The settings of generated code in a specific language.
 language_settings:
   java:
@@ -195,4 +196,3 @@ interfaces:
       name: operation_path
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
@@ -4,6 +4,7 @@
 # properties cannot be precisely decided by the tooling and may require some
 # configuration.
 type: com.google.api.codegen.ConfigProto
+config_schema_version: 1.0.0
 # The settings of generated code in a specific language.
 language_settings:
   java:
@@ -118,4 +119,3 @@ interfaces:
     retry_params_name: default
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
-

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_config.baseline
@@ -4,6 +4,7 @@
 # properties cannot be precisely decided by the tooling and may require some
 # configuration.
 type: com.google.api.codegen.ConfigProto
+config_schema_version: 1.0.0
 # The settings of generated code in a specific language.
 language_settings:
   java:


### PR DESCRIPTION
Include the required config_schema_version field when GAPIC configen generates base GAPIC YAML