### PR TITLE
Fix an confusingly incorrect error message

### DIFF
--- a/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
+++ b/src/main/java/com/google/api/codegen/config/LongRunningConfig.java
@@ -87,14 +87,14 @@ public abstract class LongRunningConfig {
           Diag.error(
               SimpleLocation.TOPLEVEL,
               "Metadata type not found for long running config: '%s'",
-              longRunningConfigProto.getReturnType()));
+              longRunningConfigProto.getMetadataType()));
       error = true;
     } else if (!metadataType.isMessage()) {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,
               "Metadata type for long running config is not a message: '%s'",
-              longRunningConfigProto.getReturnType()));
+              longRunningConfigProto.getMetadataType()));
       error = true;
     }
 


### PR DESCRIPTION
Previously, the wrong type was referenced in the error message.