### PR TITLE
Rename Rakefile tasks

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
@@ -88,7 +88,11 @@
   @# Acceptance tests
   desc "Run the {@metadata.identifier} acceptance tests."
   task :acceptance do
-    puts "The {@metadata.identifier} gem does not have acceptance tests."
+    @if metadata.hasSmokeTests
+      Rake::Task["smoke_test"].invoke
+    @else
+      puts "The {@metadata.identifier} gem does not have acceptance tests."
+    @end
   end
 
   namespace :acceptance do

--- a/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
@@ -171,22 +171,18 @@
 
   @if metadata.hasSmokeTests
     namespace :ci do
-      desc "Run the CI build, with smoke_tests."
-      task :acceptance do
+      desc "Run the CI build, with smoke tests."
+      task :smoke_test do
         Rake::Task["ci"].invoke
         header "{@metadata.identifier} smoke_test", "*"
         sh "bundle exec rake smoke_test -v"
-      end
-      task :a do
-        @# This is a handy shortcut to save typing
-        Rake::Task["ci:acceptance"].invoke
       end
     end
   @end
 
   namespace :ci do
     desc "Run the CI build, with acceptance tests."
-    task :smoke_test do
+    task :acceptance do
       Rake::Task["ci"].invoke
       header "{@metadata.identifier} acceptance", "*"
       sh "bundle exec rake acceptance -v"

--- a/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
@@ -144,7 +144,7 @@ public class GapicCodeGeneratorTest extends GapicTestBase2 {
   }
 
   @Test
-  public void library() throws Exception {
+  public void test() throws Exception {
     test(apiName);
   }
 }

--- a/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/GapicCodeGeneratorTest.java
@@ -58,7 +58,7 @@ public class GapicCodeGeneratorTest extends GapicTestBase2 {
     }
   }
 
-  @Parameters(name = "{0}")
+  @Parameters(name = "{5}")
   public static List<Object[]> testedConfigs() {
     return Arrays.asList(
         GapicTestBase2.createTestConfig(

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -415,7 +415,7 @@ end
 # Acceptance tests
 desc "Run the library acceptance tests."
 task :acceptance do
-  puts "The library gem does not have acceptance tests."
+  Rake::Task["smoke_test"].invoke
 end
 
 namespace :acceptance do
@@ -493,21 +493,17 @@ task :ci do
 end
 
 namespace :ci do
-  desc "Run the CI build, with smoke_tests."
-  task :acceptance do
+  desc "Run the CI build, with smoke tests."
+  task :smoke_test do
     Rake::Task["ci"].invoke
     header "library smoke_test", "*"
     sh "bundle exec rake smoke_test -v"
-  end
-  task :a do
-    # This is a handy shortcut to save typing
-    Rake::Task["ci:acceptance"].invoke
   end
 end
 
 namespace :ci do
   desc "Run the CI build, with acceptance tests."
-  task :smoke_test do
+  task :acceptance do
     Rake::Task["ci"].invoke
     header "library acceptance", "*"
     sh "bundle exec rake acceptance -v"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -415,7 +415,7 @@ end
 # Acceptance tests
 desc "Run the library acceptance tests."
 task :acceptance do
-  puts "The library gem does not have acceptance tests."
+  Rake::Task["smoke_test"].invoke
 end
 
 namespace :acceptance do
@@ -493,21 +493,17 @@ task :ci do
 end
 
 namespace :ci do
-  desc "Run the CI build, with smoke_tests."
-  task :acceptance do
+  desc "Run the CI build, with smoke tests."
+  task :smoke_test do
     Rake::Task["ci"].invoke
     header "library smoke_test", "*"
     sh "bundle exec rake smoke_test -v"
-  end
-  task :a do
-    # This is a handy shortcut to save typing
-    Rake::Task["ci:acceptance"].invoke
   end
 end
 
 namespace :ci do
   desc "Run the CI build, with acceptance tests."
-  task :smoke_test do
+  task :acceptance do
     Rake::Task["ci"].invoke
     header "library acceptance", "*"
     sh "bundle exec rake acceptance -v"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -469,7 +469,7 @@ end
 
 namespace :ci do
   desc "Run the CI build, with acceptance tests."
-  task :smoke_test do
+  task :acceptance do
     Rake::Task["ci"].invoke
     header "google acceptance", "*"
     sh "bundle exec rake acceptance -v"

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -456,7 +456,7 @@ end
 
 namespace :ci do
   desc "Run the CI build, with acceptance tests."
-  task :smoke_test do
+  task :acceptance do
     Rake::Task["ci"].invoke
     header "google-example acceptance", "*"
     sh "bundle exec rake acceptance -v"


### PR DESCRIPTION
#1660 renamed some tasks to introduce `ci:acceptance`, but in the wrong
place. The acceptance task should be runnable in all cases, even when
there are no smoke tests.