### PR TITLE
Java: updating set of services with no resource names

### DIFF
--- a/src/main/java/com/google/api/codegen/grpcmetadatagen/java/JavaPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/grpcmetadatagen/java/JavaPackageMetadataTransformer.java
@@ -31,14 +31,7 @@ public abstract class JavaPackageMetadataTransformer {
   // TODO determine if an API uses resource names from GAPIC config
   // https://github.com/googleapis/toolkit/issues/1668
   private ImmutableSet<String> SERVICES_WITH_NO_RESOURCE_NAMES =
-      ImmutableSet.of(
-          "common-protos",
-          "longrunning",
-          "language",
-          "speech",
-          "trace",
-          "video-intelligence",
-          "vision");
+      ImmutableSet.of("common-protos", "language", "speech", "video-intelligence", "vision");
 
   private final PackageMetadataTransformer metadataTransformer = new PackageMetadataTransformer();
 


### PR DESCRIPTION
- longrunning is no longer a package we generate
- trace v2 has resource names