### PR TITLE
go: make metadata private

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -69,7 +69,7 @@
         CallOptions *{@view.callOptionsTypeName}
 
         // The metadata to be sent with each request.
-        Metadata metadata.MD
+        xGoogMetadata metadata.MD
     }
 
     // {@view.clientConstructorName} creates a new {@view.servicePhraseName} client.
@@ -124,7 +124,7 @@
     func (c *{@view.clientTypeName}) {@setClientInfoFunc(view)}(keyval ...string) {
         kv := append([]string{"gl-go", version.Go()}, keyval...)
         kv = append(kv, "gapic", version.Repo, "gax", gax.Version, "grpc", grpc.Version)
-        c.Metadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
+        c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
     }
 
     @join getter : view.pathTemplateGetters
@@ -479,9 +479,9 @@
 @private mergeMetadata(method)
     @if method.headerRequestParams
         md := metadata.Pairs("x-goog-request-params", {@headerRequestParamString(method.headerRequestParams)})
-        ctx = insertMetadata(ctx, c.Metadata, md)
+        ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     @else
-        ctx = insertMetadata(ctx, c.Metadata)
+        ctx = insertMetadata(ctx, c.xGoogMetadata)
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -68,7 +68,7 @@
         // The call options for this service.
         CallOptions *{@view.callOptionsTypeName}
 
-        // The metadata to be sent with each request.
+        // The x-goog-* metadata to be sent with each request.
         xGoogMetadata metadata.MD
     }
 

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -260,7 +260,7 @@ type Client struct {
     // The call options for this service.
     CallOptions *CallOptions
 
-    // The metadata to be sent with each request.
+    // The x-goog-* metadata to be sent with each request.
     xGoogMetadata metadata.MD
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -261,7 +261,7 @@ type Client struct {
     CallOptions *CallOptions
 
     // The metadata to be sent with each request.
-    Metadata metadata.MD
+    xGoogMetadata metadata.MD
 }
 
 // NewClient creates a new library service client.
@@ -326,7 +326,7 @@ func (c *Client) Close() error {
 func (c *Client) SetGoogleClientInfo(keyval ...string) {
     kv := append([]string{"gl-go", version.Go()}, keyval...)
     kv = append(kv, "gapic", version.Repo, "gax", gax.Version, "grpc", grpc.Version)
-    c.Metadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
+    c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
 // ShelfPath returns the path for the shelf resource.
@@ -368,7 +368,7 @@ func (c *Client) BookIAM(book *librarypb.Book) *iam.Handle {
 // CreateShelf creates a shelf, and returns the new Shelf.
 // RPC method comment may include special characters: <>&"`'@.
 func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.CreateShelf[0:len(c.CallOptions.CreateShelf):len(c.CallOptions.CreateShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -384,7 +384,7 @@ func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequ
 
 // GetShelf gets a shelf.
 func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetShelf[0:len(c.CallOptions.GetShelf):len(c.CallOptions.GetShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -400,7 +400,7 @@ func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, o
 
 // ListShelves lists shelves.
 func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequest, opts ...gax.CallOption) *ShelfIterator {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.ListShelves[0:len(c.CallOptions.ListShelves):len(c.CallOptions.ListShelves)], opts...)
     it := &ShelfIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Shelf, string, error) {
@@ -435,7 +435,7 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
 
 // DeleteShelf deletes a shelf.
 func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest, opts ...gax.CallOption) error {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.DeleteShelf[0:len(c.CallOptions.DeleteShelf):len(c.CallOptions.DeleteShelf)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -449,7 +449,7 @@ func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequ
 // other_shelf_name to shelf name, and deletes
 // other_shelf_name. Returns the updated shelf.
 func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.MergeShelves[0:len(c.CallOptions.MergeShelves):len(c.CallOptions.MergeShelves)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -466,7 +466,7 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
     md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "name", req.GetName(), "book.read", req.GetBook().GetRead()))
-    ctx = insertMetadata(ctx, c.Metadata, md)
+    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -482,7 +482,7 @@ func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookReques
 
 // PublishSeries creates a series of books.
 func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -498,7 +498,7 @@ func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeries
 
 // GetBook gets a book.
 func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetBook[0:len(c.CallOptions.GetBook):len(c.CallOptions.GetBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -514,7 +514,7 @@ func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opt
 
 // ListBooks lists books in a shelf.
 func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest, opts ...gax.CallOption) *BookIterator {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Book, string, error) {
@@ -549,7 +549,7 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest,
 
 // DeleteBook deletes a book.
 func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest, opts ...gax.CallOption) error {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.DeleteBook[0:len(c.CallOptions.DeleteBook):len(c.CallOptions.DeleteBook)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -561,7 +561,7 @@ func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookReques
 
 // UpdateBook updates a book.
 func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.UpdateBook[0:len(c.CallOptions.UpdateBook):len(c.CallOptions.UpdateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -577,7 +577,7 @@ func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReques
 
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.MoveBook[0:len(c.CallOptions.MoveBook):len(c.CallOptions.MoveBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -593,7 +593,7 @@ func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, o
 
 // ListStrings lists a primitive resource. To test go page streaming.
 func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequest, opts ...gax.CallOption) *StringIterator {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.ListStrings[0:len(c.CallOptions.ListStrings):len(c.CallOptions.ListStrings)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
@@ -628,7 +628,7 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
 
 // AddComments adds comments to a book
 func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest, opts ...gax.CallOption) error {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.AddComments[0:len(c.CallOptions.AddComments):len(c.CallOptions.AddComments)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -640,7 +640,7 @@ func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequ
 
 // GetBookFromArchive gets a book from an archive.
 func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookFromArchiveRequest, opts ...gax.CallOption) (*librarypb.BookFromArchive, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetBookFromArchive[0:len(c.CallOptions.GetBookFromArchive):len(c.CallOptions.GetBookFromArchive)], opts...)
     var resp *librarypb.BookFromArchive
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -656,7 +656,7 @@ func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookF
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
 func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetBookFromAnywhere[0:len(c.CallOptions.GetBookFromAnywhere):len(c.CallOptions.GetBookFromAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -672,7 +672,7 @@ func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBook
 
 // GetBookFromAbsolutelyAnywhere test proper OneOf-Any resource name mapping
 func (c *Client) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *librarypb.GetBookFromAbsolutelyAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetBookFromAbsolutelyAnywhere[0:len(c.CallOptions.GetBookFromAbsolutelyAnywhere):len(c.CallOptions.GetBookFromAbsolutelyAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -688,7 +688,7 @@ func (c *Client) GetBookFromAbsolutelyAnywhere(ctx context.Context, req *library
 
 // UpdateBookIndex updates the index of a book.
 func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest, opts ...gax.CallOption) error {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.UpdateBookIndex[0:len(c.CallOptions.UpdateBookIndex):len(c.CallOptions.UpdateBookIndex)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
@@ -701,7 +701,7 @@ func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookI
 // StreamShelves test server streaming
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelvesRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamShelvesClient, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.StreamShelves[0:len(c.CallOptions.StreamShelves):len(c.CallOptions.StreamShelves)], opts...)
     var resp librarypb.LibraryService_StreamShelvesClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -718,7 +718,7 @@ func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelves
 // StreamBooks test server streaming, non-paged responses.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamBooksClient, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.StreamBooks[0:len(c.CallOptions.StreamBooks):len(c.CallOptions.StreamBooks)], opts...)
     var resp librarypb.LibraryService_StreamBooksClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -735,7 +735,7 @@ func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequ
 // DiscussBook test bidi-streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_DiscussBookClient, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.DiscussBook[0:len(c.CallOptions.DiscussBook):len(c.CallOptions.DiscussBook)], opts...)
     var resp librarypb.LibraryService_DiscussBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -752,7 +752,7 @@ func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (libra
 // MonologAboutBook test client streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_MonologAboutBookClient, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.MonologAboutBook[0:len(c.CallOptions.MonologAboutBook):len(c.CallOptions.MonologAboutBook)], opts...)
     var resp librarypb.LibraryService_MonologAboutBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -768,7 +768,7 @@ func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (
 
 // FindRelatedBooks
 func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest, opts ...gax.CallOption) *StringIterator {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.FindRelatedBooks[0:len(c.CallOptions.FindRelatedBooks):len(c.CallOptions.FindRelatedBooks)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
@@ -803,7 +803,7 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 
 // addLabel adds a label to the entity.
 func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, opts ...gax.CallOption) (*taggerpb.AddLabelResponse, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.AddLabel[0:len(c.CallOptions.AddLabel):len(c.CallOptions.AddLabel)], opts...)
     var resp *taggerpb.AddLabelResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -819,7 +819,7 @@ func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, op
 
 // GetBigBook test long-running operations
 func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigBookOperation, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetBigBook[0:len(c.CallOptions.GetBigBook):len(c.CallOptions.GetBigBook)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -837,7 +837,7 @@ func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, 
 
 // GetBigNothing test long-running operations with empty return type.
 func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigNothingOperation, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.GetBigNothing[0:len(c.CallOptions.GetBigNothing):len(c.CallOptions.GetBigNothing)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -855,7 +855,7 @@ func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookReques
 
 // TestOptionalRequiredFlatteningParams test optional flattening parameters of all types
 func (c *Client) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest, opts ...gax.CallOption) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
-    ctx = insertMetadata(ctx, c.Metadata)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.TestOptionalRequiredFlatteningParams[0:len(c.CallOptions.TestOptionalRequiredFlatteningParams):len(c.CallOptions.TestOptionalRequiredFlatteningParams)], opts...)
     var resp *librarypb.TestOptionalRequiredFlatteningParamsResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {


### PR DESCRIPTION
This is technically a breaking change;
it was accidentally made public before.