### PR TITLE
Fix setRequestParamsExtractor -> setParamsExtractor typo in java snippets

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_stub.snip
@@ -154,7 +154,8 @@
           GrpcCallSettings.<{@methodDescriptor.requestTypeName}, {@methodDescriptor.responseTypeName}>newBuilder()
               .setMethodDescriptor({@methodDescriptor.name})
               @if methodDescriptor.hasHeaderRequestParams
-                .setRequestParamsExtractor({@requestParamsExtractor(methodDescriptor)})
+                .setParamsExtractor(
+                    {@requestParamsExtractor(methodDescriptor)})
               @end
               .build();
     @end

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -5424,15 +5424,16 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<CreateBookRequest, Book> createBookTransportSettings =
         GrpcCallSettings.<CreateBookRequest, Book>newBuilder()
             .setMethodDescriptor(createBookMethodDescriptor)
-            .setRequestParamsExtractor(new RequestParamsExtractor<CreateBookRequest>() {
-                                         @Override
-                                         public Map<String, String> extract(CreateBookRequest request) {
-                                           ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                                           params.put("name", String.valueOf(request.getName()));
-                                           params.put("book.read", String.valueOf(request.getBook().getRead()));
-                                           return params.build();
-                                         }
-                                       })
+            .setParamsExtractor(
+                new RequestParamsExtractor<CreateBookRequest>() {
+                  @Override
+                  public Map<String, String> extract(CreateBookRequest request) {
+                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
+                    params.put("name", String.valueOf(request.getName()));
+                    params.put("book.read", String.valueOf(request.getBook().getRead()));
+                    return params.build();
+                  }
+                })
             .build();
     GrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesTransportSettings =
         GrpcCallSettings.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()


### PR DESCRIPTION
The typo breaks header routing functionality.