### PR TITLE
Node.js: Accept point versions.

### DIFF
--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
@@ -26,7 +26,7 @@ public class NodeJSCodePathMapper implements GapicCodePathMapper {
     List<String> packages = Splitter.on(".").splitToList(elementFullName);
     if (packages.size() > 2) {
       String parentName = packages.get(packages.size() - 2);
-      if (parentName.matches("v[0-9]+((alpha|beta)[0-9]+)?")) {
+      if (parentName.matches("v[0-9]+(p[0-9]+)?((alpha|beta)[0-9]+)?")) {
         apiVersion = parentName;
       }
     }


### PR DESCRIPTION
This was making vision `v1p1beta1` toss files in the wrong place.