### PR TITLE
Rakefile updates for consistency with google-cloud-ruby

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataNamer.java
@@ -46,4 +46,8 @@ public class RubyPackageMetadataNamer extends PackageMetadataNamer {
   public String getOutputFileName() {
     return getMetadataIdentifier() + ".gemspec";
   }
+
+  public String getSmokeTestProjectVariable(String productName) {
+    return Name.from(productName, "test", "project").toUpperUnderscore();
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -292,6 +292,7 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer {
         .hasSmokeTests(hasSmokeTests)
         .versionPath(surfaceNamer.getVersionIndexFileImportName())
         .versionNamespace(validVersionNamespace(interfaceModels, surfaceNamer))
+        .smokeTestProjectVariable(namer.getSmokeTestProjectVariable(packageConfig.shortName()))
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
@@ -163,6 +163,9 @@ public abstract class PackageMetadataView implements ViewModel {
   @Nullable
   public abstract String sampleAppPackage();
 
+  @Nullable
+  public abstract String smokeTestProjectVariable();
+
   public static Builder newBuilder() {
     return new AutoValue_PackageMetadataView.Builder().hasSmokeTests(false);
   }
@@ -278,6 +281,9 @@ public abstract class PackageMetadataView implements ViewModel {
 
     /** Package name of the sample application. */
     public abstract Builder sampleAppPackage(String s);
+
+    /** Environment variable to determine the Google Cloud project used to run smoke tests. */
+    public abstract Builder smokeTestProjectVariable(String s);
 
     public abstract PackageMetadataView build();
   }

--- a/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
@@ -23,7 +23,6 @@
 
 @private header(fileHeader)
   {@toComments(fileHeader.copyrightLines)}
-  #
   {@toComments(fileHeader.licenseLines)}
 
   require "bundler/setup"
@@ -60,9 +59,9 @@
 @private smokeTestsTask(metadata)
   desc "Runs the smoke tests."
   task :smoke_test do
-    if ENV["SMOKE_TEST_PROJECT"].nil?
-      fail "The SMOKE_TEST_PROJECT environment variable must be set. "@\
-        "e.g SMOKE_TEST_PROJECT=test123 rake smoke_test"
+    if ENV["{@metadata.smokeTestProjectVariable}"].nil?
+      fail "The {@metadata.smokeTestProjectVariable} environment variable must be set. "@\
+        "e.g {@metadata.smokeTestProjectVariable}=test123 rake smoke_test"
     end
 
     $LOAD_PATH.unshift "lib", "smoke_test"
@@ -88,16 +87,16 @@
   @# Acceptance tests
   desc "Run the {@metadata.identifier} acceptance tests."
   task :acceptance do
-    @if metadata.hasSmokeTests
-      Rake::Task["smoke_test"].invoke
-    @else
-      puts "The {@metadata.identifier} gem does not have acceptance tests."
-    @end
+    Rake::Task["acceptance:run"].invoke
   end
 
   namespace :acceptance do
     task :run do
-      puts "This gem does not have acceptance tests."
+      @if metadata.hasSmokeTests
+        Rake::Task["smoke_test"].invoke
+      @else
+        puts "The {@metadata.identifier} gem does not have acceptance tests."
+      @end
     end
 
     desc "Run acceptance tests with coverage."

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -389,9 +389,9 @@ end
 
 desc "Runs the smoke tests."
 task :smoke_test do
-  if ENV["SMOKE_TEST_PROJECT"].nil?
-    fail "The SMOKE_TEST_PROJECT environment variable must be set. "\
-      "e.g SMOKE_TEST_PROJECT=test123 rake smoke_test"
+  if ENV["LIBRARY_TEST_PROJECT"].nil?
+    fail "The LIBRARY_TEST_PROJECT environment variable must be set. "\
+      "e.g LIBRARY_TEST_PROJECT=test123 rake smoke_test"
   end
 
   $LOAD_PATH.unshift "lib", "smoke_test"
@@ -415,12 +415,12 @@ end
 # Acceptance tests
 desc "Run the library acceptance tests."
 task :acceptance do
-  Rake::Task["smoke_test"].invoke
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
   task :run do
-    puts "This gem does not have acceptance tests."
+    Rake::Task["smoke_test"].invoke
   end
 
   desc "Run acceptance tests with coverage."

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -389,9 +389,9 @@ end
 
 desc "Runs the smoke tests."
 task :smoke_test do
-  if ENV["SMOKE_TEST_PROJECT"].nil?
-    fail "The SMOKE_TEST_PROJECT environment variable must be set. "\
-      "e.g SMOKE_TEST_PROJECT=test123 rake smoke_test"
+  if ENV["LIBRARY_TEST_PROJECT"].nil?
+    fail "The LIBRARY_TEST_PROJECT environment variable must be set. "\
+      "e.g LIBRARY_TEST_PROJECT=test123 rake smoke_test"
   end
 
   $LOAD_PATH.unshift "lib", "smoke_test"
@@ -415,12 +415,12 @@ end
 # Acceptance tests
 desc "Run the library acceptance tests."
 task :acceptance do
-  Rake::Task["smoke_test"].invoke
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
   task :run do
-    puts "This gem does not have acceptance tests."
+    Rake::Task["smoke_test"].invoke
   end
 
   desc "Run acceptance tests with coverage."

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -389,12 +389,12 @@ end
 # Acceptance tests
 desc "Run the google acceptance tests."
 task :acceptance do
-  puts "The google gem does not have acceptance tests."
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
   task :run do
-    puts "This gem does not have acceptance tests."
+    puts "The google gem does not have acceptance tests."
   end
 
   desc "Run acceptance tests with coverage."

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -376,12 +376,12 @@ end
 # Acceptance tests
 desc "Run the google-example acceptance tests."
 task :acceptance do
-  puts "The google-example gem does not have acceptance tests."
+  Rake::Task["acceptance:run"].invoke
 end
 
 namespace :acceptance do
   task :run do
-    puts "This gem does not have acceptance tests."
+    puts "The google-example gem does not have acceptance tests."
   end
 
   desc "Run acceptance tests with coverage."


### PR DESCRIPTION
- Have the `:acceptance` task invoke `acceptance:run`
- Look for the smoke test project in {API_NAME}_TEST_PROJECT env var,
  rather than SMOKE_TEST_PROJECT

Updates #1704
Fixes #1688