### PR TITLE
Disconnect ConfigAdvisor from CodeGeneratorApi

### DIFF
--- a/src/main/java/com/google/api/codegen/CodeGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/CodeGeneratorApi.java
@@ -17,13 +17,11 @@ package com.google.api.codegen;
 import com.google.api.codegen.advising.Adviser;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
-import com.google.api.codegen.configgen.MessageGenerator;
-import com.google.api.codegen.configgen.mergers.ProtoConfigMerger;
-import com.google.api.codegen.configgen.nodes.ConfigNode;
 import com.google.api.codegen.gapic.GapicGeneratorConfig;
 import com.google.api.codegen.gapic.GapicProvider;
 import com.google.api.codegen.gapic.GapicProviderFactory;
 import com.google.api.codegen.util.ClassInstantiator;
+import com.google.api.tools.framework.model.ConfigSource;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.SimpleLocation;
@@ -36,9 +34,11 @@ import com.google.api.tools.framework.tools.ToolUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.inject.TypeLiteral;
 import com.google.protobuf.ExtensionRegistry;
+import com.google.protobuf.Message;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -103,12 +103,17 @@ public class CodeGeneratorApi extends ToolDriverBase {
       return;
     }
 
-    model.establishStage(Merged.KEY);
+    ConfigSource configSource = loadConfigFromFiles(configFileNames);
+    if (configSource == null) {
+      return;
+    }
 
-    ConfigProto configProto = loadConfigFromFiles(configFileNames);
+    ConfigProto configProto = (ConfigProto) configSource.getConfig();
     if (configProto == null) {
       return;
     }
+
+    model.establishStage(Merged.KEY);
 
     List<String> adviceSuppressors = options.get(ADVICE_SUPPRESSORS);
     Adviser adviser = new Adviser(adviceSuppressors);
@@ -190,24 +195,15 @@ public class CodeGeneratorApi extends ToolDriverBase {
     return provider;
   }
 
-  private ConfigProto loadConfigFromFiles(List<String> configFileNames) {
+  private ConfigSource loadConfigFromFiles(List<String> configFileNames) {
     List<File> configFiles = pathsToFiles(configFileNames);
     if (model.getDiagCollector().getErrorCount() > 0) {
       return null;
     }
-
-    ProtoConfigMerger configMerger = new ProtoConfigMerger();
-    MessageGenerator messageGenerator = new MessageGenerator(ConfigProto.newBuilder());
-    for (File file : configFiles) {
-      ConfigNode configNode = configMerger.mergeConfig(model, file);
-      messageGenerator.visit(configNode.getChild());
-    }
-    ConfigProto configProto = (ConfigProto) messageGenerator.getValue();
-    if (configProto == null || configProto.equals(ConfigProto.getDefaultInstance())) {
-      return null;
-    }
-
-    return configProto;
+    ImmutableMap<String, Message> supportedConfigTypes =
+        ImmutableMap.<String, Message>of(
+            ConfigProto.getDescriptor().getFullName(), ConfigProto.getDefaultInstance());
+    return MultiYamlReader.read(model.getDiagCollector(), configFiles, supportedConfigTypes);
   }
 
   private List<File> pathsToFiles(List<String> configFileNames) {

--- a/src/main/java/com/google/api/codegen/MultiYamlReader.java
+++ b/src/main/java/com/google/api/codegen/MultiYamlReader.java
@@ -1,0 +1,95 @@
+/* Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import com.google.api.tools.framework.model.ConfigSource;
+import com.google.api.tools.framework.model.Diag;
+import com.google.api.tools.framework.model.DiagCollector;
+import com.google.api.tools.framework.model.SimpleLocation;
+import com.google.api.tools.framework.yaml.YamlReader;
+import com.google.common.base.Preconditions;
+import com.google.common.io.Files;
+import com.google.protobuf.Message;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+public class MultiYamlReader {
+
+  @Nullable
+  public static ConfigSource read(
+      DiagCollector collector,
+      List<String> inputNames,
+      List<String> inputs,
+      Map<String, Message> supportedConfigTypes) {
+    Preconditions.checkArgument(
+        inputNames.size() == inputs.size(),
+        "size() of inputNames and inputs not equal: %d != %d",
+        inputNames.size(),
+        inputs.size());
+    ConfigSource.Builder sourceBuilder = null;
+    for (int i = 0; i < inputs.size(); i++) {
+      String inputName = inputNames.get(i);
+      String input = inputs.get(i);
+
+      ConfigSource source =
+          YamlReader.readConfig(collector, inputName, input, supportedConfigTypes);
+
+      if (source != null) {
+        if (sourceBuilder == null) {
+          sourceBuilder = source.toBuilder();
+        } else {
+          sourceBuilder.mergeFrom(source);
+        }
+      }
+    }
+
+    if (sourceBuilder == null) {
+      return null;
+    } else {
+      return sourceBuilder.build();
+    }
+  }
+
+  @Nullable
+  public static ConfigSource read(
+      DiagCollector collector, List<File> files, Map<String, Message> supportedConfigTypes) {
+    List<String> inputNames = new ArrayList<>();
+    List<String> inputs = new ArrayList<>();
+    for (File file : files) {
+      inputNames.add(file.getName());
+      try {
+        String fileContent = Files.toString(file, Charset.forName("UTF8"));
+        inputs.add(fileContent);
+      } catch (IOException e) {
+        collector.addDiag(
+            Diag.error(
+                SimpleLocation.TOPLEVEL,
+                "Cannot read configuration file '%s': %s",
+                file.getName(),
+                e.getMessage()));
+      }
+    }
+    if (collector.getErrorCount() > 0) {
+      return null;
+    } else {
+      return read(collector, inputNames, inputs, supportedConfigTypes);
+    }
+  }
+}


### PR DESCRIPTION
This is a partial rollback for a bug that CodeGeneratorApi seems to have
introduced for Ruby libraries where the GAPIC config is no longer being
parsed properly.

This rolls back #1692 for the files affected.

I've verified the repro case in #1736 (Ruby LRO package).

See https://github.com/googleapis/toolkit/issues/1736