### PR TITLE
Add support for custom static headers

### DIFF
--- a/src/main/java/com/google/api/codegen/GeneratorVersionProvider.java
+++ b/src/main/java/com/google/api/codegen/GeneratorVersionProvider.java
@@ -15,24 +15,19 @@
 package com.google.api.codegen;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Properties;
 
 public class GeneratorVersionProvider {
-  private static final String DEFAULT_VERSION = "0.0.5";
+
+  private static final String DEFAULT_VERSION = "";
 
   public static String getGeneratorVersion() {
     String version = DEFAULT_VERSION;
     Properties properties = new Properties();
-
     try {
-      InputStream resourceStream =
+      properties.load(
           GeneratorVersionProvider.class
-              .getResourceAsStream("/com/google/api/codegen/codegen.properties");
-      if (resourceStream == null) {
-        return version;
-      }
-      properties.load(resourceStream);
+              .getResourceAsStream("/com/google/api/codegen/codegen.properties"));
       version = properties.getProperty("version");
     } catch (IOException e) {
       e.printStackTrace(System.err);

--- a/src/main/java/com/google/api/codegen/GeneratorVersionProvider.java
+++ b/src/main/java/com/google/api/codegen/GeneratorVersionProvider.java
@@ -15,19 +15,24 @@
 package com.google.api.codegen;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 public class GeneratorVersionProvider {
-
-  private static final String DEFAULT_VERSION = "";
+  private static final String DEFAULT_VERSION = "0.0.5";
 
   public static String getGeneratorVersion() {
     String version = DEFAULT_VERSION;
     Properties properties = new Properties();
+
     try {
-      properties.load(
+      InputStream resourceStream =
           GeneratorVersionProvider.class
-              .getResourceAsStream("/com/google/api/codegen/codegen.properties"));
+              .getResourceAsStream("/com/google/api/codegen/codegen.properties");
+      if (resourceStream == null) {
+        return version;
+      }
+      properties.load(resourceStream);
       version = properties.getProperty("version");
     } catch (IOException e) {
       e.printStackTrace(System.err);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -338,9 +338,12 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
   private void addUnitTestImports(InterfaceContext context) {
     ImportTypeTable typeTable = context.getImportTypeTable();
     typeTable.saveNicknameFor("com.google.api.gax.core.NoCredentialsProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiClientHeaderProvider");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.InvalidArgumentException");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.StatusCode");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcClientHeaderProvider");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcStatusCode");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.testing.LocalChannelProvider");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.testing.MockGrpcService");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.testing.MockServiceHelper");
     typeTable.saveNicknameFor("com.google.common.collect.Lists");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -341,7 +341,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiClientHeaderProvider");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.InvalidArgumentException");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.StatusCode");
-    typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcClientHeaderProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.GaxGrpcProperties");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcStatusCode");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.testing.LocalChannelProvider");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.testing.MockGrpcService");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -652,9 +652,9 @@ public class JavaSurfaceTransformer {
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.core.CredentialsProvider");
     typeTable.saveNicknameFor("com.google.api.gax.core.ExecutorProvider");
+    typeTable.saveNicknameFor("com.google.api.gax.core.GaxProperties");
     typeTable.saveNicknameFor("com.google.api.gax.core.GoogleCredentialsProvider");
     typeTable.saveNicknameFor("com.google.api.gax.core.InstantiatingExecutorProvider");
-    typeTable.saveNicknameFor("com.google.api.gax.core.PropertiesProvider");
     typeTable.saveNicknameFor("com.google.api.gax.retrying.RetrySettings");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiClientHeaderProvider");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.ClientContext");
@@ -714,12 +714,13 @@ public class JavaSurfaceTransformer {
         if (interfaceConfig.hasLongRunningOperations()) {
           typeTable.saveNicknameFor("com.google.api.gax.grpc.ProtoOperationTransformers");
         }
-        typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcExtraHeaderData");
+        typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcClientHeaderProvider");
         break;
       case DISCOVERY:
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonTransportChannel");
         typeTable.saveNicknameFor(
             "com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider");
+        typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonClientHeaderProvider");
         break;
     }
   }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -714,13 +714,13 @@ public class JavaSurfaceTransformer {
         if (interfaceConfig.hasLongRunningOperations()) {
           typeTable.saveNicknameFor("com.google.api.gax.grpc.ProtoOperationTransformers");
         }
-        typeTable.saveNicknameFor("com.google.api.gax.grpc.GrpcClientHeaderProvider");
+        typeTable.saveNicknameFor("com.google.api.gax.grpc.GaxGrpcProperties");
         break;
       case DISCOVERY:
         typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonTransportChannel");
         typeTable.saveNicknameFor(
             "com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider");
-        typeTable.saveNicknameFor("com.google.api.gax.httpjson.HttpJsonClientHeaderProvider");
+        typeTable.saveNicknameFor("com.google.api.gax.httpjson.GaxHttpJsonProperties");
         break;
     }
   }

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -157,7 +157,7 @@
     @else
       return HttpJsonClientHeaderProvider.newBuilder()
     @end
-        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion({@xsettingsClass.name}.class));
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion({@xsettingsClass.name}.class));
   }
 
   /**

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -69,14 +69,6 @@
         .build();
     {@""}
   @end
-
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE = "/{@xsettingsClass.packagePath}/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
   {@""}
 @end
 
@@ -160,22 +152,12 @@
 
   @@BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        @if xsettingsClass.transportProtocol == "GRPC"
-          .addApiClientHeaderLineData(GrpcExtraHeaderData.getXGoogApiClientData())
-        @end
-        ;
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion = PropertiesProvider.loadProperty(
-          {@xsettingsClass.name}.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+    @if xsettingsClass.transportProtocol == "GRPC"
+      return GrpcClientHeaderProvider.newBuilder()
+    @else
+      return HttpJsonClientHeaderProvider.newBuilder()
+    @end
+        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion({@xsettingsClass.name}.class));
   }
 
   /**
@@ -571,7 +553,7 @@
     @if xsettingsClass.hasDefaultInstance
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
-      builder.setHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
     @end
     return initDefaults(builder);

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -152,12 +152,13 @@
 
   @@BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    @if xsettingsClass.transportProtocol == "GRPC"
-      return GrpcClientHeaderProvider.newBuilder()
-    @else
-      return HttpJsonClientHeaderProvider.newBuilder()
-    @end
-        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion({@xsettingsClass.name}.class));
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion({@xsettingsClass.name}.class))
+        @if xsettingsClass.transportProtocol == "GRPC"
+          .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
+        @else
+          .setTransportToken(GaxHttpJsonProperties.getHttpJsonTokenName(), GaxHttpJsonProperties.getHttpJsonVersion());
+        @end
   }
 
   /**

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -11,6 +11,7 @@
     @end
     private static MockServiceHelper serviceHelper;
     private {@xapiTest.testClass.apiClassName} client;
+    private LocalChannelProvider channelProvider;
 
     @@BeforeClass
     public static void startStaticServer() {
@@ -29,8 +30,9 @@
     @@Before
     public void setUp() throws IOException {
       serviceHelper.reset();
+      channelProvider = serviceHelper.createChannelProvider();
       {@xapiTest.testClass.apiSettingsClassName} settings = {@xapiTest.testClass.apiSettingsClassName}.newBuilder()
-          .setTransportChannelProvider(serviceHelper.createChannelProvider())
+          .setTransportChannelProvider(channelProvider)
           .setCredentialsProvider(NoCredentialsProvider.create())
           .build();
       client = {@xapiTest.testClass.apiClassName}.create(settings);
@@ -287,6 +289,10 @@
       @end
     @end
   @end
+  Assert.assertTrue(
+      channelProvider.validateSentHeader(
+          ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+          GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
 @end
 
 @private sampleMethodCallArgList(fieldSettings)

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -290,9 +290,9 @@
     @end
   @end
   Assert.assertTrue(
-      channelProvider.validateSentHeader(
+      channelProvider.isHeaderSent(
           ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-          GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+          GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
 @end
 
 @private sampleMethodCallArgList(fieldSettings)

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -5203,9 +5203,10 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.core.PropertiesProvider;
+import com.google.api.gax.httpjson.HttpJsonClientHeaderProvider;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -5278,14 +5279,6 @@ public class AddressSettings extends ClientSettings<AddressSettings> {
       .add("https://www.googleapis.com/auth/devstorage.read_only")
       .add("https://www.googleapis.com/auth/devstorage.read_write")
       .build();
-
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE = "/com/google/cloud/simplecompute/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
 
   private final UnaryCallSettings<DeleteAddressHttpRequest, Operation> deleteAddressSettings;
   private final UnaryCallSettings<GetAddressHttpRequest, Address> getAddressSettings;
@@ -5383,19 +5376,8 @@ public class AddressSettings extends ClientSettings<AddressSettings> {
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        ;
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion = PropertiesProvider.loadProperty(
-          AddressSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+    return HttpJsonClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion(AddressSettings.class));
   }
 
   /**
@@ -5549,7 +5531,7 @@ public class AddressSettings extends ClientSettings<AddressSettings> {
       Builder builder = new Builder((ClientContext) null);
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
-      builder.setHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
       return initDefaults(builder);
     }

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -5377,7 +5377,7 @@ public class AddressSettings extends ClientSettings<AddressSettings> {
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return HttpJsonClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion(AddressSettings.class));
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(AddressSettings.class));
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -5206,7 +5206,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.httpjson.HttpJsonClientHeaderProvider;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.HttpJsonTransportChannel;
 import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -5376,8 +5376,9 @@ public class AddressSettings extends ClientSettings<AddressSettings> {
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return HttpJsonClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(AddressSettings.class));
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(AddressSettings.class))
+        .setTransportToken(GaxHttpJsonProperties.getHttpJsonTokenName(), GaxHttpJsonProperties.getHttpJsonVersion());
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -5976,10 +5976,13 @@ package com.google.gcloud.pubsub.v1;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.core.PagedListResponse;
+import com.google.api.gax.grpc.GrpcClientHeaderProvider;
 import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
 import com.google.api.gax.grpc.testing.MockStreamObserver;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.ApiStreamObserver;
 import com.google.api.gax.rpc.BidiStreamingCallable;
 import com.google.api.gax.rpc.InvalidArgumentException;
@@ -6069,6 +6072,7 @@ public class LibraryClientTest {
   private static MockLabeler mockLabeler;
   private static MockServiceHelper serviceHelper;
   private LibraryClient client;
+  private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -6086,8 +6090,9 @@ public class LibraryClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
     LibrarySettings settings = LibrarySettings.newBuilder()
-        .setTransportChannelProvider(serviceHelper.createChannelProvider())
+        .setTransportChannelProvider(channelProvider)
         .setCredentialsProvider(NoCredentialsProvider.create())
         .build();
     client = LibraryClient.create(settings);
@@ -6122,6 +6127,10 @@ public class LibraryClientTest {
     CreateShelfRequest actualRequest = (CreateShelfRequest)actualRequests.get(0);
 
     Assert.assertEquals(shelf, actualRequest.getShelf());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6164,6 +6173,10 @@ public class LibraryClientTest {
     GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6208,6 +6221,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(message, actualRequest.getMessage());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6255,6 +6272,10 @@ public class LibraryClientTest {
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(message, actualRequest.getMessage());
     Assert.assertEquals(stringBuilder, actualRequest.getStringBuilder());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6299,6 +6320,10 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
 
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6332,6 +6357,10 @@ public class LibraryClientTest {
     DeleteShelfRequest actualRequest = (DeleteShelfRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6376,6 +6405,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
     Assert.assertEquals(otherShelfName, actualRequest.getOtherShelfNameAsShelfName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6423,6 +6456,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(book, actualRequest.getBook());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6472,6 +6509,10 @@ public class LibraryClientTest {
     Assert.assertEquals(books, actualRequest.getBooksList());
     Assert.assertEquals(edition, actualRequest.getEdition());
     Assert.assertEquals(seriesUuid, actualRequest.getSeriesUuid());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6522,6 +6563,10 @@ public class LibraryClientTest {
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6567,6 +6612,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
     Assert.assertEquals(filter, actualRequest.getFilter());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6601,6 +6650,10 @@ public class LibraryClientTest {
     DeleteBookRequest actualRequest = (DeleteBookRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6647,6 +6700,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertEquals(book, actualRequest.getBook());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6700,6 +6757,10 @@ public class LibraryClientTest {
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
     Assert.assertEquals(physicalMask, actualRequest.getPhysicalMask());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6750,6 +6811,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertEquals(otherShelfName, actualRequest.getOtherShelfNameAsShelfName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6796,6 +6861,10 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
 
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6842,6 +6911,10 @@ public class LibraryClientTest {
     ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
 
     Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getNameAsResourceName()));
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6885,6 +6958,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(comments, actualRequest.getCommentsList());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6938,6 +7015,10 @@ public class LibraryClientTest {
     GetBookFromArchiveRequest actualRequest = (GetBookFromArchiveRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsArchivedBookName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6984,6 +7065,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookNameOneof());
     Assert.assertEquals(BookNameOneof.from(altBookName), actualRequest.getAltBookNameAsBookNameOneof());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7029,6 +7114,10 @@ public class LibraryClientTest {
     GetBookFromAbsolutelyAnywhereRequest actualRequest = (GetBookFromAbsolutelyAnywhereRequest)actualRequests.get(0);
 
     Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getNameAsResourceName()));
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7068,6 +7157,10 @@ public class LibraryClientTest {
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertEquals(indexName, actualRequest.getIndexName());
     Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7281,6 +7374,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(names, actualRequest.getNamesListAsBookNameList());
     Assert.assertEquals(shelves, actualRequest.getShelvesListAsShelfNameList());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7320,6 +7417,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(formattedResource, actualRequest.getResource());
     Assert.assertEquals(tag, actualRequest.getTag());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7358,6 +7459,10 @@ public class LibraryClientTest {
 
     Assert.assertEquals(formattedResource, actualRequest.getResource());
     Assert.assertEquals(label, actualRequest.getLabel());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7409,6 +7514,10 @@ public class LibraryClientTest {
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7453,6 +7562,10 @@ public class LibraryClientTest {
     GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7490,6 +7603,10 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     TestOptionalRequiredFlatteningParamsRequest actualRequest = (TestOptionalRequiredFlatteningParamsRequest)actualRequests.get(0);
 
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7631,6 +7748,10 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalRepeatedFixed32, actualRequest.getOptionalRepeatedFixed32List());
     Assert.assertEquals(optionalRepeatedFixed64, actualRequest.getOptionalRepeatedFixed64List());
     Assert.assertEquals(optionalMap, actualRequest.getOptionalMapMap());
+    Assert.assertTrue(
+        channelProvider.validateSentHeader(
+            ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
+            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -2976,10 +2976,10 @@ import com.google.api.gax.batching.PartitionKey;
 import com.google.api.gax.batching.RequestBuilder;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.core.PropertiesProvider;
-import com.google.api.gax.grpc.GrpcExtraHeaderData;
+import com.google.api.gax.grpc.GrpcClientHeaderProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.grpc.OperationFuture;
@@ -3105,14 +3105,6 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
       .add("https://www.googleapis.com/auth/cloud-platform")
       .add("https://www.googleapis.com/auth/library")
       .build();
-
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE = "/com/google/gcloud/pubsub/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
 
   private final UnaryCallSettings<CreateShelfRequest, Shelf> createShelfSettings;
   private final UnaryCallSettings<GetShelfRequest, Shelf> getShelfSettings;
@@ -3411,20 +3403,8 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        .addApiClientHeaderLineData(GrpcExtraHeaderData.getXGoogApiClientData())
-        ;
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion = PropertiesProvider.loadProperty(
-          LibrarySettings.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+    return GrpcClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion(LibrarySettings.class));
   }
 
   /**
@@ -3971,7 +3951,7 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
       Builder builder = new Builder((ClientContext) null);
       builder.setTransportChannelProvider(defaultTransportChannelProvider());
       builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
-      builder.setHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
       builder.setEndpoint(getDefaultEndpoint());
       return initDefaults(builder);
     }

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -3404,7 +3404,7 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return GrpcClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion(LibrarySettings.class));
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(LibrarySettings.class));
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -2979,7 +2979,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.grpc.GrpcClientHeaderProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.grpc.OperationFuture;
@@ -3403,8 +3403,9 @@ public class LibrarySettings extends ClientSettings<LibrarySettings> {
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return GrpcClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(LibrarySettings.class));
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(LibrarySettings.class))
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   /**
@@ -5976,7 +5977,7 @@ package com.google.gcloud.pubsub.v1;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.core.PagedListResponse;
-import com.google.api.gax.grpc.GrpcClientHeaderProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
@@ -6128,9 +6129,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(shelf, actualRequest.getShelf());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6174,9 +6175,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6222,9 +6223,9 @@ public class LibraryClientTest {
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(message, actualRequest.getMessage());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6273,9 +6274,9 @@ public class LibraryClientTest {
     Assert.assertEquals(message, actualRequest.getMessage());
     Assert.assertEquals(stringBuilder, actualRequest.getStringBuilder());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6321,9 +6322,9 @@ public class LibraryClientTest {
     ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
 
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6358,9 +6359,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6406,9 +6407,9 @@ public class LibraryClientTest {
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
     Assert.assertEquals(otherShelfName, actualRequest.getOtherShelfNameAsShelfName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6457,9 +6458,9 @@ public class LibraryClientTest {
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6510,9 +6511,9 @@ public class LibraryClientTest {
     Assert.assertEquals(edition, actualRequest.getEdition());
     Assert.assertEquals(seriesUuid, actualRequest.getSeriesUuid());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6564,9 +6565,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6613,9 +6614,9 @@ public class LibraryClientTest {
     Assert.assertEquals(name, actualRequest.getNameAsShelfName());
     Assert.assertEquals(filter, actualRequest.getFilter());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6651,9 +6652,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6701,9 +6702,9 @@ public class LibraryClientTest {
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertEquals(book, actualRequest.getBook());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6758,9 +6759,9 @@ public class LibraryClientTest {
     Assert.assertEquals(updateMask, actualRequest.getUpdateMask());
     Assert.assertEquals(physicalMask, actualRequest.getPhysicalMask());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6812,9 +6813,9 @@ public class LibraryClientTest {
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertEquals(otherShelfName, actualRequest.getOtherShelfNameAsShelfName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6862,9 +6863,9 @@ public class LibraryClientTest {
     ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
 
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6912,9 +6913,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getNameAsResourceName()));
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -6959,9 +6960,9 @@ public class LibraryClientTest {
     Assert.assertEquals(formattedName, actualRequest.getName());
     Assert.assertEquals(comments, actualRequest.getCommentsList());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7016,9 +7017,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsArchivedBookName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7066,9 +7067,9 @@ public class LibraryClientTest {
     Assert.assertEquals(name, actualRequest.getNameAsBookNameOneof());
     Assert.assertEquals(BookNameOneof.from(altBookName), actualRequest.getAltBookNameAsBookNameOneof());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7115,9 +7116,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getNameAsResourceName()));
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7158,9 +7159,9 @@ public class LibraryClientTest {
     Assert.assertEquals(indexName, actualRequest.getIndexName());
     Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7375,9 +7376,9 @@ public class LibraryClientTest {
     Assert.assertEquals(names, actualRequest.getNamesListAsBookNameList());
     Assert.assertEquals(shelves, actualRequest.getShelvesListAsShelfNameList());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7418,9 +7419,9 @@ public class LibraryClientTest {
     Assert.assertEquals(formattedResource, actualRequest.getResource());
     Assert.assertEquals(tag, actualRequest.getTag());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7460,9 +7461,9 @@ public class LibraryClientTest {
     Assert.assertEquals(formattedResource, actualRequest.getResource());
     Assert.assertEquals(label, actualRequest.getLabel());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7515,9 +7516,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7563,9 +7564,9 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7604,9 +7605,9 @@ public class LibraryClientTest {
     TestOptionalRequiredFlatteningParamsRequest actualRequest = (TestOptionalRequiredFlatteningParamsRequest)actualRequests.get(0);
 
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test
@@ -7749,9 +7750,9 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalRepeatedFixed64, actualRequest.getOptionalRepeatedFixed64List());
     Assert.assertEquals(optionalMap, actualRequest.getOptionalMapMap());
     Assert.assertTrue(
-        channelProvider.validateSentHeader(
+        channelProvider.isHeaderSent(
             ApiClientHeaderProvider.getDefaultApiClientHeaderKey(),
-            GrpcClientHeaderProvider.getDefaultApiClientHeaderPattern()));
+            GaxGrpcProperties.getDefaultApiClientHeaderPattern()));
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -241,7 +241,7 @@ import com.google.api.gax.core.ExecutorProvider;
 import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.grpc.GrpcClientHeaderProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -319,8 +319,9 @@ public class NoTemplatesApiServiceSettings extends ClientSettings<NoTemplatesApi
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return GrpcClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(NoTemplatesApiServiceSettings.class));
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(NoTemplatesApiServiceSettings.class))
+        .setTransportToken(GaxGrpcProperties.getGrpcTokenName(), GaxGrpcProperties.getGrpcVersion());
   }
 
   /**
@@ -789,7 +790,7 @@ public class MockNoTemplatesAPIServiceImpl extends NoTemplatesAPIServiceImplBase
 package com.google.gcloud.example;
 
 import com.google.api.gax.core.NoCredentialsProvider;
-import com.google.api.gax.grpc.GrpcClientHeaderProvider;
+import com.google.api.gax.grpc.GaxGrpcProperties;
 import com.google.api.gax.grpc.GrpcStatusCode;
 import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -238,10 +238,10 @@ import com.google.api.core.ApiFunction;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.InstantiatingExecutorProvider;
-import com.google.api.gax.core.PropertiesProvider;
-import com.google.api.gax.grpc.GrpcExtraHeaderData;
+import com.google.api.gax.grpc.GrpcClientHeaderProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.api.gax.retrying.RetrySettings;
@@ -276,14 +276,6 @@ import org.threeten.bp.Duration;
 @Generated("by GAPIC v0.0.5")
 @BetaApi
 public class NoTemplatesApiServiceSettings extends ClientSettings<NoTemplatesApiServiceSettings> {
-
-  private static final String DEFAULT_GAPIC_NAME = "gapic";
-  private static final String DEFAULT_GAPIC_VERSION = "";
-
-  private static final String PROPERTIES_FILE = "/com/google/gcloud/example/project.properties";
-  private static final String META_VERSION_KEY = "artifact.version";
-
-  private static String gapicVersion;
 
   private final UnaryCallSettings<IncrementRequest, Empty> incrementSettings;
 
@@ -327,20 +319,8 @@ public class NoTemplatesApiServiceSettings extends ClientSettings<NoTemplatesApi
 
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
-    return ApiClientHeaderProvider.newBuilder()
-        .setGeneratorHeader(DEFAULT_GAPIC_NAME, getGapicVersion())
-        .setApiClientHeaderLineKey("x-goog-api-client")
-        .addApiClientHeaderLineData(GrpcExtraHeaderData.getXGoogApiClientData())
-        ;
-  }
-
-  private static String getGapicVersion() {
-    if (gapicVersion == null) {
-      gapicVersion = PropertiesProvider.loadProperty(
-          NoTemplatesApiServiceSettings.class, PROPERTIES_FILE, META_VERSION_KEY);
-      gapicVersion = gapicVersion == null ? DEFAULT_GAPIC_VERSION : gapicVersion;
-    }
-    return gapicVersion;
+    return GrpcClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion(NoTemplatesApiServiceSettings.class));
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -320,7 +320,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings<NoTemplatesApi
   @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
   public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
     return GrpcClientHeaderProvider.newBuilder()
-        .setGeneratedLibToken(null, GaxProperties.getLibraryVersion(NoTemplatesApiServiceSettings.class));
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(NoTemplatesApiServiceSettings.class));
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -789,9 +789,12 @@ public class MockNoTemplatesAPIServiceImpl extends NoTemplatesAPIServiceImplBase
 package com.google.gcloud.example;
 
 import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.GrpcClientHeaderProvider;
 import com.google.api.gax.grpc.GrpcStatusCode;
+import com.google.api.gax.grpc.testing.LocalChannelProvider;
 import com.google.api.gax.grpc.testing.MockGrpcService;
 import com.google.api.gax.grpc.testing.MockServiceHelper;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
 import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.api.gax.rpc.StatusCode;
 import com.google.common.collect.Lists;
@@ -816,6 +819,7 @@ public class NoTemplatesApiServiceClientTest {
   private static MockNoTemplatesAPIService mockNoTemplatesAPIService;
   private static MockServiceHelper serviceHelper;
   private NoTemplatesApiServiceClient client;
+  private LocalChannelProvider channelProvider;
 
   @BeforeClass
   public static void startStaticServer() {
@@ -832,8 +836,9 @@ public class NoTemplatesApiServiceClientTest {
   @Before
   public void setUp() throws IOException {
     serviceHelper.reset();
+    channelProvider = serviceHelper.createChannelProvider();
     NoTemplatesApiServiceSettings settings = NoTemplatesApiServiceSettings.newBuilder()
-        .setTransportChannelProvider(serviceHelper.createChannelProvider())
+        .setTransportChannelProvider(channelProvider)
         .setCredentialsProvider(NoCredentialsProvider.create())
         .build();
     client = NoTemplatesApiServiceClient.create(settings);


### PR DESCRIPTION
**gax** portion: https://github.com/googleapis/gax-java/pull/432
**gcj** portion: https://github.com/GoogleCloudPlatform/google-cloud-java/pull/2690

This also hardcodes generation version in GeneratorVersionProvider as default value (to make tests easier to run under IDE without need to execute prebuild setps).