### PR TITLE
make numeric init value non-negative

### DIFF
--- a/src/main/java/com/google/api/codegen/util/testing/StandardValueProducer.java
+++ b/src/main/java/com/google/api/codegen/util/testing/StandardValueProducer.java
@@ -30,7 +30,11 @@ public class StandardValueProducer implements ValueProducer {
       return Byte.toString(lowByte);
     } else if (typeRef.getPrimitiveTypeName().contains("int")
         || typeRef.getPrimitiveTypeName().contains("fixed")) {
-      return Integer.toString(identifier.hashCode());
+      int value = identifier.hashCode();
+      if (value == Integer.MIN_VALUE) {
+        value = 0;
+      }
+      return "" + Math.abs(value);
     } else if (typeRef.isDoubleType() || typeRef.isFloatType()) {
       return Double.toString(identifier.hashCode() / 10);
     } else {

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -3999,8 +3999,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
 
     mockLibrary.resps = append(mockLibrary.resps[:0], expectedResponse)
 
-    var requiredSingularInt32 int32 = -72313594
-    var requiredSingularInt64 int64 = -72313499
+    var requiredSingularInt32 int32 = 72313594
+    var requiredSingularInt64 int64 = 72313499
     var requiredSingularFloat float32 = -7514705.0
     var requiredSingularDouble float64 = 1.9111005E8
     var requiredSingularBool bool = true
@@ -4080,8 +4080,8 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     errCode := codes.PermissionDenied
     mockLibrary.err = gstatus.Error(errCode, "test error")
 
-    var requiredSingularInt32 int32 = -72313594
-    var requiredSingularInt64 int64 = -72313499
+    var requiredSingularInt32 int32 = 72313594
+    var requiredSingularInt64 int64 = 72313499
     var requiredSingularFloat float32 = -7514705.0
     var requiredSingularDouble float64 = 1.9111005E8
     var requiredSingularBool bool = true

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -6474,7 +6474,7 @@ public class LibraryClientTest {
 
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
-    int edition = -1887963714;
+    int edition = 1887963714;
     String seriesString = "foobar";
     SeriesUuid seriesUuid = SeriesUuid.newBuilder()
       .setSeriesString(seriesString)
@@ -6503,7 +6503,7 @@ public class LibraryClientTest {
     try {
       Shelf shelf = Shelf.newBuilder().build();
       List<Book> books = new ArrayList<>();
-      int edition = -1887963714;
+      int edition = 1887963714;
       String seriesString = "foobar";
       SeriesUuid seriesUuid = SeriesUuid.newBuilder()
         .setSeriesString(seriesString)
@@ -7534,8 +7534,8 @@ public class LibraryClientTest {
     TestOptionalRequiredFlatteningParamsResponse expectedResponse = TestOptionalRequiredFlatteningParamsResponse.newBuilder().build();
     mockLibraryService.addResponse(expectedResponse);
 
-    int requiredSingularInt32 = -72313594;
-    long requiredSingularInt64 = -72313499L;
+    int requiredSingularInt32 = 72313594;
+    long requiredSingularInt64 = 72313499L;
     float requiredSingularFloat = -7514705.0F;
     double requiredSingularDouble = 1.9111005E8;
     boolean requiredSingularBool = true;
@@ -7561,8 +7561,8 @@ public class LibraryClientTest {
     List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
     List<Long> requiredRepeatedFixed64 = new ArrayList<>();
     Map<Integer, String> requiredMap = new HashMap<>();
-    int optionalSingularInt32 = -1196565723;
-    long optionalSingularInt64 = -1196565628L;
+    int optionalSingularInt32 = 1196565723;
+    long optionalSingularInt64 = 1196565628L;
     float optionalSingularFloat = -1.19939918E8F;
     double optionalSingularDouble = 1.41902287E8;
     boolean optionalSingularBool = false;
@@ -7572,8 +7572,8 @@ public class LibraryClientTest {
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
     BookName optionalSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
     BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.from(BookName.of("[SHELF_ID]", "[BOOK_ID]"));
-    int optionalSingularFixed32 = -1648847958;
-    long optionalSingularFixed64 = -1648847863;
+    int optionalSingularFixed32 = 1648847958;
+    long optionalSingularFixed64 = 1648847863;
     List<Integer> optionalRepeatedInt32 = new ArrayList<>();
     List<Long> optionalRepeatedInt64 = new ArrayList<>();
     List<Float> optionalRepeatedFloat = new ArrayList<>();
@@ -7660,8 +7660,8 @@ public class LibraryClientTest {
     mockLibraryService.addException(exception);
 
     try {
-      int requiredSingularInt32 = -72313594;
-      long requiredSingularInt64 = -72313499L;
+      int requiredSingularInt32 = 72313594;
+      long requiredSingularInt64 = 72313499L;
       float requiredSingularFloat = -7514705.0F;
       double requiredSingularDouble = 1.9111005E8;
       boolean requiredSingularBool = true;
@@ -7687,8 +7687,8 @@ public class LibraryClientTest {
       List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
       List<Long> requiredRepeatedFixed64 = new ArrayList<>();
       Map<Integer, String> requiredMap = new HashMap<>();
-      int optionalSingularInt32 = -1196565723;
-      long optionalSingularInt64 = -1196565628L;
+      int optionalSingularInt32 = 1196565723;
+      long optionalSingularInt64 = 1196565628L;
       float optionalSingularFloat = -1.19939918E8F;
       double optionalSingularDouble = 1.41902287E8;
       boolean optionalSingularBool = false;
@@ -7698,8 +7698,8 @@ public class LibraryClientTest {
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
       BookName optionalSingularResourceName = BookName.of("[SHELF_ID]", "[BOOK_ID]");
       BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.from(BookName.of("[SHELF_ID]", "[BOOK_ID]"));
-      int optionalSingularFixed32 = -1648847958;
-      long optionalSingularFixed64 = -1648847863;
+      int optionalSingularFixed32 = 1648847958;
+      long optionalSingularFixed64 = 1648847863;
       List<Integer> optionalRepeatedInt32 = new ArrayList<>();
       List<Long> optionalRepeatedInt64 = new ArrayList<>();
       List<Float> optionalRepeatedFloat = new ArrayList<>();

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -6665,8 +6665,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      var requiredSingularInt32 = -72313594;
-      var requiredSingularInt64 = -72313499;
+      var requiredSingularInt32 = 72313594;
+      var requiredSingularInt64 = 72313499;
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;
@@ -6745,8 +6745,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      var requiredSingularInt32 = -72313594;
-      var requiredSingularInt64 = -72313499;
+      var requiredSingularInt32 = 72313594;
+      var requiredSingularInt64 = 72313499;
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -4628,8 +4628,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      var requiredSingularInt32 = -72313594;
-      var requiredSingularInt64 = -72313499;
+      var requiredSingularInt32 = 72313594;
+      var requiredSingularInt64 = 72313499;
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;
@@ -4708,8 +4708,8 @@ describe('LibraryServiceClient', () => {
       });
 
       // Mock request
-      var requiredSingularInt32 = -72313594;
-      var requiredSingularInt64 = -72313499;
+      var requiredSingularInt32 = 72313594;
+      var requiredSingularInt64 = 72313499;
       var requiredSingularFloat = -7514705.0;
       var requiredSingularDouble = 1.9111005E8;
       var requiredSingularBool = true;

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -5130,8 +5130,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $grpcStub->addResponse($expectedResponse);
 
         // Mock request
-        $requiredSingularInt32 = -72313594;
-        $requiredSingularInt64 = -72313499;
+        $requiredSingularInt32 = 72313594;
+        $requiredSingularInt64 = 72313499;
         $requiredSingularFloat = -7514705.0;
         $requiredSingularDouble = 1.9111005E8;
         $requiredSingularBool = true;
@@ -5220,8 +5220,8 @@ class LibraryServiceClientTest extends GeneratedTest
         $grpcStub->addResponse(null, $status);
 
         // Mock request
-        $requiredSingularInt32 = -72313594;
-        $requiredSingularInt64 = -72313499;
+        $requiredSingularInt32 = 72313594;
+        $requiredSingularInt64 = 72313499;
         $requiredSingularFloat = -7514705.0;
         $requiredSingularDouble = 1.9111005E8;
         $requiredSingularBool = true;

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -4323,8 +4323,8 @@ class TestLibraryServiceClient(object):
             channel=channel)
 
         # Setup Request
-        required_singular_int32 = -72313594
-        required_singular_int64 = -72313499
+        required_singular_int32 = 72313594
+        required_singular_int64 = 72313499
         required_singular_float = -7514705.0
         required_singular_double = 1.9111005E8
         required_singular_bool = True
@@ -4366,8 +4366,8 @@ class TestLibraryServiceClient(object):
              channel=channel)
 
         # Setup request
-        required_singular_int32 = -72313594
-        required_singular_int64 = -72313499
+        required_singular_int32 = 72313594
+        required_singular_int64 = 72313499
         required_singular_float = -7514705.0
         required_singular_double = 1.9111005E8
         required_singular_bool = True


### PR DESCRIPTION
The hash can be any int value.
However, if the proto type is an unsigned int,
the value overflows.
Just always return a non-negative so it works everywhere.