### PR TITLE
Ruby: Fix api method name conversion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ ext {
 
     // Testing
     junit: 'junit:junit:4.12',
+    mockito: 'org.mockito:mockito-core:2.+',
     truth: 'com.google.truth:truth:0.34',
     toolsFxTesting: 'com.google.api:api-compiler:0.0.6:testing',
 
@@ -111,7 +112,8 @@ dependencies {
 
   testCompile libraries.junit,
     libraries.truth,
-    libraries.toolsFxTesting
+    libraries.toolsFxTesting,
+    libraries.mockito
 }
 
 task fatJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -336,6 +336,17 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getApiMethodName(MethodModel method, VisibilityConfig visibility) {
+    // This is defined in grpc/generic/service.rb
+    return method
+        .getSimpleName()
+        .replaceAll("([A-Z]+)([A-Z][a-z])", "$1_$2")
+        .replaceAll("([a-z\\d])([A-Z])", "$1_$2")
+        .replaceAll("-", "_")
+        .toLowerCase();
+  }
+
+  @Override
   public String getModuleVersionName() {
     List<String> apiModules = getApiModules();
     return apiModules.get(apiModules.size() - 1);

--- a/src/test/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamerTest.java
@@ -1,0 +1,39 @@
+/* Copyright 2017 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.ruby;
+
+import com.google.api.codegen.config.MethodModel;
+import com.google.api.codegen.config.VisibilityConfig;
+import com.google.common.truth.Truth;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class RubySurfaceNamerTest {
+  @Test
+  public void getApiMethodName() {
+    RubySurfaceNamer namer = new RubySurfaceNamer("Unused::Package::Name");
+    MethodModel method = Mockito.mock(MethodModel.class);
+    Mockito.when(method.getSimpleName()).thenReturn("PrintHTML");
+    Truth.assertThat(namer.getApiMethodName(method, VisibilityConfig.PUBLIC))
+        .isEqualTo("print_html");
+    Mockito.when(method.getSimpleName()).thenReturn("AMethod");
+    Truth.assertThat(namer.getApiMethodName(method, VisibilityConfig.PUBLIC)).isEqualTo("a_method");
+    Mockito.when(method.getSimpleName()).thenReturn("AnRpc");
+    Truth.assertThat(namer.getApiMethodName(method, VisibilityConfig.PUBLIC)).isEqualTo("an_rpc");
+    Mockito.when(method.getSimpleName()).thenReturn("SeeHTMLBooks");
+    Truth.assertThat(namer.getApiMethodName(method, VisibilityConfig.PUBLIC))
+        .isEqualTo("see_html_books");
+  }
+}


### PR DESCRIPTION
Fixes: #1760 

The implementation is a java-ized copy of this method in grpc:
https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/generic/service.rb#L33

The unit test is a copy of this unit test:
https://github.com/grpc/grpc/blob/master/src/ruby/spec/generic/service_spec.rb#L53