### PR TITLE
Python: Change to shorter nox session names.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/nox.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/nox.py.snip
@@ -75,7 +75,7 @@
             'py.test',
             '--quiet',
             os.path.join('tests', 'system'),
-            *session.posargs,
+            *session.posargs
         )
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/nox.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/nox.py.snip
@@ -26,50 +26,57 @@
 
 @private unit_tests()
     @@nox.session
-    @@nox.parametrize('python_version', ['2.7', '3.4', '3.5', '3.6'])
-    def unit_tests(session, python_version):
+    def default(session):
+        return unit(session, 'default')
+
+
+    @@nox.session
+    @@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+    def unit(session, py):
         """Run the unit test suite."""
 
-        # Run unit tests against all supported versions of Python.
-        session.interpreter = 'python{}'.format(python_version)
+        @# Run unit tests against all supported versions of Python.
+        if py != 'default':
+            session.interpreter = 'python{}'.format(py)
 
-        # Set the virtualenv dirname.
-        session.virtualenv_dirname = 'unit-' + python_version
+        @# Set the virtualenv directory name.
+        session.virtualenv_dirname = 'unit-' + py
 
-        # Install all test dependencies, then install this package in-place.
+        @# Install all test dependencies, then install this package in-place.
         session.install('pytest')
         session.install('-e', '.')
 
-        # Run py.test against the unit tests.
+        @# Run py.test against the unit tests.
         session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 @end
 
 @private system_tests()
     @@nox.session
-    @@nox.parametrize('python_version', ['2.7', '3.6'])
-    def system_tests(session, python_version):
+    @@nox.parametrize('py', ['2.7', '3.6'])
+    def system(session, py):
         """Run the system test suite."""
 
-        # Sanity check: Only run system tests if the environment variable is set.
+        @# Sanity check: Only run system tests if the environment variable is set.
         if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
             session.skip('Credentials must be set via environment variable.')
 
-        # Run unit tests against all supported versions of Python.
-        session.interpreter = 'python{}'.format(python_version)
+        @# Run unit tests against all supported versions of Python.
+        session.interpreter = 'python{}'.format(py)
 
-        # Set the virtualenv dirname.
-        session.virtualenv_dirname = 'sys-' + python_version
+        @# Set the virtualenv dirname.
+        session.virtualenv_dirname = 'sys-' + py
 
-        # Install all test dependencies, then install this package in-place.
+        @# Install all test dependencies, then install this package in-place.
         session.install('pytest')
         session.install('-e', '.')
 
-        # Run py.test against the unit tests.
+        @# Run py.test against the unit tests.
         session.run(
             'py.test',
             '--quiet',
             os.path.join('tests', 'system'),
-            *session.posargs)
+            *session.posargs,
+        )
 @end
 
 @private lint_setup_py()

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3143,40 +3143,56 @@ import nox
 
 
 @nox.session
-@nox.parametrize('python_version', ['2.7', '3.4', '3.5', '3.6'])
-def unit_tests(session, python_version):
+def default(session):
+    return unit(session, 'default')
+
+
+@nox.session
+@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+def unit(session, py):
     """Run the unit test suite."""
 
-    session.interpreter = 'python{}'.format(python_version)
+    # Run unit tests against all supported versions of Python.
+    if py != 'default':
+        session.interpreter = 'python{}'.format(py)
 
-    session.virtualenv_dirname = 'unit-' + python_version
+    # Set the virtualenv directory name.
+    session.virtualenv_dirname = 'unit-' + py
 
+    # Install all test dependencies, then install this package in-place.
     session.install('pytest')
     session.install('-e', '.')
 
+    # Run py.test against the unit tests.
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 
 @nox.session
-@nox.parametrize('python_version', ['2.7', '3.6'])
-def system_tests(session, python_version):
+@nox.parametrize('py', ['2.7', '3.6'])
+def system(session, py):
     """Run the system test suite."""
 
+    # Sanity check: Only run system tests if the environment variable is set.
     if not os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', ''):
         session.skip('Credentials must be set via environment variable.')
 
-    session.interpreter = 'python{}'.format(python_version)
+    # Run unit tests against all supported versions of Python.
+    session.interpreter = 'python{}'.format(py)
 
-    session.virtualenv_dirname = 'sys-' + python_version
+    # Set the virtualenv dirname.
+    session.virtualenv_dirname = 'sys-' + py
 
+    # Install all test dependencies, then install this package in-place.
     session.install('pytest')
     session.install('-e', '.')
 
+    # Run py.test against the unit tests.
     session.run(
         'py.test',
         '--quiet',
         os.path.join('tests', 'system'),
-        *session.posargs)
+        *session.posargs,
+    )
 
 
 @nox.session

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3191,7 +3191,7 @@ def system(session, py):
         'py.test',
         '--quiet',
         os.path.join('tests', 'system'),
-        *session.posargs,
+        *session.posargs
     )
 
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
@@ -988,17 +988,27 @@ import nox
 
 
 @nox.session
-@nox.parametrize('python_version', ['2.7', '3.4', '3.5', '3.6'])
-def unit_tests(session, python_version):
+def default(session):
+    return unit(session, 'default')
+
+
+@nox.session
+@nox.parametrize('py', ['2.7', '3.4', '3.5', '3.6'])
+def unit(session, py):
     """Run the unit test suite."""
 
-    session.interpreter = 'python{}'.format(python_version)
+    # Run unit tests against all supported versions of Python.
+    if py != 'default':
+        session.interpreter = 'python{}'.format(py)
 
-    session.virtualenv_dirname = 'unit-' + python_version
+    # Set the virtualenv directory name.
+    session.virtualenv_dirname = 'unit-' + py
 
+    # Install all test dependencies, then install this package in-place.
     session.install('pytest')
     session.install('-e', '.')
 
+    # Run py.test against the unit tests.
     session.run('py.test', '--quiet', os.path.join('tests', 'unit'))
 
 


### PR DESCRIPTION
This mirrors a change @dhermes made to the manual layer noxfiles awhile back, and will cause future APIs not to bork up @duggelz's testing framework for new runtimes.