### PR TITLE
Update PHP docs for string arg

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/client_impl.snip
+++ b/src/main/resources/com/google/api/codegen/php/client_impl.snip
@@ -405,10 +405,10 @@
      *     @@type \Google\Auth\CredentialsLoader $credentialsLoader
      *           A CredentialsLoader object created using the Google\Auth library.
      @if xapiClass.hasDefaultServiceScopes
-         *     @@type array $scopes A string array of scopes to use when acquiring credentials.
+         *     @@type string[] $scopes A string array of scopes to use when acquiring credentials.
          *                          Defaults to the scopes for the {@xapiClass.serviceTitle}.
      @else
-         *     @@type array $scopes Required. A string array of scopes to use when acquiring credentials.
+         *     @@type string[] $scopes Required. A string array of scopes to use when acquiring credentials.
      @end
      *     @@type string $clientConfigPath
      *           Path to a JSON file containing client method configuration, including retry settings.

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -473,7 +473,7 @@ class LibraryServiceGapicClient
      *           NOTE: if the $channel optional argument is specified, then this option is unused.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *           A CredentialsLoader object created using the Google\Auth library.
-     *     @type array $scopes A string array of scopes to use when acquiring credentials.
+     *     @type string[] $scopes A string array of scopes to use when acquiring credentials.
      *                          Defaults to the scopes for the Google Example Library API.
      *     @type string $clientConfigPath
      *           Path to a JSON file containing client method configuration, including retry settings.

--- a/src/test/java/com/google/api/codegen/testdata/php/php_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_longrunning.baseline
@@ -216,7 +216,7 @@ class OperationsGapicClient
      *           NOTE: if the $channel optional argument is specified, then this option is unused.
      *     @type \Google\Auth\CredentialsLoader $credentialsLoader
      *           A CredentialsLoader object created using the Google\Auth library.
-     *     @type array $scopes Required. A string array of scopes to use when acquiring credentials.
+     *     @type string[] $scopes Required. A string array of scopes to use when acquiring credentials.
      *     @type string $clientConfigPath
      *           Path to a JSON file containing client method configuration, including retry settings.
      *           Specify this setting to specify the retry behavior of all methods on the client.


### PR DESCRIPTION
Fixes https://github.com/googleapis/toolkit/issues/1533 - all other places use this style of array arg documentation, or else are associative arrays.