### PR TITLE
Implement release level configuration override

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
@@ -14,8 +14,10 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.ApiModel;
+import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.VersionBound;
 import com.google.api.codegen.viewmodel.metadata.PackageDependencyView;
@@ -97,6 +99,23 @@ public class PackageMetadataTransformer {
         .fullName(model.getTitle())
         .discoveryApiName(discoveryApiName)
         .hasMultipleServices(false);
+  }
+
+  /**
+   * Merges release levels from a PackageMetadataConfig and a GapicProductConfig. The
+   * GapicProductConfig always overrides the PackageMetadataConfig if its release level is set.
+   */
+  public ReleaseLevel getMergedReleaseLevel(
+      PackageMetadataConfig packageConfig,
+      GapicProductConfig productConfig,
+      TargetLanguage language) {
+    ReleaseLevel releaseLevel = productConfig.getReleaseLevel();
+    if (releaseLevel == ReleaseLevel.UNSET_RELEASE_LEVEL) {
+      releaseLevel = packageConfig.releaseLevel(TargetLanguage.RUBY);
+    }
+    return productConfig.getReleaseLevel() == ReleaseLevel.UNSET_RELEASE_LEVEL
+        ? packageConfig.releaseLevel(language)
+        : productConfig.getReleaseLevel();
   }
 
   private List<PackageDependencyView> getDependencies(

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -120,7 +120,9 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
                 .gapicPackageName("gapic-" + packageConfig.packageName(TargetLanguage.NODEJS))
                 .majorVersion(packageConfig.apiVersion())
                 .developmentStatusTitle(
-                    namer.getReleaseAnnotation(packageConfig.releaseLevel(TargetLanguage.NODEJS)))
+                    namer.getReleaseAnnotation(
+                        metadataTransformer.getMergedReleaseLevel(
+                            packageConfig, productConfig, TargetLanguage.PYTHON)))
                 .targetLanguage("Node.js")
                 .mainReadmeLink(GITHUB_REPO_HOST + MAIN_README_PATH)
                 .libraryDocumentationLink(

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -122,7 +122,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
                 .developmentStatusTitle(
                     namer.getReleaseAnnotation(
                         metadataTransformer.getMergedReleaseLevel(
-                            packageConfig, productConfig, TargetLanguage.PYTHON)))
+                            packageConfig, productConfig, TargetLanguage.NODEJS)))
                 .targetLanguage("Node.js")
                 .mainReadmeLink(GITHUB_REPO_HOST + MAIN_README_PATH)
                 .libraryDocumentationLink(

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -197,7 +197,9 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer 
             metadataNamer, packageConfig, model, template, outputPath, TargetLanguage.PYTHON)
         .namespacePackages(computeNamespacePackages(productConfig.getPackageName()))
         .developmentStatus(
-            surfaceNamer.getReleaseAnnotation(packageConfig.releaseLevel(TargetLanguage.PYTHON)))
+            surfaceNamer.getReleaseAnnotation(
+                metadataTransformer.getMergedReleaseLevel(
+                    packageConfig, productConfig, TargetLanguage.PYTHON)))
         .clientModules(clientModules(surfaceNamer))
         .apiModules(apiModules(packageConfig.apiVersion()))
         .typeModules(typesModules(surfaceNamer))
@@ -222,7 +224,8 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer 
                 .majorVersion(packageConfig.apiVersion())
                 .developmentStatusTitle(
                     metadataNamer.getReleaseAnnotation(
-                        packageConfig.releaseLevel(TargetLanguage.PYTHON)))
+                        metadataTransformer.getMergedReleaseLevel(
+                            packageConfig, productConfig, TargetLanguage.PYTHON)))
                 .targetLanguage("Python")
                 .mainReadmeLink(GITHUB_REPO_HOST + MAIN_README_PATH)
                 .libraryDocumentationLink(

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataNamer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer.ruby;
 
+import com.google.api.codegen.ReleaseLevel;
 import com.google.api.codegen.transformer.PackageMetadataNamer;
 import com.google.api.codegen.util.Name;
 import com.google.common.base.Joiner;
@@ -57,5 +58,15 @@ public class RubyPackageMetadataNamer extends PackageMetadataNamer {
   private String getSimpleMetadataIdentifier() {
     return Iterables.getLast(
         Splitter.on(METADATA_IDENTIFIER_SEPARATOR).split(getMetadataIdentifier()));
+  }
+
+  @Override
+  public String getReleaseAnnotation(ReleaseLevel releaseLevel) {
+    switch (releaseLevel) {
+      case GA:
+        return "GA";
+      default:
+        return super.getReleaseAnnotation(releaseLevel);
+    }
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyPackageMetadataTransformer.java
@@ -124,7 +124,9 @@ public class RubyPackageMetadataTransformer implements ModelToViewTransformer {
         .majorVersion(packageConfig.apiVersion())
         .hasMultipleServices(false)
         .developmentStatusTitle(
-            namer.getReleaseAnnotation(packageConfig.releaseLevel(TargetLanguage.RUBY)))
+            namer.getReleaseAnnotation(
+                metadataTransformer.getMergedReleaseLevel(
+                    packageConfig, productConfig, TargetLanguage.RUBY)))
         .targetLanguage("Ruby")
         .mainReadmeLink(GITHUB_REPO_HOST + MAIN_README_PATH)
         .libraryDocumentationLink("")

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -299,7 +299,7 @@ gem "rainbow", "~> 2.1.0"
    limitations under the License.
 
 ============== file: README.md ==============
-# Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+# Ruby Client for Google Example API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 
 [Google Example API][Product Documentation]:
 This description tests descriptions that span multiple lines. This is a service
@@ -532,7 +532,7 @@ module Google
   # rubocop:disable LineLength
 
   ##
-  # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+  # # Ruby Client for Google Example API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
   # [Google Example API][Product Documentation]:
   # This description tests descriptions that span multiple lines. This is a service
@@ -711,7 +711,7 @@ module Google
   # rubocop:disable LineLength
 
   ##
-  # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
+  # # Ruby Client for Google Example API ([GA](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
   # [Google Example API][Product Documentation]:
   # This description tests descriptions that span multiple lines. This is a service

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_gapic.yaml
@@ -7,6 +7,7 @@ language_settings:
     package_name: example
   ruby:
     package_name: Google::Example::V1
+    release_level: GA
   php:
     package_name: Google\Example\V1
   nodejs:

--- a/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/multiple_services_pkg.yaml
@@ -36,6 +36,7 @@ generated_ga_package_version:
 release_level:
   python: ALPHA
   java: GA
+  ruby: BETA
 
 # Dependencies
 auth_version:


### PR DESCRIPTION
The GAPIC config release level should override the default release
level set in googleapis.

Additionally, change the GA string in Ruby from "Production/Stable"
to "GA" for consistence with google-cloud-ruby.

Fixes #1796