### PR TITLE
Ruby package metadata and linter updates

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/Gemfile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Gemfile.snip
@@ -3,7 +3,6 @@
 
   gemspec
 
-  gem "rake", "~> 11.0"
   gem "gcloud-jsondoc",
       git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
       branch: "gcloud-jsondoc"
@@ -11,9 +10,6 @@
   @# WORKAROUND: builds are having problems since the release of 3.0.0
   @# pin to the last known good version
   gem "public_suffix", "~> 2.0"
-
-  @# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
-  @# so pinning to 2.1 for now.
-  gem "rainbow", "~> 2.1.0"
+  gem "rake", "~> 11.0"
 
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/Rakefile.snip
@@ -86,34 +86,36 @@
   @# Acceptance tests
   desc "Run the {@metadata.identifier} acceptance tests."
   task :acceptance, :project, :keyfile do |t, args|
-    project = args[:project]
-    project ||=
-      ENV["{@metadata.smokeTestProjectVariable}"] ||
-      ENV["GCLOUD_TEST_PROJECT"]
-    keyfile = args[:keyfile]
-    keyfile ||=
-      ENV["{@metadata.smokeTestKeyfileVariable}"] ||
-      ENV["GCLOUD_TEST_KEYFILE"]
-    if keyfile
-      keyfile = File.read keyfile
-    else
+    @if metadata.hasSmokeTests
+      project = args[:project]
+      project ||=
+        ENV["{@metadata.smokeTestProjectVariable}"] ||
+        ENV["GCLOUD_TEST_PROJECT"]
+      keyfile = args[:keyfile]
       keyfile ||=
-        ENV["{@metadata.smokeTestJsonKeyVariable}"] ||
-        ENV["GCLOUD_TEST_KEYFILE_JSON"]
-    end
-    if project.nil? || keyfile.nil?
-      fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or {@metadata.smokeTestProjectVariable}=test123 {@metadata.smokeTestKeyfileVariable}=/path/to/keyfile.json rake acceptance"
-    end
-    # clear any env var already set
-    {@importList(metadata.fileHeader.importSection.appImports)}
-    ({@metadata.credentialsClassName}::PATH_ENV_VARS +
-     {@metadata.credentialsClassName}::JSON_ENV_VARS).each do |path|
-      ENV[path] = nil
-    end
-    # always overwrite when running tests
-    ENV["{@metadata.projectVariable}"] = project
-    ENV["{@metadata.smokeTestProjectVariable}"] = project
-    ENV["{@metadata.jsonKeyVariable}"] = keyfile
+        ENV["{@metadata.smokeTestKeyfileVariable}"] ||
+        ENV["GCLOUD_TEST_KEYFILE"]
+      if keyfile
+        keyfile = File.read keyfile
+      else
+        keyfile ||=
+          ENV["{@metadata.smokeTestJsonKeyVariable}"] ||
+          ENV["GCLOUD_TEST_KEYFILE_JSON"]
+      end
+      if project.nil? || keyfile.nil?
+        fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or {@metadata.smokeTestProjectVariable}=test123 {@metadata.smokeTestKeyfileVariable}=/path/to/keyfile.json rake acceptance"
+      end
+      # clear any env var already set
+      {@importList(metadata.fileHeader.importSection.appImports)}
+      ({@metadata.credentialsClassName}::PATH_ENV_VARS +
+       {@metadata.credentialsClassName}::JSON_ENV_VARS).each do |path|
+        ENV[path] = nil
+      end
+      # always overwrite when running tests
+      ENV["{@metadata.projectVariable}"] = project
+      ENV["{@metadata.smokeTestProjectVariable}"] = project
+      ENV["{@metadata.jsonKeyVariable}"] = keyfile
+    @end
     
     Rake::Task["acceptance:run"].invoke
   end

--- a/src/main/resources/com/google/api/codegen/ruby/gemspec.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/gemspec.snip
@@ -26,7 +26,7 @@
     @end
 
     gem.add_development_dependency "minitest", "~> 5.10"
-    gem.add_development_dependency "rubocop", "<= 0.35.1"
+    gem.add_development_dependency "rubocop", "~> 0.50.0"
     gem.add_development_dependency "simplecov", "~> 0.9"
   end
 

--- a/src/main/resources/com/google/api/codegen/ruby/rubocop.yml.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/rubocop.yml.snip
@@ -15,43 +15,5 @@
     EnforcedStyle: double_quotes
   Style/MethodDefParentheses:
     EnforcedStyle: require_no_parentheses
-  Style/NumericLiterals:
-    Enabled: false
-  Style/SpaceAroundOperators:
-    Enabled: false
-  Metrics/ClassLength:
-    Enabled: false
-  Style/EmptyLines:
-    Enabled: false
-  Style/EmptyElse:
-    Enabled: false
-  Style/HashSyntax:
-    Exclude:
-      - "lib/{@metadata.versionPath}/**/*"
-  Metrics/LineLength:
-    Exclude:
-      - "lib/{@metadata.versionPath}/**/*"
-  Metrics/CyclomaticComplexity:
-    Max: 10
-  Metrics/PerceivedComplexity:
-    Max: 10
-  Metrics/AbcSize:
-    Max: 25
-    Exclude:
-      - "lib/{@metadata.versionPath}/**/*"
-  Metrics/MethodLength:
-    Max: 20
-    Exclude:
-      - "lib/{@metadata.versionPath}/**/*"
-  Metrics/ParameterLists:
-    Enabled: false
-  Style/RescueModifier:
-    Enabled: false
-  Style/ClassVars:
-    Enabled: false
-  Style/TrivialAccessors:
-    Enabled: false
-  Style/FileName:
-    Enabled: false
 
 @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -29,44 +29,6 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/SpaceAroundOperators:
-  Enabled: false
-Metrics/ClassLength:
-  Enabled: false
-Style/EmptyLines:
-  Enabled: false
-Style/EmptyElse:
-  Enabled: false
-Style/HashSyntax:
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/LineLength:
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/ParameterLists:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/ClassVars:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/FileName:
-  Enabled: false
 
 ============== file: .yardopts ==============
 --no-private
@@ -83,7 +45,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 11.0"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
@@ -91,10 +52,7 @@ gem "gcloud-jsondoc",
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
-
-# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
-# so pinning to 2.1 for now.
-gem "rainbow", "~> 2.1.0"
+gem "rake", "~> 11.0"
 
 ============== file: LICENSE ==============
                             Apache License
@@ -4238,7 +4196,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-some-other-package-v1", "~> 0.2.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
-  gem.add_development_dependency "rubocop", "<= 0.35.1"
+  gem.add_development_dependency "rubocop", "~> 0.50.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
 end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -29,44 +29,6 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/SpaceAroundOperators:
-  Enabled: false
-Metrics/ClassLength:
-  Enabled: false
-Style/EmptyLines:
-  Enabled: false
-Style/EmptyElse:
-  Enabled: false
-Style/HashSyntax:
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/LineLength:
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - "lib/library/v1/**/*"
-Metrics/ParameterLists:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/ClassVars:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/FileName:
-  Enabled: false
 
 ============== file: .yardopts ==============
 --no-private
@@ -83,7 +45,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 11.0"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
@@ -91,10 +52,7 @@ gem "gcloud-jsondoc",
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
-
-# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
-# so pinning to 2.1 for now.
-gem "rainbow", "~> 2.1.0"
+gem "rake", "~> 11.0"
 
 ============== file: LICENSE ==============
                             Apache License
@@ -2691,7 +2649,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-some-other-package-v1", "~> 0.2.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
-  gem.add_development_dependency "rubocop", "<= 0.35.1"
+  gem.add_development_dependency "rubocop", "~> 0.50.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
 end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -29,44 +29,6 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/SpaceAroundOperators:
-  Enabled: false
-Metrics/ClassLength:
-  Enabled: false
-Style/EmptyLines:
-  Enabled: false
-Style/EmptyElse:
-  Enabled: false
-Style/HashSyntax:
-  Exclude:
-    - "lib/google/longrunning/**/*"
-Metrics/LineLength:
-  Exclude:
-    - "lib/google/longrunning/**/*"
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-  Exclude:
-    - "lib/google/longrunning/**/*"
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - "lib/google/longrunning/**/*"
-Metrics/ParameterLists:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/ClassVars:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/FileName:
-  Enabled: false
 
 ============== file: .yardopts ==============
 --no-private
@@ -83,7 +45,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 11.0"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
@@ -91,10 +52,7 @@ gem "gcloud-jsondoc",
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
-
-# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
-# so pinning to 2.1 for now.
-gem "rainbow", "~> 2.1.0"
+gem "rake", "~> 11.0"
 
 ============== file: LICENSE ==============
                             Apache License
@@ -651,7 +609,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-gax", "~> 0.8.0"
 
   gem.add_development_dependency "minitest", "~> 5.10"
-  gem.add_development_dependency "rubocop", "<= 0.35.1"
+  gem.add_development_dependency "rubocop", "~> 0.50.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
 end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -29,44 +29,6 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/MethodDefParentheses:
   EnforcedStyle: require_no_parentheses
-Style/NumericLiterals:
-  Enabled: false
-Style/SpaceAroundOperators:
-  Enabled: false
-Metrics/ClassLength:
-  Enabled: false
-Style/EmptyLines:
-  Enabled: false
-Style/EmptyElse:
-  Enabled: false
-Style/HashSyntax:
-  Exclude:
-    - "lib/google/example/v1/**/*"
-Metrics/LineLength:
-  Exclude:
-    - "lib/google/example/v1/**/*"
-Metrics/CyclomaticComplexity:
-  Max: 10
-Metrics/PerceivedComplexity:
-  Max: 10
-Metrics/AbcSize:
-  Max: 25
-  Exclude:
-    - "lib/google/example/v1/**/*"
-Metrics/MethodLength:
-  Max: 20
-  Exclude:
-    - "lib/google/example/v1/**/*"
-Metrics/ParameterLists:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/ClassVars:
-  Enabled: false
-Style/TrivialAccessors:
-  Enabled: false
-Style/FileName:
-  Enabled: false
 
 ============== file: .yardopts ==============
 --no-private
@@ -83,7 +45,6 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rake", "~> 11.0"
 gem "gcloud-jsondoc",
     git: "https://github.com/GoogleCloudPlatform/google-cloud-ruby.git",
     branch: "gcloud-jsondoc"
@@ -91,10 +52,7 @@ gem "gcloud-jsondoc",
 # WORKAROUND: builds are having problems since the release of 3.0.0
 # pin to the last known good version
 gem "public_suffix", "~> 2.0"
-
-# TEMP: rainbow (a dependency of rubocop) version 2.2 seems to have a problem,
-# so pinning to 2.1 for now.
-gem "rainbow", "~> 2.1.0"
+gem "rake", "~> 11.0"
 
 ============== file: LICENSE ==============
                             Apache License
@@ -378,32 +336,6 @@ end
 # Acceptance tests
 desc "Run the google-example acceptance tests."
 task :acceptance, :project, :keyfile do |t, args|
-  project = args[:project]
-  project ||=
-    ENV["EXAMPLE_TEST_PROJECT"] ||
-    ENV["GCLOUD_TEST_PROJECT"]
-  keyfile = args[:keyfile]
-  keyfile ||=
-    ENV["EXAMPLE_TEST_KEYFILE"] ||
-    ENV["GCLOUD_TEST_KEYFILE"]
-  if keyfile
-    keyfile = File.read keyfile
-  else
-    keyfile ||=
-      ENV["EXAMPLE_TEST_KEYFILE_JSON"] ||
-      ENV["GCLOUD_TEST_KEYFILE_JSON"]
-  end
-  if project.nil? || keyfile.nil?
-    fail "You must provide a project and keyfile. e.g. rake acceptance[test123, /path/to/keyfile.json] or EXAMPLE_TEST_PROJECT=test123 EXAMPLE_TEST_KEYFILE=/path/to/keyfile.json rake acceptance"
-  end
-  require "google/example/credentials"
-  (Google::Example::Credentials::PATH_ENV_VARS +
-   Google::Example::Credentials::JSON_ENV_VARS).each do |path|
-    ENV[path] = nil
-  end
-  ENV["EXAMPLE_PROJECT"] = project
-  ENV["EXAMPLE_TEST_PROJECT"] = project
-  ENV["EXAMPLE_KEYFILE_JSON"] = keyfile
 
   Rake::Task["acceptance:run"].invoke
 end
@@ -533,7 +465,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "google-some-other-package-v1", "~> 0.2.1"
 
   gem.add_development_dependency "minitest", "~> 5.10"
-  gem.add_development_dependency "rubocop", "<= 0.35.1"
+  gem.add_development_dependency "rubocop", "~> 0.50.0"
   gem.add_development_dependency "simplecov", "~> 0.9"
 end
 


### PR DESCRIPTION
- Upgrade rubocop to 0.50.0 (with corresponding config updates)
- Do not check smoke test environment variables if there is no
  smoke test