### PR TITLE
google-cloud-python #4295 - guard calls to setuptools.setup()

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/setup.py.snip
@@ -22,34 +22,35 @@
 
   with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
       long_description = readme_file.read()
-
-  setup(
-      name='{@metadata.gapicPackageName}',
-      version='{@metadata.packageVersionBound.lower}',
-      author='{@metadata.author}',
-      author_email='{@metadata.email}',
-      classifiers=[
-          'Intended Audience :: Developers',
-          'Development Status :: {@metadata.developmentStatus}',
-          'Intended Audience :: Developers',
-          'License :: OSI Approved :: Apache Software License',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
-          'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.4',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-      ],
-      description='GAPIC library for the {@metadata.fullName}',
-      include_package_data=True,
-      long_description=long_description,
-      install_requires=install_requires,
-      license='{@metadata.licenseName}',
-      packages=find_packages(exclude=('tests*',)),
-      namespace_packages=[{@quotedList(metadata.namespacePackages)}],
-      url='{@metadata.homepage}',
-      zip_safe=False,
-  )
+      
+  if __name__ == '__main__':
+      setup(
+          name='{@metadata.gapicPackageName}',
+          version='{@metadata.packageVersionBound.lower}',
+          author='{@metadata.author}',
+          author_email='{@metadata.email}',
+          classifiers=[
+              'Intended Audience :: Developers',
+              'Development Status :: {@metadata.developmentStatus}',
+              'Intended Audience :: Developers',
+              'License :: OSI Approved :: Apache Software License',
+              'Programming Language :: Python',
+              'Programming Language :: Python :: 2',
+              'Programming Language :: Python :: 2.7',
+              'Programming Language :: Python :: 3',
+              'Programming Language :: Python :: 3.4',
+              'Programming Language :: Python :: 3.5',
+              'Programming Language :: Python :: 3.6',
+          ],
+          description='GAPIC library for the {@metadata.fullName}',
+          include_package_data=True,
+          long_description=long_description,
+          install_requires=install_requires,
+          license='{@metadata.licenseName}',
+          packages=find_packages(exclude=('tests*',)),
+          namespace_packages=[{@quotedList(metadata.namespacePackages)}],
+          url='{@metadata.homepage}',
+          zip_safe=False,
+      )
 
 @end

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3443,34 +3443,35 @@ install_requires = [
 with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
     long_description = readme_file.read()
 
-setup(
-    name='google-cloud-library',
-    version='0.15.0',
-    author='Google LLC',
-    author_email='googleapis-packages@google.com',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ],
-    description='GAPIC library for the Google Example Library API',
-    include_package_data=True,
-    long_description=long_description,
-    install_requires=install_requires,
-    license='Apache 2.0',
-    packages=find_packages(exclude=('tests*',)),
-    namespace_packages=['google', 'google.cloud'],
-    url='https://github.com/googleapis/googleapis',
-    zip_safe=False,
-)
+if __name__ == '__main__':
+    setup(
+        name='google-cloud-library',
+        version='0.15.0',
+        author='Google LLC',
+        author_email='googleapis-packages@google.com',
+        classifiers=[
+            'Intended Audience :: Developers',
+            'Development Status :: 3 - Alpha',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+        ],
+        description='GAPIC library for the Google Example Library API',
+        include_package_data=True,
+        long_description=long_description,
+        install_requires=install_requires,
+        license='Apache 2.0',
+        packages=find_packages(exclude=('tests*',)),
+        namespace_packages=['google', 'google.cloud'],
+        url='https://github.com/googleapis/googleapis',
+        zip_safe=False,
+    )
 
 ============== file: tests/system/gapic/v1/test_system_library_service_v1.py ==============
 # Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
@@ -1067,34 +1067,35 @@ install_requires = [
 with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
     long_description = readme_file.read()
 
-setup(
-    name='google-cloud-library',
-    version='0.15.0',
-    author='Google LLC',
-    author_email='googleapis-packages@google.com',
-    classifiers=[
-        'Intended Audience :: Developers',
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ],
-    description='GAPIC library for the Google Fake API',
-    include_package_data=True,
-    long_description=long_description,
-    install_requires=install_requires,
-    license='Apache 2.0',
-    packages=find_packages(exclude=('tests*',)),
-    namespace_packages=[],
-    url='https://github.com/googleapis/googleapis',
-    zip_safe=False,
-)
+if __name__ == '__main__':
+    setup(
+        name='google-cloud-library',
+        version='0.15.0',
+        author='Google LLC',
+        author_email='googleapis-packages@google.com',
+        classifiers=[
+            'Intended Audience :: Developers',
+            'Development Status :: 4 - Beta',
+            'Intended Audience :: Developers',
+            'License :: OSI Approved :: Apache Software License',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Programming Language :: Python :: 3.6',
+        ],
+        description='GAPIC library for the Google Fake API',
+        include_package_data=True,
+        long_description=long_description,
+        install_requires=install_requires,
+        license='Apache 2.0',
+        packages=find_packages(exclude=('tests*',)),
+        namespace_packages=[],
+        url='https://github.com/googleapis/googleapis',
+        zip_safe=False,
+    )
 
 ============== file: tests/unit/gapic/v1/test_no_templates_api_service_client_v1.py ==============
 # Copyright 2018 Google LLC


### PR DESCRIPTION
[google-cloud-python/4295](https://github.com/GoogleCloudPlatform/google-cloud-python/issues/4295)