### PR TITLE
Remove auth and requests from Python dependencies.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -272,11 +272,6 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer 
     ImmutableList.Builder<PackageDependencyView> dependencies = ImmutableList.builder();
     dependencies.add(
         PackageDependencyView.create("google-api-core", VersionBound.create("0.1.0", "0.2.0dev")));
-    dependencies.add(
-        PackageDependencyView.create(
-            "google-auth", packageConfig.authVersionBound(TargetLanguage.PYTHON)));
-    dependencies.add(
-        PackageDependencyView.create("requests", VersionBound.create("2.18.4", "3.0dev")));
     return dependencies.build();
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3434,10 +3434,8 @@ import sys
 
 install_requires = [
     'google-api-core >= 0.1.0, < 0.2.0dev',
-    'google-auth >= 1.0.2, < 2.0dev',
     'googleapis-common-protos[grpc] >= 1.5.0, < 2.0dev',
     'python-other-package >= 12.1.0, < 13.5.1',
-    'requests >= 2.18.4, < 3.0dev',
 ]
 
 with io.open('README.rst', 'r', encoding='utf-8') as readme_file:

--- a/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_no_path_templates.baseline
@@ -1058,10 +1058,8 @@ import sys
 
 install_requires = [
     'google-api-core >= 0.1.0, < 0.2.0dev',
-    'google-auth >= 1.0.2, < 2.0dev',
     'googleapis-common-protos[grpc] >= 1.5.0, < 2.0dev',
     'python-other-package >= 12.1.0, < 13.5.1',
-    'requests >= 2.18.4, < 3.0dev',
 ]
 
 with io.open('README.rst', 'r', encoding='utf-8') as readme_file:


### PR DESCRIPTION
api_core handles them.

/cc @jonparrott