### PR TITLE
Add "under development" disclaimer to new samplegen config fields

### DIFF
--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -274,11 +274,19 @@ message MethodConfigProto {
 
   // Specifies sets of parameter values to be used together in a
   // sample. If this is not set, no samples are output.
+  //
+  // UNDER DEVELOPMENT: Sample generation using this field is still
+  // being developed. For now, continue using
+  // `sample_code_init_fields` to generate in-code samples.
   repeated SampleValueSet sample_value_sets = 16;
 
   // Defines combinations of method calling forms (sample code
   // structures as output by the client library generator) and
   // `sample_value_sets` that should be combined to generate samples.
+  //
+  // UNDER DEVELOPMENT: Sample generation using this field is still
+  // being developed. For now, continue using
+  // `sample_code_init_fields` to generate in-code samples.
   SampleConfiguration samples = 17;
 
   // Route calls through a different gRPC interface than the one this method

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -275,8 +275,8 @@ message MethodConfigProto {
   // Specifies sets of parameter values to be used together in a
   // sample. If this is not set, no samples are output.
   //
-  // UNDER DEVELOPMENT: Sample generation using this field is still
-  // being developed. For now, continue using
+  // UNDER DEVELOPMENT: Usage of this field for sample generation is
+  // still being developed. For now, continue using
   // `sample_code_init_fields` to generate in-code samples.
   repeated SampleValueSet sample_value_sets = 16;
 
@@ -284,8 +284,8 @@ message MethodConfigProto {
   // structures as output by the client library generator) and
   // `sample_value_sets` that should be combined to generate samples.
   //
-  // UNDER DEVELOPMENT: Sample generation using this field is still
-  // being developed. For now, continue using
+  // UNDER DEVELOPMENT: Usage of this field for sample generation is
+  // still being developed. For now, continue using
   // `sample_code_init_fields` to generate in-code samples.
   SampleConfiguration samples = 17;
 


### PR DESCRIPTION
Users can populate these fields, but they will have no effect yet as
we are still developing the back-end code to act on these settings.