### PR TITLE
Quick Fix for Java static import issue 

### DIFF
--- a/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicResourceNameToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discogapic/transformer/java/JavaDiscoGapicResourceNameToViewTransformer.java
@@ -156,7 +156,7 @@ public class JavaDiscoGapicResourceNameToViewTransformer implements DocumentToVi
     String outputPath = pathMapper.getOutputPath(null, context.getDocContext().getProductConfig());
     apiFile.outputPath(outputPath + File.separator + messageView.typeName() + ".java");
 
-    apiFile.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    apiFile.fileHeader(fileHeaderTransformer.generateFileHeader(context, messageView.typeName()));
 
     return apiFile.build();
   }
@@ -174,7 +174,7 @@ public class JavaDiscoGapicResourceNameToViewTransformer implements DocumentToVi
     apiFile.outputPath(outputPath + File.separator + className + ".java");
 
     // must be done as the last step to catch all imports
-    apiFile.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    apiFile.fileHeader(fileHeaderTransformer.generateFileHeader(context, className));
 
     return apiFile.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
@@ -29,9 +29,13 @@ public class FileHeaderTransformer {
   }
 
   public FileHeaderView generateFileHeader(TransformationContext context) {
+    return generateFileHeader(context, null);
+  }
+
+  public FileHeaderView generateFileHeader(TransformationContext context, String className) {
     return generateFileHeader(
         context.getProductConfig(),
-        importSectionTransformer.generateImportSection(context),
+        importSectionTransformer.generateImportSection(context, className),
         context.getNamer());
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/ImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ImportSectionTransformer.java
@@ -20,7 +20,7 @@ import com.google.api.codegen.viewmodel.ImportSectionView;
 /** Generates import sections. */
 public interface ImportSectionTransformer {
   /** Generates an ImportSectionView for a file header. */
-  ImportSectionView generateImportSection(TransformationContext context);
+  ImportSectionView generateImportSection(TransformationContext context, String className);
 
   /** Generates an ImportSectionView for the InitCodeTransformer. */
   ImportSectionView generateImportSection(

--- a/src/main/java/com/google/api/codegen/transformer/StandardImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardImportSectionTransformer.java
@@ -71,7 +71,7 @@ public class StandardImportSectionTransformer implements ImportSectionTransforme
     // should return true.
     //
     // It is also assumed that everything in full class name which is not a letter/digit/underscore
-    // is a path seprator. This should be good enough for all languages that we support.
+    // is a path separator. This should be good enough for all languages that we support.
     if (parentFullName.length() > className.length()) {
       char packageSeparator =
           parentFullName.charAt(parentFullName.length() - className.length() - 1);

--- a/src/main/java/com/google/api/codegen/transformer/StandardImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StandardImportSectionTransformer.java
@@ -53,17 +53,29 @@ public class StandardImportSectionTransformer implements ImportSectionTransforme
   }
 
   private boolean excludeAppImport(TypeAlias alias, String className) {
-    String parentName = alias.getParentFullName();
+    String parentFullName = alias.getParentFullName();
     if (className == null
         || alias.getImportType() != ImportType.StaticImport
-        || parentName == null
-        || !parentName.endsWith(className)) {
+        || parentFullName == null
+        || !parentFullName.endsWith(className)) {
       return false;
     }
 
-    if (parentName.length() > className.length()) {
-      char packageSeparator = parentName.charAt(parentName.length() - className.length() - 1);
-      if (Character.isLetterOrDigit(packageSeparator)) {
+    // Trying to handle cases when className is a suffix of the actual parrent name in a
+    // language-agnostic way. For example:
+    //     parentFullName = "package.path.ParentTheClass";
+    //     className = "TheClass" ;
+    // should return false, but:
+    //     parentFullName = "package.path.ParentTheClass";
+    //     className = "ParentTheClass";
+    // should return true.
+    //
+    // It is also assumed that everything in full class name which is not a letter/digit/underscore
+    // is a path seprator. This should be good enough for all languages that we support.
+    if (parentFullName.length() > className.length()) {
+      char packageSeparator =
+          parentFullName.charAt(parentFullName.length() - className.length() - 1);
+      if (Character.isLetterOrDigit(packageSeparator) || '_' == packageSeparator) {
         return false;
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoImportSectionTransformer.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class GoImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(TransformationContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context, String className) {
     return generateImportSection(context.getImportTypeTable().getImports());
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -173,7 +173,7 @@ public class JavaSurfaceTransformer {
     apiFile.outputPath(outputPath + File.separator + className + ".java");
 
     // must be done as the last step to catch all imports
-    apiFile.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    apiFile.fileHeader(fileHeaderTransformer.generateFileHeader(context, className));
 
     return apiFile.build();
   }
@@ -342,7 +342,7 @@ public class JavaSurfaceTransformer {
     settingsFile.outputPath(outputPath + File.separator + className + ".java");
 
     // must be done as the last step to catch all imports
-    settingsFile.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    settingsFile.fileHeader(fileHeaderTransformer.generateFileHeader(context, className));
 
     return settingsFile.build();
   }
@@ -366,7 +366,7 @@ public class JavaSurfaceTransformer {
     settingsFile.outputPath(outputPath + File.separator + className + ".java");
 
     // must be done as the last step to catch all imports
-    settingsFile.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    settingsFile.fileHeader(fileHeaderTransformer.generateFileHeader(context, className));
 
     return settingsFile.build();
   }
@@ -503,7 +503,7 @@ public class JavaSurfaceTransformer {
     fileView.outputPath(outputPath + File.separator + className + ".java");
 
     // must be done as the last step to catch all imports
-    fileView.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    fileView.fileHeader(fileHeaderTransformer.generateFileHeader(context, className));
 
     return fileView.build();
   }
@@ -558,7 +558,7 @@ public class JavaSurfaceTransformer {
     fileView.outputPath(outputPath + File.separator + className + ".java");
 
     // must be done as the last step to catch all imports
-    fileView.fileHeader(fileHeaderTransformer.generateFileHeader(context));
+    fileView.fileHeader(fileHeaderTransformer.generateFileHeader(context, className));
 
     return fileView.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -144,7 +144,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
     }
 
     ImportSectionView importSection =
-        importSectionTransformer.generateImportSection(typeTable.getImports());
+        importSectionTransformer.generateImportSection(typeTable.getImports(), null);
     return MockCombinedView.newBuilder()
         .outputPath(testCaseOutputFile(namer))
         .serviceImpls(impls)

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 public class NodeJSImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(TransformationContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context, String className) {
     ImportSectionView.Builder importSection = ImportSectionView.newBuilder();
     importSection.externalImports(generateExternalImports((GapicInterfaceContext) context));
     return importSection.build();

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpImportSectionTransformer.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class PhpImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(TransformationContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context, String className) {
     return generateImportSection(context.getImportTypeTable().getImports());
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
@@ -48,7 +48,7 @@ import java.util.TreeSet;
 
 public class PythonImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(TransformationContext context) {
+  public ImportSectionView generateImportSection(TransformationContext context, String className) {
     InterfaceContext interfaceContext = (InterfaceContext) context;
     return ImportSectionView.newBuilder()
         .standardImports(generateFileHeaderStandardImports(interfaceContext))

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
@@ -35,7 +35,8 @@ import java.util.TreeSet;
 
 public class RubyImportSectionTransformer implements ImportSectionTransformer {
   @Override
-  public ImportSectionView generateImportSection(TransformationContext transformationContext) {
+  public ImportSectionView generateImportSection(
+      TransformationContext transformationContext, String className) {
     // TODO support non-Gapic inputs
     GapicInterfaceContext context = (GapicInterfaceContext) transformationContext;
     Set<String> importFilenames = generateImportFilenames(context);

--- a/src/main/resources/com/google/api/codegen/java/common.snip
+++ b/src/main/resources/com/google/api/codegen/java/common.snip
@@ -18,7 +18,8 @@
       @case "SimpleImport"
         import {@import.fullName};
       @case "StaticImport"
-        import static {@import.fullName};
+        # TODO: fix or just remove the static import functionality altogether (it is not used)
+        # import static {@import.fullName};
       @default
         $unhandledCase: {@import.type.toString}$
       @end

--- a/src/main/resources/com/google/api/codegen/java/common.snip
+++ b/src/main/resources/com/google/api/codegen/java/common.snip
@@ -18,8 +18,7 @@
       @case "SimpleImport"
         import {@import.fullName};
       @case "StaticImport"
-        # TODO: fix or just remove the static import functionality altogether (it is not used)
-        # import static {@import.fullName};
+        import static {@import.fullName};
       @default
         $unhandledCase: {@import.type.toString}$
       @end

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -4700,7 +4700,6 @@ import com.google.api.gax.rpc.ApiExceptions;
 import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
-
 import com.google.cloud.simplecompute.v1.stub.AddressStub;
 import com.google.cloud.simplecompute.v1.stub.AddressStubSettings;
 import com.google.common.base.Function;
@@ -5327,7 +5326,7 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.auth.Credentials;
-
+import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
 import com.google.cloud.simplecompute.v1.stub.AddressStubSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -5596,7 +5595,7 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.auth.Credentials;
-
+import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -6014,7 +6013,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.simplecompute.v1.Address;
-
+import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
 import com.google.cloud.simplecompute.v1.DeleteAddressHttpRequest;
@@ -6092,7 +6091,7 @@ import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.RequestParamsExtractor;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.simplecompute.v1.Address;
-
+import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
 import com.google.cloud.simplecompute.v1.AddressSettings;

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -4700,7 +4700,7 @@ import com.google.api.gax.rpc.ApiExceptions;
 import com.google.api.gax.rpc.PageContext;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.api.pathtemplate.PathTemplate;
-import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
+
 import com.google.cloud.simplecompute.v1.stub.AddressStub;
 import com.google.cloud.simplecompute.v1.stub.AddressStubSettings;
 import com.google.common.base.Function;
@@ -5327,7 +5327,7 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.auth.Credentials;
-import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
+
 import com.google.cloud.simplecompute.v1.stub.AddressStubSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -5596,7 +5596,7 @@ import com.google.api.gax.rpc.TransportChannelProvider;
 import com.google.api.gax.rpc.UnaryCallSettings;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.auth.Credentials;
-import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -6014,7 +6014,7 @@ import com.google.api.core.BetaApi;
 import com.google.api.gax.core.BackgroundResource;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.simplecompute.v1.Address;
-import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
+
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
 import com.google.cloud.simplecompute.v1.DeleteAddressHttpRequest;
@@ -6092,7 +6092,7 @@ import com.google.api.gax.rpc.ClientContext;
 import com.google.api.gax.rpc.RequestParamsExtractor;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.simplecompute.v1.Address;
-import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
+
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
 import com.google.cloud.simplecompute.v1.AddressSettings;

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -265,10 +265,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
+
+
+
+
 import com.google.gcloud.pubsub.v1.stub.LibraryServiceStub;
 import com.google.gcloud.pubsub.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
@@ -3483,10 +3483,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
+
+
+
+
 import com.google.gcloud.pubsub.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
@@ -4286,10 +4286,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
+
+
+
+
 import com.google.gcloud.pubsub.v1.LibrarySettings;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.GrpcOperationsStub;
@@ -4977,10 +4977,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
+
+
+
+
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.ByteString;
@@ -5251,10 +5251,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
+
+
+
+
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.tagger.v1.AddLabelRequest;
@@ -6690,10 +6690,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
-import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
+
+
+
+
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -265,10 +265,6 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-
-
-
-
 import com.google.gcloud.pubsub.v1.stub.LibraryServiceStub;
 import com.google.gcloud.pubsub.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
@@ -3483,10 +3479,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-
-
-
-
+import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
 import com.google.gcloud.pubsub.v1.stub.LibraryServiceStubSettings;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
@@ -4286,10 +4282,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-
-
-
-
+import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
 import com.google.gcloud.pubsub.v1.LibrarySettings;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.GrpcOperationsStub;
@@ -4977,10 +4973,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-
-
-
-
+import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
 import com.google.longrunning.Operation;
 import com.google.longrunning.stub.OperationsStub;
 import com.google.protobuf.ByteString;
@@ -5251,10 +5247,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-
-
-
-
+import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.tagger.v1.AddLabelRequest;
@@ -6690,10 +6686,10 @@ import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsRequest
 import com.google.example.library.v1.TestOptionalRequiredFlatteningParamsResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
-
-
-
-
+import static com.google.gcloud.pubsub.v1.LibraryClient.FindRelatedBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListBooksPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListShelvesPagedResponse;
+import static com.google.gcloud.pubsub.v1.LibraryClient.ListStringsPagedResponse;
 import com.google.longrunning.Operation;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;


### PR DESCRIPTION
It is done by completely disabling the feature. Without this fix the generator produces non-compilable code for all clients which use paging. Specifically it tries to **statically** import an internal class of **the same** class where the static import happens, which breaks compilation. 

For example, it would add the following line to the `DataTransferServiceClient.java` file (note the presence of `"DataTransferServiceClient"` in the import itself):

```java
import static com.google.cloud.bigquery.datatransfer.v1.DataTransferServiceClient.ListDataSourcesPagedResponse;
```