### PR TITLE
Fix paged response wrappers duplicate generation bug

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTransformer.java
@@ -222,13 +222,12 @@ public class JavaSurfaceTransformer {
 
     ImmutableList.Builder<StaticLangPagedResponseView> pagedResponseWrappersList =
         ImmutableList.builder();
-    for (InterfaceModel apiInterface : context.getApiModel().getInterfaces()) {
-      for (MethodModel method : context.getSupportedMethods()) {
-        if (context.getMethodConfig(method).isPageStreaming()) {
-          pagedResponseWrappersList.add(
-              generatePagedResponseWrapper(
-                  context.asRequestMethodContext(method), context.getImportTypeTable()));
-        }
+
+    for (MethodModel method : context.getSupportedMethods()) {
+      if (context.getMethodConfig(method).isPageStreaming()) {
+        pagedResponseWrappersList.add(
+            generatePagedResponseWrapper(
+                context.asRequestMethodContext(method), context.getImportTypeTable()));
       }
     }
 


### PR DESCRIPTION
For each service with multiple interfaces the code was generating as many copies of response wrappers as there are interfaces, which results in non-compilable code.