### PR TITLE
Add support for importing declared types in version index file

### DIFF
--- a/src/main/java/com/google/api/codegen/InterfaceView.java
+++ b/src/main/java/com/google/api/codegen/InterfaceView.java
@@ -16,9 +16,7 @@ package com.google.api.codegen;
 
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.TypeRef;
 import com.google.protobuf.Api;
-import com.google.protobuf.Type;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,20 +34,5 @@ public class InterfaceView implements InputElementView<Interface> {
       interfaces.add(model.getSymbolTable().lookupInterface(api.getName()));
     }
     return interfaces;
-  }
-
-  /**
-   * Helper to extract the types from the underlying model.
-   *
-   * @see com.google.api.Service#getTypesList()
-   * @param model model with service config
-   * @return types
-   */
-  public Iterable<TypeRef> getTypes(Model model) {
-    List<TypeRef> types = new ArrayList<>();
-    for (Type type : model.getServiceConfig().getTypesList()) {
-      types.add(model.getSymbolTable().lookupType(type.getName()));
-    }
-    return types;
   }
 }

--- a/src/main/java/com/google/api/codegen/InterfaceView.java
+++ b/src/main/java/com/google/api/codegen/InterfaceView.java
@@ -16,8 +16,11 @@ package com.google.api.codegen;
 
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
+import com.google.api.tools.framework.model.TypeRef;
 import com.google.protobuf.Api;
+import com.google.protobuf.Type;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * An interface-based view of model, consisting of a strategy for getting the interfaces of the
@@ -28,10 +31,25 @@ public class InterfaceView implements InputElementView<Interface> {
   /** Gets the interfaces for the apis in the service config. */
   @Override
   public Iterable<Interface> getElementIterable(Model model) {
-    ArrayList<Interface> interfaces = new ArrayList<>();
+    List<Interface> interfaces = new ArrayList<>();
     for (Api api : model.getServiceConfig().getApisList()) {
       interfaces.add(model.getSymbolTable().lookupInterface(api.getName()));
     }
     return interfaces;
+  }
+
+  /**
+   * Helper to extract the types from the underlying model.
+   *
+   * @see com.google.api.Service#getTypesList()
+   * @param model model with service config
+   * @return types
+   */
+  public Iterable<TypeRef> getTypes(Model model) {
+    List<TypeRef> types = new ArrayList<>();
+    for (Type type : model.getServiceConfig().getTypesList()) {
+      types.add(model.getSymbolTable().lookupType(type.getName()));
+    }
+    return types;
   }
 }

--- a/src/main/java/com/google/api/codegen/config/ApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ApiModel.java
@@ -41,7 +41,7 @@ public interface ApiModel {
 
   Iterable<? extends InterfaceModel> getInterfaces();
 
-  Iterable<? extends TypeModel> getTypes();
+  Iterable<? extends TypeModel> getAdditionalTypes();
 
   boolean hasMultipleServices();
 

--- a/src/main/java/com/google/api/codegen/config/ApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ApiModel.java
@@ -41,6 +41,8 @@ public interface ApiModel {
 
   Iterable<? extends InterfaceModel> getInterfaces();
 
+  Iterable<? extends TypeModel> getTypes();
+
   boolean hasMultipleServices();
 
   InterfaceModel getInterface(String interfaceName);

--- a/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
@@ -64,8 +64,7 @@ public class DiscoApiModel implements ApiModel {
 
   @Override
   public Iterable<? extends TypeModel> getAdditionalTypes() {
-    // TODO: is this supported?
-    return ImmutableList.of();
+    throw new UnsupportedOperationException("Discovery does not support additional types");
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
@@ -63,7 +63,7 @@ public class DiscoApiModel implements ApiModel {
   }
 
   @Override
-  public Iterable<? extends TypeModel> getTypes() {
+  public Iterable<? extends TypeModel> getAdditionalTypes() {
     // TODO: is this supported?
     return ImmutableList.of();
   }

--- a/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoApiModel.java
@@ -63,6 +63,12 @@ public class DiscoApiModel implements ApiModel {
   }
 
   @Override
+  public Iterable<? extends TypeModel> getTypes() {
+    // TODO: is this supported?
+    return ImmutableList.of();
+  }
+
+  @Override
   public InterfaceModel getInterface(String interfaceName) {
     for (InterfaceModel interfaceModel : getInterfaces()) {
       if (interfaceModel.getSimpleName().equals(interfaceName)

--- a/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
@@ -123,14 +123,8 @@ public class ProtoApiModel implements ApiModel {
     return models.build();
   }
 
-  /**
-   * Helper to extract the types from the underlying model.
-   *
-   * @see com.google.api.Service#getTypesList()
-   * @param model model with service config
-   * @return types
-   */
-  protected Iterable<TypeRef> getTypes(Model model) {
+  /** Helper to extract the types from the underlying model. */
+  private Iterable<TypeRef> getTypes(Model model) {
     List<TypeRef> types = new ArrayList<>();
     for (Type type : model.getServiceConfig().getTypesList()) {
       types.add(model.getSymbolTable().lookupType(type.getName()));

--- a/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
@@ -20,6 +20,7 @@ import com.google.api.Service;
 import com.google.api.codegen.InterfaceView;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
+import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
@@ -110,6 +111,15 @@ public class ProtoApiModel implements ApiModel {
     }
     interfaceModels = intfModels.build();
     return interfaceModels;
+  }
+
+  @Override
+  public Iterable<ProtoTypeRef> getTypes() {
+    ImmutableList.Builder<ProtoTypeRef> models = ImmutableList.builder();
+    for (TypeRef t : new InterfaceView().getTypes(protoModel)) {
+      models.add(new ProtoTypeRef(t));
+    }
+    return models.build();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoApiModel.java
@@ -22,6 +22,7 @@ import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -114,12 +115,27 @@ public class ProtoApiModel implements ApiModel {
   }
 
   @Override
-  public Iterable<ProtoTypeRef> getTypes() {
+  public Iterable<ProtoTypeRef> getAdditionalTypes() {
     ImmutableList.Builder<ProtoTypeRef> models = ImmutableList.builder();
-    for (TypeRef t : new InterfaceView().getTypes(protoModel)) {
+    for (TypeRef t : getTypes(protoModel)) {
       models.add(new ProtoTypeRef(t));
     }
     return models.build();
+  }
+
+  /**
+   * Helper to extract the types from the underlying model.
+   *
+   * @see com.google.api.Service#getTypesList()
+   * @param model model with service config
+   * @return types
+   */
+  protected Iterable<TypeRef> getTypes(Model model) {
+    List<TypeRef> types = new ArrayList<>();
+    for (Type type : model.getServiceConfig().getTypesList()) {
+      types.add(model.getSymbolTable().lookupType(type.getName()));
+    }
+    return types;
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -234,7 +234,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
 
     // append any additional types
     Set<String> requireTypes = new HashSet<>();
-    for (TypeModel type : model.getTypes()) {
+    for (TypeModel type : model.getAdditionalTypes()) {
       if (type instanceof ProtoTypeRef) {
         ProtoTypeRef t = (ProtoTypeRef) type;
         String name =

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
@@ -51,6 +51,9 @@ public abstract class VersionIndexView implements ViewModel {
 
   public abstract List<VersionIndexRequireView> requireViews();
 
+  @Nullable
+  public abstract List<String> requireTypes();
+
   public abstract FileHeaderView fileHeader();
 
   @Nullable
@@ -101,6 +104,8 @@ public abstract class VersionIndexView implements ViewModel {
     public abstract Builder modules(List<ModuleView> val);
 
     public abstract Builder requireViews(List<VersionIndexRequireView> val);
+
+    public abstract Builder requireTypes(List<String> val);
 
     public abstract Builder fileHeader(FileHeaderView val);
 

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -11,6 +11,9 @@
         require "{@requireView.fileName}"
     @end
 
+    @join extraType : {@index.requireTypes}
+        require "{@extraType}"
+    @end
 
   @case "TopLevelIndex"
     require "google/gax"

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -3357,6 +3357,7 @@ from google.api_core.protobuf_helpers import get_messages
 
 from google.api import http_pb2
 from google.cloud.example.library_v1.proto import book_from_anywhere_pb2
+from google.cloud.example.library_v1.proto import errors_pb2
 from google.cloud.example.library_v1.proto import field_mask_pb2 as proto_field_mask_pb2
 from google.cloud.example.library_v1.proto import library_pb2
 from google.cloud.example.library_v1.proto import other_shared_type_pb2
@@ -3377,6 +3378,7 @@ from google.rpc import status_pb2
 names = []
 for module in (http_pb2,
                book_from_anywhere_pb2,
+               errors_pb2,
                proto_field_mask_pb2,
                library_pb2,
                other_shared_type_pb2,

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -714,6 +714,7 @@ end
 # limitations under the License.
 
 require "library/v1/library_service_client"
+require "library/v1/errors_pb"
 
 # rubocop:disable LineLength
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -714,6 +714,7 @@ end
 # limitations under the License.
 
 require "library/v1/library_service_client"
+require "library/v1/errors_pb"
 
 # rubocop:disable LineLength
 

--- a/src/test/java/com/google/api/codegen/testsrc/errors.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/errors.proto
@@ -1,0 +1,14 @@
+// Proto file describing the common error protos
+syntax = "proto3";
+
+package google.example.library.v1;
+
+// Custom error class
+message CustomError {
+
+  // An enum value that indicates which error occurred.
+  int32 error_code = 1;
+
+  // A human-readable description of the error.
+  string message = 2;
+}

--- a/src/test/java/com/google/api/codegen/testsrc/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/library.proto
@@ -17,6 +17,7 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/field_mask.proto";
 import "shared_type.proto";
 import "tagger.proto";
+import "errors.proto";
 
 option java_multiple_files = true;
 option java_outer_classname = "LibraryProto";

--- a/src/test/java/com/google/api/codegen/testsrc/library.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library.yaml
@@ -9,6 +9,10 @@ apis:
   mixins:
   - name: google.tagger.v1.Tagger
 
+# Additional types used
+types:
+- name: google.example.library.v1.CustomError
+
 # Documentation section
 documentation:
   summary:


### PR DESCRIPTION
This PR requires types defined in the service config in the version index file (Ruby only).

This was motivated by using custom exception types. Importing them in the index makes it more likely they will be included when an exception is raised.