### PR TITLE
Add block argument to all non-streaming generated methods

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/common.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/common.snip
@@ -57,6 +57,8 @@
     or the specified config is missing data points.
   @@param timeout [Numeric]
     The default timeout, in seconds, for calls made through this client.
+  @@param metadata [Hash]
+    Default metadata to be sent with each request. This can be overridden on a per call basis.
 @end
 
 @snippet installationLines(metadata)

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -131,7 +131,7 @@
         page_descriptors: PAGE_DESCRIPTORS,
       @end
       errors: Google::Gax::Grpc::API_ERRORS,
-      kwargs: headers
+      metadata: headers
     )
   end
 @end
@@ -143,6 +143,7 @@
       scopes: ALL_SCOPES,
       client_config: {},
       timeout: DEFAULT_TIMEOUT,
+      metadata: nil,
       lib_name: nil,
       lib_version: ""
     @# These require statements are intentionally placed here to initialize
@@ -190,6 +191,7 @@
     google_api_client.freeze
 
     headers = { :"x-goog-api-client" => google_api_client }
+    headers.merge!(metadata) if metadata.is_a?(Hash)
     {@constructDefaults(xapiClass)}
     
     @# Allow overriding the service path/port in subclasses.
@@ -324,8 +326,7 @@
     end
   @else
     @if apiMethod.hasRequestParameters
-      def {@apiMethod.name} @\
-          {@paramList(apiMethod.methodParams)}
+      {@serviceDefStatement(apiMethod)}
         req = {
           @if apiMethod.requiredRequestObjectParams
             @if apiMethod.optionalRequestObjectParamsNoPageToken
@@ -342,7 +343,12 @@
         {@makeApiCall(apiMethod)}
       end
     @else
-      def {@apiMethod.name} {@inlineParamList(apiMethod.methodParams)}
+      @if or(apiMethod.isGrpcStreamingMethod, apiMethod.isLongRunningOperation)
+        def {@apiMethod.name} {@inlineParamList(apiMethod.methodParams)}
+      @else
+        def {@apiMethod.name} {@inlineParamList(apiMethod.methodParams)}, &block
+      @end
+
         req = {@apiMethod.requestTypeName}.new
         {@makeApiCall(apiMethod)}
       end
@@ -388,11 +394,27 @@
     operation.on_done { |operation| yield(operation) } if block_given?
     operation
   @else
-    @@{@apiMethod.name}.call({@apiMethod.requestVariableName}, options)
+    @if or(apiMethod.isGrpcStreamingMethod, apiMethod.isLongRunningOperation)
+      @@{@apiMethod.name}.call({@apiMethod.requestVariableName}, options)
+    @else
+      @@{@apiMethod.name}.call({@apiMethod.requestVariableName}, options, &block)
+    @end
+
     @if apiMethod.hasReturnValue
     @else
       nil
     @end
+  @end
+@end
+
+@private serviceDefStatement(apiMethod)
+  @if or(apiMethod.isGrpcStreamingMethod, apiMethod.isLongRunningOperation)
+    def {@apiMethod.name} @\
+        {@paramList(apiMethod.methodParams)}
+  @else
+    def {@apiMethod.name} @\
+        {@paramList(apiMethod.methodParams)},
+        &block
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -132,6 +132,7 @@
       scopes: nil,
       client_config: nil,
       timeout: nil,
+      metadata: nil,
       lib_name: nil,
       lib_version: nil
     kwargs = {
@@ -139,6 +140,7 @@
       scopes: scopes,
       client_config: client_config,
       timeout: timeout,
+      metadata: metadata,
       lib_name: lib_name,
       lib_version: lib_version
     }.select { |_, v| v != nil }

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -654,6 +654,8 @@ module Library
   #     or the specified config is missing data points.
   #   @param timeout [Numeric]
   #     The default timeout, in seconds, for calls made through this client.
+  #   @param metadata [Hash]
+  #     Default metadata to be sent with each request. This can be overridden on a per call basis.
   def self.new(*args, version: :v1, **kwargs)
     unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
       raise "The version: #{version} is not available. The available versions " \
@@ -802,11 +804,14 @@ module Library
     #   or the specified config is missing data points.
     # @param timeout [Numeric]
     #   The default timeout, in seconds, for calls made through this client.
+    # @param metadata [Hash]
+    #   Default metadata to be sent with each request. This can be overridden on a per call basis.
     def self.new \
         credentials: nil,
         scopes: nil,
         client_config: nil,
         timeout: nil,
+        metadata: nil,
         lib_name: nil,
         lib_version: nil
       kwargs = {
@@ -814,6 +819,7 @@ module Library
         scopes: scopes,
         client_config: client_config,
         timeout: timeout,
+        metadata: metadata,
         lib_name: lib_name,
         lib_version: lib_version
       }.select { |_, v| v != nil }
@@ -2575,11 +2581,14 @@ module Library
       #   or the specified config is missing data points.
       # @param timeout [Numeric]
       #   The default timeout, in seconds, for calls made through this client.
+      # @param metadata [Hash]
+      #   Default metadata to be sent with each request. This can be overridden on a per call basis.
       def initialize \
           credentials: nil,
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
+          metadata: nil,
           lib_name: nil,
           lib_version: ""
         # These require statements are intentionally placed here to initialize
@@ -2625,6 +2634,7 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        headers.merge!(metadata) if metadata.is_a?(Hash)
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"
         )
@@ -2638,7 +2648,7 @@ module Library
             bundle_descriptors: BUNDLE_DESCRIPTORS,
             page_descriptors: PAGE_DESCRIPTORS,
             errors: Google::Gax::Grpc::API_ERRORS,
-            kwargs: headers
+            metadata: headers
           )
         end
 
@@ -2806,12 +2816,13 @@ module Library
 
       def create_shelf \
           shelf,
-          options: nil
+          options: nil,
+          &block
         req = {
           shelf: shelf
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateShelfRequest)
-        @create_shelf.call(req, options)
+        @create_shelf.call(req, options, &block)
       end
 
       # Gets a shelf.
@@ -2847,7 +2858,8 @@ module Library
           options_,
           message: nil,
           string_builder: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           options: options_,
@@ -2855,7 +2867,7 @@ module Library
           string_builder: string_builder
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetShelfRequest)
-        @get_shelf.call(req, options)
+        @get_shelf.call(req, options, &block)
       end
 
       # Lists shelves.
@@ -2887,9 +2899,9 @@ module Library
       #     end
       #   end
 
-      def list_shelves options: nil
+      def list_shelves options: nil, &block
         req = Google::Example::Library::V1::ListShelvesRequest.new
-        @list_shelves.call(req, options)
+        @list_shelves.call(req, options, &block)
       end
 
       # Deletes a shelf.
@@ -2909,12 +2921,13 @@ module Library
 
       def delete_shelf \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteShelfRequest)
-        @delete_shelf.call(req, options)
+        @delete_shelf.call(req, options, &block)
         nil
       end
 
@@ -2942,13 +2955,14 @@ module Library
       def merge_shelves \
           name,
           other_shelf_name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MergeShelvesRequest)
-        @merge_shelves.call(req, options)
+        @merge_shelves.call(req, options, &block)
       end
 
       # Creates a book.
@@ -2977,13 +2991,14 @@ module Library
       def create_book \
           name,
           book,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           book: book
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateBookRequest)
-        @create_book.call(req, options)
+        @create_book.call(req, options, &block)
       end
 
       # Creates a series of books.
@@ -3029,7 +3044,8 @@ module Library
           series_uuid,
           edition: nil,
           review_copy: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           shelf: shelf,
           books: books,
@@ -3038,7 +3054,7 @@ module Library
           review_copy: review_copy
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::PublishSeriesRequest)
-        @publish_series.call(req, options)
+        @publish_series.call(req, options, &block)
       end
 
       # Gets a book.
@@ -3059,12 +3075,13 @@ module Library
 
       def get_book \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
-        @get_book.call(req, options)
+        @get_book.call(req, options, &block)
       end
 
       # Lists books in a shelf.
@@ -3112,14 +3129,15 @@ module Library
           name,
           page_size: nil,
           filter: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           page_size: page_size,
           filter: filter
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListBooksRequest)
-        @list_books.call(req, options)
+        @list_books.call(req, options, &block)
       end
 
       # Deletes a book.
@@ -3139,12 +3157,13 @@ module Library
 
       def delete_book \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteBookRequest)
-        @delete_book.call(req, options)
+        @delete_book.call(req, options, &block)
         nil
       end
 
@@ -3187,7 +3206,8 @@ module Library
           optional_foo: nil,
           update_mask: nil,
           physical_mask: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           book: book,
@@ -3196,7 +3216,7 @@ module Library
           physical_mask: physical_mask
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookRequest)
-        @update_book.call(req, options)
+        @update_book.call(req, options, &block)
       end
 
       # Moves a book to another shelf, and returns the new book.
@@ -3221,13 +3241,14 @@ module Library
       def move_book \
           name,
           other_shelf_name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBookRequest)
-        @move_book.call(req, options)
+        @move_book.call(req, options, &block)
       end
 
       # Lists a primitive resource. To test go page streaming.
@@ -3269,13 +3290,14 @@ module Library
       def list_strings \
           name: nil,
           page_size: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           page_size: page_size
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListStringsRequest)
-        @list_strings.call(req, options)
+        @list_strings.call(req, options, &block)
       end
 
       # Adds comments to a book
@@ -3307,13 +3329,14 @@ module Library
       def add_comments \
           name,
           comments,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           comments: comments
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::AddCommentsRequest)
-        @add_comments.call(req, options)
+        @add_comments.call(req, options, &block)
         nil
       end
 
@@ -3335,12 +3358,13 @@ module Library
 
       def get_book_from_archive \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromArchiveRequest)
-        @get_book_from_archive.call(req, options)
+        @get_book_from_archive.call(req, options, &block)
       end
 
       # Gets a book from a shelf or archive.
@@ -3366,13 +3390,14 @@ module Library
       def get_book_from_anywhere \
           name,
           alt_book_name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           alt_book_name: alt_book_name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromAnywhereRequest)
-        @get_book_from_anywhere.call(req, options)
+        @get_book_from_anywhere.call(req, options, &block)
       end
 
       # Test proper OneOf-Any resource name mapping
@@ -3393,12 +3418,13 @@ module Library
 
       def get_book_from_absolutely_anywhere \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromAbsolutelyAnywhereRequest)
-        @get_book_from_absolutely_anywhere.call(req, options)
+        @get_book_from_absolutely_anywhere.call(req, options, &block)
       end
 
       # Updates the index of a book.
@@ -3429,14 +3455,15 @@ module Library
           name,
           index_name,
           index_map,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           index_name: index_name,
           index_map: index_map
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookIndexRequest)
-        @update_book_index.call(req, options)
+        @update_book_index.call(req, options, &block)
         nil
       end
 
@@ -3614,14 +3641,15 @@ module Library
           names,
           shelves,
           page_size: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           names: names,
           shelves: shelves,
           page_size: page_size
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::FindRelatedBooksRequest)
-        @find_related_books.call(req, options)
+        @find_related_books.call(req, options, &block)
       end
 
       # Adds a tag to the book. This RPC is a mixin.
@@ -3650,13 +3678,14 @@ module Library
       def add_tag \
           resource,
           tag,
-          options: nil
+          options: nil,
+          &block
         req = {
           resource: resource,
           tag: tag
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Tagger::V1::AddTagRequest)
-        @add_tag.call(req, options)
+        @add_tag.call(req, options, &block)
       end
 
       # Adds a label to the entity.
@@ -3685,13 +3714,14 @@ module Library
       def add_label \
           resource,
           label,
-          options: nil
+          options: nil,
+          &block
         req = {
           resource: resource,
           label: label
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Tagger::V1::AddLabelRequest)
-        @add_label.call(req, options)
+        @add_label.call(req, options, &block)
       end
 
       # Test long-running operations
@@ -4025,7 +4055,8 @@ module Library
           optional_repeated_fixed32: nil,
           optional_repeated_fixed64: nil,
           optional_map: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           required_singular_int32: required_singular_int32,
           required_singular_int64: required_singular_int64,
@@ -4083,7 +4114,7 @@ module Library
           optional_map: optional_map
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest)
-        @test_optional_required_flattening_params.call(req, options)
+        @test_optional_required_flattening_params.call(req, options, &block)
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -654,6 +654,8 @@ module Library
   #     or the specified config is missing data points.
   #   @param timeout [Numeric]
   #     The default timeout, in seconds, for calls made through this client.
+  #   @param metadata [Hash]
+  #     Default metadata to be sent with each request. This can be overridden on a per call basis.
   def self.new(*args, version: :v1, **kwargs)
     unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
       raise "The version: #{version} is not available. The available versions " \
@@ -802,11 +804,14 @@ module Library
     #   or the specified config is missing data points.
     # @param timeout [Numeric]
     #   The default timeout, in seconds, for calls made through this client.
+    # @param metadata [Hash]
+    #   Default metadata to be sent with each request. This can be overridden on a per call basis.
     def self.new \
         credentials: nil,
         scopes: nil,
         client_config: nil,
         timeout: nil,
+        metadata: nil,
         lib_name: nil,
         lib_version: nil
       kwargs = {
@@ -814,6 +819,7 @@ module Library
         scopes: scopes,
         client_config: client_config,
         timeout: timeout,
+        metadata: metadata,
         lib_name: lib_name,
         lib_version: lib_version
       }.select { |_, v| v != nil }
@@ -1028,11 +1034,14 @@ module Library
       #   or the specified config is missing data points.
       # @param timeout [Numeric]
       #   The default timeout, in seconds, for calls made through this client.
+      # @param metadata [Hash]
+      #   Default metadata to be sent with each request. This can be overridden on a per call basis.
       def initialize \
           credentials: nil,
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
+          metadata: nil,
           lib_name: nil,
           lib_version: ""
         # These require statements are intentionally placed here to initialize
@@ -1078,6 +1087,7 @@ module Library
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        headers.merge!(metadata) if metadata.is_a?(Hash)
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"
         )
@@ -1091,7 +1101,7 @@ module Library
             bundle_descriptors: BUNDLE_DESCRIPTORS,
             page_descriptors: PAGE_DESCRIPTORS,
             errors: Google::Gax::Grpc::API_ERRORS,
-            kwargs: headers
+            metadata: headers
           )
         end
 
@@ -1259,12 +1269,13 @@ module Library
 
       def create_shelf \
           shelf,
-          options: nil
+          options: nil,
+          &block
         req = {
           shelf: shelf
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateShelfRequest)
-        @create_shelf.call(req, options)
+        @create_shelf.call(req, options, &block)
       end
 
       # Gets a shelf.
@@ -1300,7 +1311,8 @@ module Library
           options_,
           message: nil,
           string_builder: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           options: options_,
@@ -1308,7 +1320,7 @@ module Library
           string_builder: string_builder
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetShelfRequest)
-        @get_shelf.call(req, options)
+        @get_shelf.call(req, options, &block)
       end
 
       # Lists shelves.
@@ -1340,9 +1352,9 @@ module Library
       #     end
       #   end
 
-      def list_shelves options: nil
+      def list_shelves options: nil, &block
         req = Google::Example::Library::V1::ListShelvesRequest.new
-        @list_shelves.call(req, options)
+        @list_shelves.call(req, options, &block)
       end
 
       # Deletes a shelf.
@@ -1362,12 +1374,13 @@ module Library
 
       def delete_shelf \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteShelfRequest)
-        @delete_shelf.call(req, options)
+        @delete_shelf.call(req, options, &block)
         nil
       end
 
@@ -1395,13 +1408,14 @@ module Library
       def merge_shelves \
           name,
           other_shelf_name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MergeShelvesRequest)
-        @merge_shelves.call(req, options)
+        @merge_shelves.call(req, options, &block)
       end
 
       # Creates a book.
@@ -1430,13 +1444,14 @@ module Library
       def create_book \
           name,
           book,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           book: book
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateBookRequest)
-        @create_book.call(req, options)
+        @create_book.call(req, options, &block)
       end
 
       # Creates a series of books.
@@ -1482,7 +1497,8 @@ module Library
           series_uuid,
           edition: nil,
           review_copy: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           shelf: shelf,
           books: books,
@@ -1491,7 +1507,7 @@ module Library
           review_copy: review_copy
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::PublishSeriesRequest)
-        @publish_series.call(req, options)
+        @publish_series.call(req, options, &block)
       end
 
       # Gets a book.
@@ -1512,12 +1528,13 @@ module Library
 
       def get_book \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
-        @get_book.call(req, options)
+        @get_book.call(req, options, &block)
       end
 
       # Lists books in a shelf.
@@ -1565,14 +1582,15 @@ module Library
           name,
           page_size: nil,
           filter: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           page_size: page_size,
           filter: filter
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListBooksRequest)
-        @list_books.call(req, options)
+        @list_books.call(req, options, &block)
       end
 
       # Deletes a book.
@@ -1592,12 +1610,13 @@ module Library
 
       def delete_book \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteBookRequest)
-        @delete_book.call(req, options)
+        @delete_book.call(req, options, &block)
         nil
       end
 
@@ -1640,7 +1659,8 @@ module Library
           optional_foo: nil,
           update_mask: nil,
           physical_mask: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           book: book,
@@ -1649,7 +1669,7 @@ module Library
           physical_mask: physical_mask
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookRequest)
-        @update_book.call(req, options)
+        @update_book.call(req, options, &block)
       end
 
       # Moves a book to another shelf, and returns the new book.
@@ -1674,13 +1694,14 @@ module Library
       def move_book \
           name,
           other_shelf_name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBookRequest)
-        @move_book.call(req, options)
+        @move_book.call(req, options, &block)
       end
 
       # Lists a primitive resource. To test go page streaming.
@@ -1722,13 +1743,14 @@ module Library
       def list_strings \
           name: nil,
           page_size: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           page_size: page_size
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListStringsRequest)
-        @list_strings.call(req, options)
+        @list_strings.call(req, options, &block)
       end
 
       # Adds comments to a book
@@ -1760,13 +1782,14 @@ module Library
       def add_comments \
           name,
           comments,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           comments: comments
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::AddCommentsRequest)
-        @add_comments.call(req, options)
+        @add_comments.call(req, options, &block)
         nil
       end
 
@@ -1788,12 +1811,13 @@ module Library
 
       def get_book_from_archive \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromArchiveRequest)
-        @get_book_from_archive.call(req, options)
+        @get_book_from_archive.call(req, options, &block)
       end
 
       # Gets a book from a shelf or archive.
@@ -1819,13 +1843,14 @@ module Library
       def get_book_from_anywhere \
           name,
           alt_book_name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           alt_book_name: alt_book_name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromAnywhereRequest)
-        @get_book_from_anywhere.call(req, options)
+        @get_book_from_anywhere.call(req, options, &block)
       end
 
       # Test proper OneOf-Any resource name mapping
@@ -1846,12 +1871,13 @@ module Library
 
       def get_book_from_absolutely_anywhere \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromAbsolutelyAnywhereRequest)
-        @get_book_from_absolutely_anywhere.call(req, options)
+        @get_book_from_absolutely_anywhere.call(req, options, &block)
       end
 
       # Updates the index of a book.
@@ -1882,14 +1908,15 @@ module Library
           name,
           index_name,
           index_map,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           index_name: index_name,
           index_map: index_map
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookIndexRequest)
-        @update_book_index.call(req, options)
+        @update_book_index.call(req, options, &block)
         nil
       end
 
@@ -2067,14 +2094,15 @@ module Library
           names,
           shelves,
           page_size: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           names: names,
           shelves: shelves,
           page_size: page_size
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::FindRelatedBooksRequest)
-        @find_related_books.call(req, options)
+        @find_related_books.call(req, options, &block)
       end
 
       # Adds a tag to the book. This RPC is a mixin.
@@ -2103,13 +2131,14 @@ module Library
       def add_tag \
           resource,
           tag,
-          options: nil
+          options: nil,
+          &block
         req = {
           resource: resource,
           tag: tag
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Tagger::V1::AddTagRequest)
-        @add_tag.call(req, options)
+        @add_tag.call(req, options, &block)
       end
 
       # Adds a label to the entity.
@@ -2138,13 +2167,14 @@ module Library
       def add_label \
           resource,
           label,
-          options: nil
+          options: nil,
+          &block
         req = {
           resource: resource,
           label: label
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Tagger::V1::AddLabelRequest)
-        @add_label.call(req, options)
+        @add_label.call(req, options, &block)
       end
 
       # Test long-running operations
@@ -2478,7 +2508,8 @@ module Library
           optional_repeated_fixed32: nil,
           optional_repeated_fixed64: nil,
           optional_map: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           required_singular_int32: required_singular_int32,
           required_singular_int64: required_singular_int64,
@@ -2536,7 +2567,7 @@ module Library
           optional_map: optional_map
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest)
-        @test_optional_required_flattening_params.call(req, options)
+        @test_optional_required_flattening_params.call(req, options, &block)
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_longrunning.baseline
@@ -733,11 +733,14 @@ module Google
     #   or the specified config is missing data points.
     # @param timeout [Numeric]
     #   The default timeout, in seconds, for calls made through this client.
+    # @param metadata [Hash]
+    #   Default metadata to be sent with each request. This can be overridden on a per call basis.
     def self.new \
         credentials: nil,
         scopes: nil,
         client_config: nil,
         timeout: nil,
+        metadata: nil,
         lib_name: nil,
         lib_version: nil
       kwargs = {
@@ -745,6 +748,7 @@ module Google
         scopes: scopes,
         client_config: client_config,
         timeout: timeout,
+        metadata: metadata,
         lib_name: lib_name,
         lib_version: lib_version
       }.select { |_, v| v != nil }
@@ -861,11 +865,14 @@ module Google
       #   or the specified config is missing data points.
       # @param timeout [Numeric]
       #   The default timeout, in seconds, for calls made through this client.
+      # @param metadata [Hash]
+      #   Default metadata to be sent with each request. This can be overridden on a per call basis.
       def initialize \
           credentials: nil,
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
+          metadata: nil,
           lib_name: nil,
           lib_version: ""
         # These require statements are intentionally placed here to initialize
@@ -901,6 +908,7 @@ module Google
         google_api_client.freeze
 
         headers = { :"x-goog-api-client" => google_api_client }
+        headers.merge!(metadata) if metadata.is_a?(Hash)
         client_config_file = Pathname.new(__dir__).join(
           "operations_client_config.json"
         )
@@ -913,7 +921,7 @@ module Google
             timeout,
             page_descriptors: PAGE_DESCRIPTORS,
             errors: Google::Gax::Grpc::API_ERRORS,
-            kwargs: headers
+            metadata: headers
           )
         end
 
@@ -972,12 +980,13 @@ module Google
 
       def get_operation \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Longrunning::GetOperationRequest)
-        @get_operation.call(req, options)
+        @get_operation.call(req, options, &block)
       end
 
       # Lists operations that match the specified filter in the request. If the
@@ -1033,14 +1042,15 @@ module Google
           name,
           filter,
           page_size: nil,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name,
           filter: filter,
           page_size: page_size
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Longrunning::ListOperationsRequest)
-        @list_operations.call(req, options)
+        @list_operations.call(req, options, &block)
       end
 
       # Starts asynchronous cancellation on a long-running operation.  The server
@@ -1071,12 +1081,13 @@ module Google
 
       def cancel_operation \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Longrunning::CancelOperationRequest)
-        @cancel_operation.call(req, options)
+        @cancel_operation.call(req, options, &block)
         nil
       end
 
@@ -1102,12 +1113,13 @@ module Google
 
       def delete_operation \
           name,
-          options: nil
+          options: nil,
+          &block
         req = {
           name: name
         }.delete_if { |_, v| v.nil? }
         req = Google::Gax::to_proto(req, Google::Longrunning::DeleteOperationRequest)
-        @delete_operation.call(req, options)
+        @delete_operation.call(req, options, &block)
         nil
       end
     end

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_multiple_services.baseline
@@ -557,6 +557,8 @@ module Google
       #     or the specified config is missing data points.
       #   @param timeout [Numeric]
       #     The default timeout, in seconds, for calls made through this client.
+      #   @param metadata [Hash]
+      #     Default metadata to be sent with each request. This can be overridden on a per call basis.
       def self.new(*args, version: :v1, **kwargs)
         unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
           raise "The version: #{version} is not available. The available versions " \
@@ -602,6 +604,8 @@ module Google
       #     or the specified config is missing data points.
       #   @param timeout [Numeric]
       #     The default timeout, in seconds, for calls made through this client.
+      #   @param metadata [Hash]
+      #     Default metadata to be sent with each request. This can be overridden on a per call basis.
       def self.new(*args, version: :v1, **kwargs)
         unless AVAILABLE_VERSIONS.include?(version.to_s.downcase)
           raise "The version: #{version} is not available. The available versions " \
@@ -725,11 +729,14 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
         def self.new \
             credentials: nil,
             scopes: nil,
             client_config: nil,
             timeout: nil,
+            metadata: nil,
             lib_name: nil,
             lib_version: nil
           kwargs = {
@@ -737,6 +744,7 @@ module Google
             scopes: scopes,
             client_config: client_config,
             timeout: timeout,
+            metadata: metadata,
             lib_name: lib_name,
             lib_version: lib_version
           }.select { |_, v| v != nil }
@@ -770,11 +778,14 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
         def self.new \
             credentials: nil,
             scopes: nil,
             client_config: nil,
             timeout: nil,
+            metadata: nil,
             lib_name: nil,
             lib_version: nil
           kwargs = {
@@ -782,6 +793,7 @@ module Google
             scopes: scopes,
             client_config: client_config,
             timeout: timeout,
+            metadata: metadata,
             lib_name: lib_name,
             lib_version: lib_version
           }.select { |_, v| v != nil }
@@ -868,11 +880,14 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
         def initialize \
             credentials: nil,
             scopes: ALL_SCOPES,
             client_config: {},
             timeout: DEFAULT_TIMEOUT,
+            metadata: nil,
             lib_name: nil,
             lib_version: ""
           # These require statements are intentionally placed here to initialize
@@ -908,6 +923,7 @@ module Google
           google_api_client.freeze
 
           headers = { :"x-goog-api-client" => google_api_client }
+          headers.merge!(metadata) if metadata.is_a?(Hash)
           client_config_file = Pathname.new(__dir__).join(
             "decrementer_service_client_config.json"
           )
@@ -919,7 +935,7 @@ module Google
               Google::Gax::Grpc::STATUS_CODE_NAMES,
               timeout,
               errors: Google::Gax::Grpc::API_ERRORS,
-              kwargs: headers
+              metadata: headers
             )
           end
 
@@ -956,9 +972,9 @@ module Google
         #   decrementer_service_client = Google::Example::V1::Decrementer.new
         #   decrementer_service_client.decrement
 
-        def decrement options: nil
+        def decrement options: nil, &block
           req = Google::Cloud::Example::V1::DecrementRequest.new
-          @decrement.call(req, options)
+          @decrement.call(req, options, &block)
           nil
         end
       end
@@ -1057,11 +1073,14 @@ module Google
         #   or the specified config is missing data points.
         # @param timeout [Numeric]
         #   The default timeout, in seconds, for calls made through this client.
+        # @param metadata [Hash]
+        #   Default metadata to be sent with each request. This can be overridden on a per call basis.
         def initialize \
             credentials: nil,
             scopes: ALL_SCOPES,
             client_config: {},
             timeout: DEFAULT_TIMEOUT,
+            metadata: nil,
             lib_name: nil,
             lib_version: ""
           # These require statements are intentionally placed here to initialize
@@ -1097,6 +1116,7 @@ module Google
           google_api_client.freeze
 
           headers = { :"x-goog-api-client" => google_api_client }
+          headers.merge!(metadata) if metadata.is_a?(Hash)
           client_config_file = Pathname.new(__dir__).join(
             "incrementer_service_client_config.json"
           )
@@ -1108,7 +1128,7 @@ module Google
               Google::Gax::Grpc::STATUS_CODE_NAMES,
               timeout,
               errors: Google::Gax::Grpc::API_ERRORS,
-              kwargs: headers
+              metadata: headers
             )
           end
 
@@ -1145,9 +1165,9 @@ module Google
         #   incrementer_service_client = Google::Example::V1::Incrementer.new
         #   incrementer_service_client.increment
 
-        def increment options: nil
+        def increment options: nil, &block
           req = Google::Cloud::Example::V1::IncrementRequest.new
-          @increment.call(req, options)
+          @increment.call(req, options, &block)
           nil
         end
       end


### PR DESCRIPTION
This PR is related to a change in GAX to allow the underlying GRC operation to be exposed to the caller via an optional block: https://github.com/googleapis/gax-ruby/pull/118 

Streaming methods are not implemented. 

The current functionality is not changed:
```ruby
result = client.do_something(...)
```

This alternative calling style has been added (note that the variable same_result is shown for clarity, but it would not normally be used)
```ruby
same_result = client.do_something(...) do | result, op |
  # do stuff with result or metadata
  puts "#{result} with #{op.trailing_metadata}"
end
```

In addition, the following changes were also included:
  + An optional metadata parameter was added to generated clients. This metadata is sent on every call unless overridden with different call options.
  + A bug was fixed so that if metadata is specified via a call option the default metadata (x-goog-api-*, etc.) is not dropped.