### PR TITLE
Add more test object types and methods to discogapic test API

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeNameConverter.java
@@ -86,6 +86,10 @@ public abstract class SchemaTypeNameConverter implements TypeNameConverter {
 
   @Override
   public TypeName getTypeName(TypeModel type) {
+    // TODO(andrealin): Remove this hack when null response types are implemented.
+    if (type == null) {
+      return new TypeName("nullTypeName");
+    }
     if (type instanceof DiscoveryRequestType) {
       Method method = ((DiscoveryRequestType) type).parentMethod().getDiscoMethod();
       return getDiscoGapicNamer().getRequestTypeName(method, getNamer());

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
@@ -177,6 +177,10 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
 
   @Override
   public String getFullNameFor(TypeModel type) {
+    // TODO(andrealin): Remove this hack when null response types are implemented.
+    if (type == null) {
+      return "nullFullName";
+    }
     if (type instanceof DiscoveryRequestType) {
       Method method = ((DiscoveryRequestType) type).parentMethod().getDiscoMethod();
       return discoGapicNamer.getRequestTypeName(method, languageNamer).getFullName();

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -338,6 +338,10 @@ public class TestCaseTransformer {
     if (context.getMethodConfig().isLongRunningOperation()) {
       outputType = context.getMethodConfig().getLongRunningConfig().getReturnType();
     }
+    // TODO(andrealin): Remove this hack when null response types are implemented.
+    if (outputType == null) {
+      outputType = context.getMethodModel().getInputType().makeOptional();
+    }
     return InitCodeContext.newBuilder()
         .initObjectType(outputType)
         .symbolTable(symbolTable)

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -211,6 +211,195 @@ public final class AddressName implements ResourceName {
   }
 }
 
+============== file: src/main/java/com/google/cloud/simplecompute/v1/DummyObjectName.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import com.google.api.resourcenames.ResourceNameFactory;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Generated;
+
+@Generated("by GAPIC")
+@BetaApi
+public final class DummyObjectName implements ResourceName {
+  private final String dummyObject;
+  private final String project;
+  private static final PathTemplate PATH_TEMPLATE =
+        PathTemplate.createWithoutUrlEncoding("projects/{project}/dummyObjects/{dummyObject}");
+
+  private volatile Map<String, String> fieldValuesMap;
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private DummyObjectName(Builder builder) {
+    dummyObject = Preconditions.checkNotNull(builder.getDummyObject());
+    project = Preconditions.checkNotNull(builder.getProject());
+  }
+
+  public static DummyObjectName of(
+      String dummyObject,
+      String project
+      ) {
+    return newBuilder()
+    .setDummyObject(dummyObject)
+    .setProject(project)
+      .build();
+  }
+
+  public static String format(
+      String dummyObject,
+      String project
+      ) {
+    return of(
+        dummyObject,
+        project
+        )
+        .toString();
+  }
+
+  public String getDummyObject() {
+    return dummyObject;
+  }
+
+  public String getProject() {
+    return project;
+  }
+
+
+  @Override
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          fieldMapBuilder.put("dummyObject", dummyObject);
+          fieldMapBuilder.put("project", project);
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+
+  public static ResourceNameFactory<DummyObjectName> newFactory() {
+    return new ResourceNameFactory<DummyObjectName>() {
+      public DummyObjectName parse(String formattedString) {return DummyObjectName.parse(formattedString);}
+    };
+  }
+
+  public static DummyObjectName parse(String formattedString) {
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "DummyObjectName.parse: formattedString not in valid format");
+    return of(
+      matchMap.get("dummyObject"),
+      matchMap.get("project")
+    );
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  public static class Builder {
+    private String dummyObject;
+    private String project;
+
+    public String getDummyObject() {
+      return dummyObject;
+    }
+    public String getProject() {
+      return project;
+    }
+
+    public Builder setDummyObject(String dummyObject) {
+      this.dummyObject = dummyObject;
+      return this;
+    }
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    private Builder() {}
+
+    public Builder (DummyObjectName dummyObjectName) {
+      dummyObject = dummyObjectName.dummyObject;
+      project = dummyObjectName.project;
+    }
+
+    public DummyObjectName build() {
+      return new DummyObjectName(this);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate(
+        "dummyObject", dummyObject,
+        "project", project
+        );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof DummyObjectName) {
+      DummyObjectName that = (DummyObjectName) o;
+      return
+          Objects.equals(this.dummyObject, that.getDummyObject()) &&
+          Objects.equals(this.project, that.getProject())
+          ;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      dummyObject,
+      project
+    );
+  }
+}
+
 ============== file: src/main/java/com/google/cloud/simplecompute/v1/ProjectAddressName.java ==============
 /*
  * Copyright 2018 Google LLC
@@ -2326,12 +2515,14 @@ import javax.annotation.Nullable;
 @BetaApi
 public final class DummyObject implements ApiMessage {
   private final Float floatie;
+  private final String name;
   private final Double precisionFloatie;
   private final Address primaryAddress;
   private final Address secondaryAddress;
 
   private DummyObject() {
     this.floatie = null;
+    this.name = null;
     this.precisionFloatie = null;
     this.primaryAddress = null;
     this.secondaryAddress = null;
@@ -2340,11 +2531,13 @@ public final class DummyObject implements ApiMessage {
 
   private DummyObject(
       Float floatie,
+      String name,
       Double precisionFloatie,
       Address primaryAddress,
       Address secondaryAddress
       ) {
     this.floatie = floatie;
+    this.name = name;
     this.precisionFloatie = precisionFloatie;
     this.primaryAddress = primaryAddress;
     this.secondaryAddress = secondaryAddress;
@@ -2355,6 +2548,9 @@ public final class DummyObject implements ApiMessage {
     Map<String, List<String>> fieldMap = new HashMap<>();
     if (fieldNames.contains("floatie") && floatie != null) {
       fieldMap.put("floatie", Collections.singletonList(String.valueOf(floatie)));
+    }
+    if (fieldNames.contains("name") && name != null) {
+      fieldMap.put("name", Collections.singletonList(String.valueOf(name)));
     }
     if (fieldNames.contains("precisionFloatie") && precisionFloatie != null) {
       fieldMap.put("precisionFloatie", Collections.singletonList(String.valueOf(precisionFloatie)));
@@ -2372,6 +2568,9 @@ public final class DummyObject implements ApiMessage {
   public String getFieldStringValue(String fieldName) {
     if (fieldName.equals("floatie")) {
       return String.valueOf(floatie);
+    }
+    if (fieldName.equals("name")) {
+      return String.valueOf(name);
     }
     if (fieldName.equals("precisionFloatie")) {
       return String.valueOf(precisionFloatie);
@@ -2393,6 +2592,10 @@ public final class DummyObject implements ApiMessage {
 
   public Float getFloatie() {
     return floatie;
+  }
+
+  public String getName() {
+    return name;
   }
 
   public Double getPrecisionFloatie() {
@@ -2429,6 +2632,7 @@ public final class DummyObject implements ApiMessage {
 
   public static class Builder {
     private Float floatie;
+    private String name;
     private Double precisionFloatie;
     private Address primaryAddress;
     private Address secondaryAddress;
@@ -2439,6 +2643,9 @@ public final class DummyObject implements ApiMessage {
       if (other == DummyObject.getDefaultInstance()) return this;
       if (other.getFloatie() != null) {
         this.floatie = other.floatie;
+      }
+      if (other.getName() != null) {
+        this.name = other.name;
       }
       if (other.getPrecisionFloatie() != null) {
         this.precisionFloatie = other.precisionFloatie;
@@ -2454,6 +2661,7 @@ public final class DummyObject implements ApiMessage {
 
     Builder(DummyObject source) {
       this.floatie = source.floatie;
+      this.name = source.name;
       this.precisionFloatie = source.precisionFloatie;
       this.primaryAddress = source.primaryAddress;
       this.secondaryAddress = source.secondaryAddress;
@@ -2465,6 +2673,15 @@ public final class DummyObject implements ApiMessage {
 
     public Builder setFloatie(Float floatie) {
       this.floatie = floatie;
+      return this;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public Builder setName(String name) {
+      this.name = name;
       return this;
     }
 
@@ -2500,8 +2717,10 @@ public final class DummyObject implements ApiMessage {
 
 
 
+
       return new DummyObject(
         floatie,
+        name,
         precisionFloatie,
         primaryAddress,
         secondaryAddress
@@ -2511,6 +2730,7 @@ public final class DummyObject implements ApiMessage {
     public Builder clone() {
       Builder newBuilder = new Builder();
       newBuilder.setFloatie(this.floatie);
+      newBuilder.setName(this.name);
       newBuilder.setPrecisionFloatie(this.precisionFloatie);
       newBuilder.setAddress(this.primaryAddress);
       newBuilder.setAddress(this.secondaryAddress);
@@ -2522,6 +2742,7 @@ public final class DummyObject implements ApiMessage {
   public String toString() {
     return "DummyObject{"
         + "floatie=" + floatie + ", "
+        + "name=" + name + ", "
         + "precisionFloatie=" + precisionFloatie + ", "
         + "primaryAddress=" + primaryAddress + ", "
         + "secondaryAddress=" + secondaryAddress
@@ -2537,6 +2758,7 @@ public final class DummyObject implements ApiMessage {
       DummyObject that = (DummyObject) o;
       return
           Objects.equals(this.floatie, that.getFloatie()) &&
+          Objects.equals(this.name, that.getName()) &&
           Objects.equals(this.precisionFloatie, that.getPrecisionFloatie()) &&
           Objects.equals(this.primaryAddress, that.getAddress()) &&
           Objects.equals(this.secondaryAddress, that.getAddress())
@@ -2549,6 +2771,7 @@ public final class DummyObject implements ApiMessage {
   public int hashCode() {
     return Objects.hash(
       floatie,
+      name,
       precisionFloatie,
       primaryAddress,
       secondaryAddress
@@ -5321,6 +5544,415 @@ public final class DeleteAddressHttpRequest implements ApiMessage {
       access_token,
       address,
       callback,
+      fields,
+      key,
+      prettyPrint,
+      quotaUser,
+      userIp
+    );
+  }
+}
+
+============== file: src/main/java/com/google/cloud/simplecompute/v1/DeleteDummyObjectHttpRequest.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.httpjson.ApiMessage;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Generated;
+import javax.annotation.Nullable;
+
+@Generated("by GAPIC")
+@BetaApi
+public final class DeleteDummyObjectHttpRequest implements ApiMessage {
+  private final String access_token;
+  private final String callback;
+  private final String dummyObject;
+  private final String fields;
+  private final String key;
+  private final String prettyPrint;
+  private final String quotaUser;
+  private final String userIp;
+
+  private DeleteDummyObjectHttpRequest() {
+    this.access_token = null;
+    this.callback = null;
+    this.dummyObject = null;
+    this.fields = null;
+    this.key = null;
+    this.prettyPrint = null;
+    this.quotaUser = null;
+    this.userIp = null;
+  }
+
+
+  private DeleteDummyObjectHttpRequest(
+      String access_token,
+      String callback,
+      String dummyObject,
+      String fields,
+      String key,
+      String prettyPrint,
+      String quotaUser,
+      String userIp
+      ) {
+    this.access_token = access_token;
+    this.callback = callback;
+    this.dummyObject = dummyObject;
+    this.fields = fields;
+    this.key = key;
+    this.prettyPrint = prettyPrint;
+    this.quotaUser = quotaUser;
+    this.userIp = userIp;
+  }
+
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("access_token") && access_token != null) {
+      fieldMap.put("access_token", Collections.singletonList(String.valueOf(access_token)));
+    }
+    if (fieldNames.contains("callback") && callback != null) {
+      fieldMap.put("callback", Collections.singletonList(String.valueOf(callback)));
+    }
+    if (fieldNames.contains("dummyObject") && dummyObject != null) {
+      fieldMap.put("dummyObject", Collections.singletonList(String.valueOf(dummyObject)));
+    }
+    if (fieldNames.contains("fields") && fields != null) {
+      fieldMap.put("fields", Collections.singletonList(String.valueOf(fields)));
+    }
+    if (fieldNames.contains("key") && key != null) {
+      fieldMap.put("key", Collections.singletonList(String.valueOf(key)));
+    }
+    if (fieldNames.contains("prettyPrint") && prettyPrint != null) {
+      fieldMap.put("prettyPrint", Collections.singletonList(String.valueOf(prettyPrint)));
+    }
+    if (fieldNames.contains("quotaUser") && quotaUser != null) {
+      fieldMap.put("quotaUser", Collections.singletonList(String.valueOf(quotaUser)));
+    }
+    if (fieldNames.contains("userIp") && userIp != null) {
+      fieldMap.put("userIp", Collections.singletonList(String.valueOf(userIp)));
+    }
+    return fieldMap;
+  }
+
+  @Override
+  public String getFieldStringValue(String fieldName) {
+    if (fieldName.equals("access_token")) {
+      return String.valueOf(access_token);
+    }
+    if (fieldName.equals("callback")) {
+      return String.valueOf(callback);
+    }
+    if (fieldName.equals("dummyObject")) {
+      return String.valueOf(dummyObject);
+    }
+    if (fieldName.equals("fields")) {
+      return String.valueOf(fields);
+    }
+    if (fieldName.equals("key")) {
+      return String.valueOf(key);
+    }
+    if (fieldName.equals("prettyPrint")) {
+      return String.valueOf(prettyPrint);
+    }
+    if (fieldName.equals("quotaUser")) {
+      return String.valueOf(quotaUser);
+    }
+    if (fieldName.equals("userIp")) {
+      return String.valueOf(userIp);
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ApiMessage getApiMessageRequestBody() {
+    return null;
+  }
+
+  public String getAccessToken() {
+    return access_token;
+  }
+
+  public String getCallback() {
+    return callback;
+  }
+
+  public String getDummyObject() {
+    return dummyObject;
+  }
+
+  public String getFields() {
+    return fields;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getPrettyPrint() {
+    return prettyPrint;
+  }
+
+  public String getQuotaUser() {
+    return quotaUser;
+  }
+
+  public String getUserIp() {
+    return userIp;
+  }
+
+
+  public static Builder newBuilder() {
+    return DEFAULT_INSTANCE.toBuilder();
+  }
+  public static Builder newBuilder(DeleteDummyObjectHttpRequest prototype) {
+    return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+  }
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE
+        ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  public static DeleteDummyObjectHttpRequest getDefaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+  private static final DeleteDummyObjectHttpRequest DEFAULT_INSTANCE;
+  static {
+    DEFAULT_INSTANCE = new DeleteDummyObjectHttpRequest();
+  }
+
+  public static class Builder {
+    private String access_token;
+    private String callback;
+    private String dummyObject;
+    private String fields;
+    private String key;
+    private String prettyPrint;
+    private String quotaUser;
+    private String userIp;
+
+    Builder() {}
+
+    public Builder mergeFrom(DeleteDummyObjectHttpRequest other) {
+      if (other == DeleteDummyObjectHttpRequest.getDefaultInstance()) return this;
+      if (other.getAccessToken() != null) {
+        this.access_token = other.access_token;
+      }
+      if (other.getCallback() != null) {
+        this.callback = other.callback;
+      }
+      if (other.getDummyObject() != null) {
+        this.dummyObject = other.dummyObject;
+      }
+      if (other.getFields() != null) {
+        this.fields = other.fields;
+      }
+      if (other.getKey() != null) {
+        this.key = other.key;
+      }
+      if (other.getPrettyPrint() != null) {
+        this.prettyPrint = other.prettyPrint;
+      }
+      if (other.getQuotaUser() != null) {
+        this.quotaUser = other.quotaUser;
+      }
+      if (other.getUserIp() != null) {
+        this.userIp = other.userIp;
+      }
+      return this;
+    }
+
+    Builder(DeleteDummyObjectHttpRequest source) {
+      this.access_token = source.access_token;
+      this.callback = source.callback;
+      this.dummyObject = source.dummyObject;
+      this.fields = source.fields;
+      this.key = source.key;
+      this.prettyPrint = source.prettyPrint;
+      this.quotaUser = source.quotaUser;
+      this.userIp = source.userIp;
+    }
+
+    public String getAccessToken() {
+      return access_token;
+    }
+
+    public Builder setAccessToken(String access_token) {
+      this.access_token = access_token;
+      return this;
+    }
+
+    public String getCallback() {
+      return callback;
+    }
+
+    public Builder setCallback(String callback) {
+      this.callback = callback;
+      return this;
+    }
+
+    public String getDummyObject() {
+      return dummyObject;
+    }
+
+    public Builder setDummyObject(String dummyObject) {
+      this.dummyObject = dummyObject;
+      return this;
+    }
+
+    public String getFields() {
+      return fields;
+    }
+
+    public Builder setFields(String fields) {
+      this.fields = fields;
+      return this;
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public Builder setKey(String key) {
+      this.key = key;
+      return this;
+    }
+
+    public String getPrettyPrint() {
+      return prettyPrint;
+    }
+
+    public Builder setPrettyPrint(String prettyPrint) {
+      this.prettyPrint = prettyPrint;
+      return this;
+    }
+
+    public String getQuotaUser() {
+      return quotaUser;
+    }
+
+    public Builder setQuotaUser(String quotaUser) {
+      this.quotaUser = quotaUser;
+      return this;
+    }
+
+    public String getUserIp() {
+      return userIp;
+    }
+
+    public Builder setUserIp(String userIp) {
+      this.userIp = userIp;
+      return this;
+    }
+
+
+    public DeleteDummyObjectHttpRequest build() {
+      String missing = "";
+
+
+      if (dummyObject == null) {
+        missing += " dummyObject";
+      }
+
+
+
+
+
+      if (!missing.isEmpty()) {
+        throw new IllegalStateException("Missing required properties:" + missing);
+      }
+      return new DeleteDummyObjectHttpRequest(
+        access_token,
+        callback,
+        dummyObject,
+        fields,
+        key,
+        prettyPrint,
+        quotaUser,
+        userIp
+      );
+    }
+
+    public Builder clone() {
+      Builder newBuilder = new Builder();
+      newBuilder.setAccessToken(this.access_token);
+      newBuilder.setCallback(this.callback);
+      newBuilder.setDummyObject(this.dummyObject);
+      newBuilder.setFields(this.fields);
+      newBuilder.setKey(this.key);
+      newBuilder.setPrettyPrint(this.prettyPrint);
+      newBuilder.setQuotaUser(this.quotaUser);
+      newBuilder.setUserIp(this.userIp);
+      return newBuilder;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "DeleteDummyObjectHttpRequest{"
+        + "access_token=" + access_token + ", "
+        + "callback=" + callback + ", "
+        + "dummyObject=" + dummyObject + ", "
+        + "fields=" + fields + ", "
+        + "key=" + key + ", "
+        + "prettyPrint=" + prettyPrint + ", "
+        + "quotaUser=" + quotaUser + ", "
+        + "userIp=" + userIp
+        + "}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof DeleteDummyObjectHttpRequest) {
+      DeleteDummyObjectHttpRequest that = (DeleteDummyObjectHttpRequest) o;
+      return
+          Objects.equals(this.access_token, that.getAccessToken()) &&
+          Objects.equals(this.callback, that.getCallback()) &&
+          Objects.equals(this.dummyObject, that.getDummyObject()) &&
+          Objects.equals(this.fields, that.getFields()) &&
+          Objects.equals(this.key, that.getKey()) &&
+          Objects.equals(this.prettyPrint, that.getPrettyPrint()) &&
+          Objects.equals(this.quotaUser, that.getQuotaUser()) &&
+          Objects.equals(this.userIp, that.getUserIp())
+          ;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      access_token,
+      callback,
+      dummyObject,
       fields,
       key,
       prettyPrint,
@@ -10366,6 +10998,1115 @@ public class HttpJsonAddressCallableFactory implements HttpJsonStubCallableFacto
     return HttpJsonCallableFactory.createBatchingCallable(httpJsonCallSettings, batchingCallSettings, clientContext);
   }
 }
+============== file: src/main/java/com/google/cloud/simplecompute/v1/DummyObjectClient.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.paging.AbstractFixedSizeCollection;
+import com.google.api.gax.paging.AbstractPage;
+import com.google.api.gax.paging.AbstractPagedListResponse;
+import com.google.api.gax.paging.FixedSizeCollection;
+import com.google.api.gax.paging.Page;
+import com.google.api.gax.rpc.ApiExceptions;
+import com.google.api.gax.rpc.PageContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.cloud.simplecompute.v1.stub.DummyObjectStub;
+import com.google.cloud.simplecompute.v1.stub.DummyObjectStubSettings;
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND SERVICE
+/**
+ * Service Description: Creates and runs virtual machines on Google Cloud Platform.
+ *
+ * <p>This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * <pre>
+ * <code>
+ * try (DummyObjectClient dummyObjectClient = DummyObjectClient.create()) {
+ *   DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+ *   dummyObjectClient.deleteDummyObject(dummyObject);
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>Note: close() needs to be called on the dummyObjectClient object to clean up resources such
+ * as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's methods:
+ *
+ * <ol>
+ * <li> A "flattened" method. With this type of method, the fields of the request type have been
+ * converted into function parameters. It may be the case that not all fields are available
+ * as parameters, and not every API method will have a flattened method entry point.
+ * <li> A "request object" method. This type of method only takes one parameter, a request
+ * object, which must be constructed before the call. Not every API method will have a request
+ * object method.
+ * <li> A "callable" method. This type of method takes no parameters and returns an immutable
+ * API callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist
+ * with these names, this class includes a format method for each type of name, and additionally
+ * a parse method to extract the individual identifiers contained within names that are
+ * returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of DummyObjectSettings to
+ * create(). For example:
+ *
+ * To customize credentials:
+ *
+ * <pre>
+ * <code>
+ * DummyObjectSettings dummyObjectSettings =
+ *     DummyObjectSettings.newBuilder()
+ *         .setCredentialsProvider(FixedCredentialsProvider.create(myCredentials))
+ *         .build();
+ * DummyObjectClient dummyObjectClient =
+ *     DummyObjectClient.create(dummyObjectSettings);
+ * </code>
+ * </pre>
+ *
+ * To customize the endpoint:
+ *
+ * <pre>
+ * <code>
+ * DummyObjectSettings dummyObjectSettings =
+ *     DummyObjectSettings.newBuilder().setEndpoint(myEndpoint).build();
+ * DummyObjectClient dummyObjectClient =
+ *     DummyObjectClient.create(dummyObjectSettings);
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+@BetaApi
+public class DummyObjectClient implements BackgroundResource {
+  private final DummyObjectSettings settings;
+  private final DummyObjectStub stub;
+
+
+
+  /**
+   * Constructs an instance of DummyObjectClient with default settings.
+   */
+  public static final DummyObjectClient create() throws IOException {
+    return create(DummyObjectSettings.newBuilder().build());
+  }
+
+  /**
+   * Constructs an instance of DummyObjectClient, using the given settings.
+   * The channels are created based on the settings passed in, or defaults for any
+   * settings that are not set.
+   */
+  public static final DummyObjectClient create(DummyObjectSettings settings) throws IOException {
+    return new DummyObjectClient(settings);
+  }
+
+  /**
+   * Constructs an instance of DummyObjectClient, using the given stub for making calls. This is for
+   * advanced usage - prefer to use DummyObjectSettings}.
+   */
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public static final DummyObjectClient create(DummyObjectStub stub) {
+    return new DummyObjectClient(stub);
+  }
+
+  /**
+   * Constructs an instance of DummyObjectClient, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected DummyObjectClient(DummyObjectSettings settings) throws IOException {
+    this.settings = settings;
+    this.stub = ((DummyObjectStubSettings) settings.getStubSettings()).createStub();
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  protected DummyObjectClient(DummyObjectStub stub) {
+    this.settings = null;
+    this.stub = stub;
+  }
+
+  public final DummyObjectSettings getSettings() {
+    return settings;
+  }
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DummyObjectStub getStub() {
+    return stub;
+  }
+
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Method with no response object.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (DummyObjectClient dummyObjectClient = DummyObjectClient.create()) {
+   *   DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+   *   dummyObjectClient.deleteDummyObject(dummyObject);
+   * }
+   * </code></pre>
+   *
+   * @param dummyObject Name of the dummyObject resource to delete.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final void deleteDummyObject(DummyObjectName dummyObject) {
+
+    DeleteDummyObjectHttpRequest request =
+        DeleteDummyObjectHttpRequest.newBuilder()
+        .setDummyObject(dummyObject == null ? null : dummyObject.toString())
+        .build();
+    deleteDummyObject(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Method with no response object.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (DummyObjectClient dummyObjectClient = DummyObjectClient.create()) {
+   *   DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+   *   dummyObjectClient.deleteDummyObject(dummyObject.toString());
+   * }
+   * </code></pre>
+   *
+   * @param dummyObject Name of the dummyObject resource to delete.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final void deleteDummyObject(String dummyObject) {
+
+    DeleteDummyObjectHttpRequest request =
+        DeleteDummyObjectHttpRequest.newBuilder()
+        .setDummyObject(dummyObject)
+        .build();
+    deleteDummyObject(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Method with no response object.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (DummyObjectClient dummyObjectClient = DummyObjectClient.create()) {
+   *   DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+   *   DeleteDummyObjectHttpRequest request = DeleteDummyObjectHttpRequest.newBuilder()
+   *     .setDummyObject(dummyObject.toString())
+   *     .build();
+   *   dummyObjectClient.deleteDummyObject(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.rpc.ApiException if the remote call fails
+   */
+  @BetaApi
+  public final void deleteDummyObject(DeleteDummyObjectHttpRequest request) {
+    deleteDummyObjectCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Method with no response object.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (DummyObjectClient dummyObjectClient = DummyObjectClient.create()) {
+   *   DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+   *   DeleteDummyObjectHttpRequest request = DeleteDummyObjectHttpRequest.newBuilder()
+   *     .setDummyObject(dummyObject.toString())
+   *     .build();
+   *   ApiFuture&lt;Void&gt; future = dummyObjectClient.deleteDummyObjectCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  @BetaApi
+  public final UnaryCallable<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectCallable() {
+    return stub.deleteDummyObjectCallable();
+  }
+
+  @Override
+  public final void close() throws Exception {
+    stub.close();
+  }
+
+  @Override
+  public void shutdown() {
+    stub.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return stub.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return stub.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    stub.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return stub.awaitTermination(duration, unit);
+  }
+
+
+}
+============== file: src/main/java/com/google/cloud/simplecompute/v1/DummyObjectSettings.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
+import com.google.api.gax.httpjson.HttpJsonTransportChannel;
+import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.auth.Credentials;
+import com.google.cloud.simplecompute.v1.stub.DummyObjectStubSettings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link DummyObjectClient}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ * <li>The default service address (https://www.googleapis.com/compute/v1/projects/) and default port (443)
+ * are used.
+ * <li>Credentials are acquired automatically through Application Default Credentials.
+ * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders.
+ * When build() is called, the tree of builders is called to create the complete settings
+ * object. For example, to set the total timeout of deleteDummyObject to 30 seconds:
+ *
+ * <pre>
+ * <code>
+ * DummyObjectSettings.Builder dummyObjectSettingsBuilder =
+ *     DummyObjectSettings.newBuilder();
+ * dummyObjectSettingsBuilder.deleteDummyObjectSettings().getRetrySettings().toBuilder()
+ *     .setTotalTimeout(Duration.ofSeconds(30));
+ * DummyObjectSettings dummyObjectSettings = dummyObjectSettingsBuilder.build();
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+@BetaApi
+public class DummyObjectSettings extends ClientSettings<DummyObjectSettings> {
+  /**
+   * Returns the object with the settings used for calls to deleteDummyObject.
+   */
+  public UnaryCallSettings<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectSettings() {
+    return ((DummyObjectStubSettings) getStubSettings()).deleteDummyObjectSettings();
+  }
+
+
+  public static final DummyObjectSettings create(DummyObjectStubSettings stub) throws IOException {
+    return new DummyObjectSettings.Builder(stub.toBuilder()).build();
+  }
+
+  /**
+   * Returns a builder for the default ExecutorProvider for this service.
+   */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return DummyObjectStubSettings.defaultExecutorProviderBuilder();
+  }
+
+  /**
+   * Returns the default service endpoint.
+   */
+   public static String getDefaultEndpoint() {
+     return DummyObjectStubSettings.getDefaultEndpoint();
+   }
+  /**
+   * Returns the default service port.
+   */
+  public static int getDefaultServicePort() {
+    return DummyObjectStubSettings.getDefaultServicePort();
+  }
+
+
+  /**
+   * Returns the default service scopes.
+   */
+  public static List<String> getDefaultServiceScopes() {
+    return DummyObjectStubSettings.getDefaultServiceScopes();
+  }
+
+
+  /**
+   * Returns a builder for the default credentials for this service.
+   */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return DummyObjectStubSettings.defaultCredentialsProviderBuilder();
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingHttpJsonChannelProvider.Builder defaultHttpJsonTransportProviderBuilder() {
+    return DummyObjectStubSettings.defaultHttpJsonTransportProviderBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return DummyObjectStubSettings.defaultTransportChannelProvider();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return DummyObjectStubSettings.defaultApiClientHeaderProviderBuilder();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected DummyObjectSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+  }
+
+  /**
+   * Builder for DummyObjectSettings.
+   */
+  public static class Builder extends ClientSettings.Builder<DummyObjectSettings, Builder> {
+    protected Builder() throws IOException {
+      this((ClientContext) null);
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(DummyObjectStubSettings.newBuilder(clientContext));
+    }
+
+    private static Builder createDefault() {
+      return new Builder(DummyObjectStubSettings.newBuilder());
+    }
+
+    protected Builder(DummyObjectSettings settings) {
+      super(settings.getStubSettings().toBuilder());
+    }
+
+    protected Builder(DummyObjectStubSettings.Builder stubSettings) {
+      super(stubSettings);
+    }
+
+
+    public DummyObjectStubSettings.Builder getStubSettingsBuilder() {
+      return ((DummyObjectStubSettings.Builder) getStubSettings());
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) throws Exception {
+      super.applyToAllUnaryMethods(getStubSettingsBuilder().unaryMethodSettingsBuilders(), settingsUpdater);
+      return this;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to deleteDummyObject.
+     */
+    public UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectSettings() {
+      return getStubSettingsBuilder().deleteDummyObjectSettings();
+    }
+
+    @Override
+    public DummyObjectSettings build() throws IOException {
+      return new DummyObjectSettings(this);
+    }
+  }
+}
+============== file: src/main/java/com/google/cloud/simplecompute/v1/stub/DummyObjectStubSettings.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1.stub;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.ExecutorProvider;
+import com.google.api.gax.core.GaxProperties;
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.core.InstantiatingExecutorProvider;
+import com.google.api.gax.httpjson.GaxHttpJsonProperties;
+import com.google.api.gax.httpjson.HttpJsonTransportChannel;
+import com.google.api.gax.httpjson.InstantiatingHttpJsonChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.ApiClientHeaderProvider;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientSettings;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.StubSettings;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.auth.Credentials;
+import com.google.cloud.simplecompute.v1.DeleteDummyObjectHttpRequest;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Generated;
+import org.threeten.bp.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link DummyObjectStub}.
+ *
+ * <p>The default instance has everything set to sensible defaults:
+ *
+ * <ul>
+ * <li>The default service address (https://www.googleapis.com/compute/v1/projects/) and default port (443)
+ * are used.
+ * <li>Credentials are acquired automatically through Application Default Credentials.
+ * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+ * </ul>
+ *
+ * <p>The builder of this class is recursive, so contained classes are themselves builders.
+ * When build() is called, the tree of builders is called to create the complete settings
+ * object. For example, to set the total timeout of deleteDummyObject to 30 seconds:
+ *
+ * <pre>
+ * <code>
+ * DummyObjectStubSettings.Builder dummyObjectSettingsBuilder =
+ *     DummyObjectStubSettings.newBuilder();
+ * dummyObjectSettingsBuilder.deleteDummyObjectSettings().getRetrySettings().toBuilder()
+ *     .setTotalTimeout(Duration.ofSeconds(30));
+ * DummyObjectStubSettings dummyObjectSettings = dummyObjectSettingsBuilder.build();
+ * </code>
+ * </pre>
+ */
+@Generated("by GAPIC v0.0.5")
+@BetaApi
+public class DummyObjectStubSettings extends StubSettings<DummyObjectStubSettings> {
+  /**
+   * The default scopes of the service.
+   */
+  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES = ImmutableList.<String>builder()
+      .add("https://www.googleapis.com/auth/cloud-platform")
+      .add("https://www.googleapis.com/auth/compute")
+      .add("https://www.googleapis.com/auth/compute.readonly")
+      .add("https://www.googleapis.com/auth/devstorage.full_control")
+      .add("https://www.googleapis.com/auth/devstorage.read_only")
+      .add("https://www.googleapis.com/auth/devstorage.read_write")
+      .build();
+
+  private final UnaryCallSettings<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectSettings;
+
+  /**
+   * Returns the object with the settings used for calls to deleteDummyObject.
+   */
+  public UnaryCallSettings<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectSettings() {
+    return deleteDummyObjectSettings;
+  }
+
+
+  @BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+  public DummyObjectStub createStub() throws IOException {
+    if (getTransportChannelProvider()
+        .getTransportName()
+        .equals(HttpJsonTransportChannel.getHttpJsonTransportName())) {
+      return HttpJsonDummyObjectStub.create(this);
+    } else {
+      throw new UnsupportedOperationException(
+          "Transport not supported: " + getTransportChannelProvider().getTransportName());
+    }
+  }
+
+  /**
+   * Returns a builder for the default ExecutorProvider for this service.
+   */
+  public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder() {
+    return InstantiatingExecutorProvider.newBuilder();
+  }
+
+  /**
+   * Returns the default service endpoint.
+   */
+  public static String getDefaultEndpoint() {
+    return "https://www.googleapis.com/compute/v1/projects/";
+  }
+
+  /**
+   * Returns the default service port.
+   */
+  public static int getDefaultServicePort() {
+    return 443;
+  }
+
+
+  /**
+   * Returns the default service scopes.
+   */
+  public static List<String> getDefaultServiceScopes() {
+    return DEFAULT_SERVICE_SCOPES;
+  }
+
+
+  /**
+   * Returns a builder for the default credentials for this service.
+   */
+  public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder() {
+    return GoogleCredentialsProvider.newBuilder()
+        .setScopesToApply(DEFAULT_SERVICE_SCOPES)
+        ;
+  }
+
+  /** Returns a builder for the default ChannelProvider for this service. */
+  public static InstantiatingHttpJsonChannelProvider.Builder defaultHttpJsonTransportProviderBuilder() {
+    return InstantiatingHttpJsonChannelProvider.newBuilder();
+  }
+
+  public static TransportChannelProvider defaultTransportChannelProvider() {
+    return defaultHttpJsonTransportProviderBuilder().build();
+  }
+
+  @BetaApi("The surface for customizing headers is not stable yet and may change in the future.")
+  public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder() {
+    return ApiClientHeaderProvider.newBuilder()
+        .setGeneratedLibToken("gapic", GaxProperties.getLibraryVersion(DummyObjectStubSettings.class))
+        .setTransportToken(GaxHttpJsonProperties.getHttpJsonTokenName(), GaxHttpJsonProperties.getHttpJsonVersion());
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder(ClientContext clientContext) {
+    return new Builder(clientContext);
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  protected DummyObjectStubSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder);
+
+    deleteDummyObjectSettings = settingsBuilder.deleteDummyObjectSettings().build();
+  }
+
+
+
+
+  /**
+   * Builder for DummyObjectStubSettings.
+   */
+  public static class Builder extends StubSettings.Builder<DummyObjectStubSettings, Builder> {
+    private final ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders;
+
+    private final UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectSettings;
+
+    private static final ImmutableMap<String, ImmutableSet<StatusCode.Code>> RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<StatusCode.Code>> definitions = ImmutableMap.builder();
+      definitions.put(
+          "idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList(StatusCode.Code.DEADLINE_EXCEEDED, StatusCode.Code.UNAVAILABLE)));
+      definitions.put(
+          "non_idempotent",
+          ImmutableSet.copyOf(Lists.<StatusCode.Code>newArrayList()));
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings> definitions = ImmutableMap.builder();
+      RetrySettings settings = null;
+      settings = RetrySettings.newBuilder()
+          .setInitialRetryDelay(Duration.ofMillis(100L))
+          .setRetryDelayMultiplier(1.3)
+          .setMaxRetryDelay(Duration.ofMillis(60000L))
+          .setInitialRpcTimeout(Duration.ofMillis(20000L))
+          .setRpcTimeoutMultiplier(1.0)
+          .setMaxRpcTimeout(Duration.ofMillis(20000L))
+          .setTotalTimeout(Duration.ofMillis(600000L))
+          .build();
+      definitions.put("default", settings);
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    protected Builder() {
+      this((ClientContext) null);
+    }
+
+    protected Builder(ClientContext clientContext) {
+      super(clientContext);
+
+      deleteDummyObjectSettings = UnaryCallSettings.newUnaryCallSettingsBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+          deleteDummyObjectSettings
+      );
+
+      initDefaults(this);
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder((ClientContext) null);
+      builder.setTransportChannelProvider(defaultTransportChannelProvider());
+      builder.setCredentialsProvider(defaultCredentialsProviderBuilder().build());
+      builder.setInternalHeaderProvider(defaultApiClientHeaderProviderBuilder().build());
+      builder.setEndpoint(getDefaultEndpoint());
+      return initDefaults(builder);
+    }
+
+    private static Builder initDefaults(Builder builder) {
+
+      builder.deleteDummyObjectSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettings(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      return builder;
+    }
+
+    protected Builder(DummyObjectStubSettings settings) {
+      super(settings);
+
+      deleteDummyObjectSettings = settings.deleteDummyObjectSettings.toBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder<?, ?>>of(
+          deleteDummyObjectSettings
+      );
+    }
+
+    /**
+     * Applies the given settings updater function to all of the unary API methods in this service.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllUnaryMethods(ApiFunction<UnaryCallSettings.Builder<?, ?>, Void> settingsUpdater) throws Exception {
+      super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, settingsUpdater);
+      return this;
+    }
+
+    public ImmutableList<UnaryCallSettings.Builder<?, ?>> unaryMethodSettingsBuilders() {
+      return unaryMethodSettingsBuilders;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to deleteDummyObject.
+     */
+    public UnaryCallSettings.Builder<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectSettings() {
+      return deleteDummyObjectSettings;
+    }
+
+    @Override
+    public DummyObjectStubSettings build() throws IOException {
+      return new DummyObjectStubSettings(this);
+    }
+  }
+}
+============== file: src/main/java/com/google/cloud/simplecompute/v1/stub/DummyObjectStub.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1.stub;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.simplecompute.v1.DeleteDummyObjectHttpRequest;
+import com.google.cloud.simplecompute.v1.DummyObjectName;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Base stub class for simplecompute.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by GAPIC v0.0.5")
+@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+public abstract class DummyObjectStub implements BackgroundResource {
+
+
+  @BetaApi
+  public UnaryCallable<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectCallable() {
+    throw new UnsupportedOperationException("Not implemented: deleteDummyObjectCallable()");
+  }
+
+}
+============== file: src/main/java/com/google/cloud/simplecompute/v1/stub/HttpJsonDummyObjectStub.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1.stub;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.httpjson.ApiMessageHttpRequestFormatter;
+import com.google.api.gax.httpjson.ApiMessageHttpResponseParser;
+import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.RequestParamsExtractor;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.cloud.simplecompute.v1.DeleteDummyObjectHttpRequest;
+import com.google.cloud.simplecompute.v1.DummyObjectName;
+import com.google.cloud.simplecompute.v1.DummyObjectSettings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * HTTP stub implementation for simplecompute.
+ *
+ * <p>This class is for advanced usage and reflects the underlying API directly.
+ */
+@Generated("by GAPIC v0.0.5")
+@BetaApi("A restructuring of stub classes is planned, so this may break in the future")
+public class HttpJsonDummyObjectStub extends DummyObjectStub {
+  @InternalApi
+  public static final ApiMethodDescriptor<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectMethodDescriptor =
+      ApiMethodDescriptor.<DeleteDummyObjectHttpRequest, nullTypeName>newBuilder()
+          .setFullMethodName("compute.dummyObjects.delete")
+          .setHttpMethod(HttpMethods.DELETE)
+          .setRequestFormatter(
+              ApiMessageHttpRequestFormatter.<DeleteDummyObjectHttpRequest>newBuilder()
+                  .setRequestInstance(DeleteDummyObjectHttpRequest.getDefaultInstance())
+                  .setPathTemplate(PathTemplate.create("{project}/dummyObjects/{dummyObject}"))
+                  .setQueryParams(Sets.<String>newHashSet(
+                                     ))
+                  .setResourceNameFactory(DummyObjectName.newFactory())
+                  .setResourceNameField("dummyObject")
+                  .build())
+          .setResponseParser(
+              ApiMessageHttpResponseParser.<nullTypeName>newBuilder()
+                  .build())
+          .build();
+  private final BackgroundResource backgroundResources;
+
+  private final UnaryCallable<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectCallable;
+
+  private final HttpJsonStubCallableFactory callableFactory;
+  public static final HttpJsonDummyObjectStub create(DummyObjectStubSettings settings) throws IOException {
+    return new HttpJsonDummyObjectStub(settings, ClientContext.create(settings));
+  }
+
+  public static final HttpJsonDummyObjectStub create(ClientContext clientContext) throws IOException {
+    return new HttpJsonDummyObjectStub(DummyObjectStubSettings.newBuilder().build(), clientContext);
+  }
+
+  public static final HttpJsonDummyObjectStub create(ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
+    return new HttpJsonDummyObjectStub(DummyObjectStubSettings.newBuilder().build(), clientContext, callableFactory);
+  }
+
+  /**
+   * Constructs an instance of HttpJsonDummyObjectStub, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected HttpJsonDummyObjectStub(DummyObjectStubSettings settings, ClientContext clientContext) throws IOException {
+    this(settings, clientContext, new HttpJsonDummyObjectCallableFactory());
+  }
+
+  /**
+   * Constructs an instance of HttpJsonDummyObjectStub, using the given settings.
+   * This is protected so that it is easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected HttpJsonDummyObjectStub(DummyObjectStubSettings settings, ClientContext clientContext, HttpJsonStubCallableFactory callableFactory) throws IOException {
+    this.callableFactory = callableFactory;
+
+    HttpJsonCallSettings<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectTransportSettings =
+        HttpJsonCallSettings.<DeleteDummyObjectHttpRequest, nullTypeName>newBuilder()
+            .setMethodDescriptor(deleteDummyObjectMethodDescriptor)
+            .build();
+
+    this.deleteDummyObjectCallable = callableFactory.createUnaryCallable(deleteDummyObjectTransportSettings,settings.deleteDummyObjectSettings(), clientContext);
+
+    backgroundResources = new BackgroundResourceAggregation(clientContext.getBackgroundResources());
+  }
+
+  @BetaApi
+  public UnaryCallable<DeleteDummyObjectHttpRequest, nullTypeName> deleteDummyObjectCallable() {
+    return deleteDummyObjectCallable;
+  }
+
+  @Override
+  public final void close() throws Exception {
+    shutdown();
+  }
+
+  @Override
+  public void shutdown() {
+    backgroundResources.shutdown();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return backgroundResources.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return backgroundResources.isTerminated();
+  }
+
+  @Override
+  public void shutdownNow() {
+    backgroundResources.shutdownNow();
+  }
+
+  @Override
+  public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+    return backgroundResources.awaitTermination(duration, unit);
+  }
+
+}
+============== file: src/main/java/com/google/cloud/simplecompute/v1/stub/HttpJsonDummyObjectCallableFactory.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1.stub;
+
+import com.google.api.client.http.HttpMethods;
+import com.google.api.core.BetaApi;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.core.BackgroundResource;
+import com.google.api.gax.core.BackgroundResourceAggregation;
+import com.google.api.gax.httpjson.ApiMessageHttpRequestFormatter;
+import com.google.api.gax.httpjson.ApiMessageHttpResponseParser;
+import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.HttpJsonCallSettings;
+import com.google.api.gax.httpjson.HttpJsonCallableFactory;
+import com.google.api.gax.httpjson.HttpJsonStubCallableFactory;
+import com.google.api.gax.rpc.BatchingCallSettings;
+import com.google.api.gax.rpc.BidiStreamingCallable;
+import com.google.api.gax.rpc.ClientContext;
+import com.google.api.gax.rpc.ClientStreamingCallable;
+import com.google.api.gax.rpc.OperationCallSettings;
+import com.google.api.gax.rpc.OperationCallable;
+import com.google.api.gax.rpc.PagedCallSettings;
+import com.google.api.gax.rpc.RequestParamsExtractor;
+import com.google.api.gax.rpc.ServerStreamingCallSettings;
+import com.google.api.gax.rpc.ServerStreamingCallable;
+import com.google.api.gax.rpc.StreamingCallSettings;
+import com.google.api.gax.rpc.UnaryCallSettings;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.cloud.simplecompute.v1.DeleteDummyObjectHttpRequest;
+import com.google.cloud.simplecompute.v1.DummyObjectName;
+import com.google.cloud.simplecompute.v1.DummyObjectSettings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import com.google.longrunning.Operation;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Generated;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * HTTP callable factory implementation for simplecompute.
+ *
+ * <p>This class is for advanced usage.
+ */
+@Generated("by GAPIC v0.0.5")
+@BetaApi("The surface for use by generated code is not stable yet and may change in the future.")
+public class HttpJsonDummyObjectCallableFactory implements HttpJsonStubCallableFactory {
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createUnaryCallable(
+      HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+      UnaryCallSettings<RequestT, ResponseT> callSettings,
+      ClientContext clientContext) {
+    return HttpJsonCallableFactory.createUnaryCallable(httpJsonCallSettings, callSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT, PagedListResponseT>
+      UnaryCallable<RequestT, PagedListResponseT> createPagedCallable(
+      HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+      PagedCallSettings<RequestT, ResponseT, PagedListResponseT> pagedCallSettings,
+      ClientContext clientContext) {
+    return HttpJsonCallableFactory.createPagedCallable(httpJsonCallSettings, pagedCallSettings, clientContext);
+  }
+
+  @Override
+  public <RequestT, ResponseT> UnaryCallable<RequestT, ResponseT> createBatchingCallable(
+      HttpJsonCallSettings<RequestT, ResponseT> httpJsonCallSettings,
+      BatchingCallSettings<RequestT, ResponseT> batchingCallSettings,
+      ClientContext clientContext) {
+    return HttpJsonCallableFactory.createBatchingCallable(httpJsonCallSettings, batchingCallSettings, clientContext);
+  }
+}
 ============== file: src/main/java/com/google/cloud/simplecompute/v1/package-info.java ==============
 /*
  * Copyright 2018 Google LLC
@@ -10400,6 +12141,22 @@ public class HttpJsonAddressCallableFactory implements HttpJsonStubCallableFacto
  * try (AddressClient addressClient = AddressClient.create()) {
  *   AddressName address = AddressName.of("[PROJECT]", "[REGION]", "[ADDRESS]");
  *   Operation response = addressClient.deleteAddress(address);
+ * }
+ * </code>
+ * </pre>
+ *
+ * =================
+ * DummyObjectClient
+ * =================
+ *
+ * Service Description: Creates and runs virtual machines on Google Cloud Platform.
+ *
+ * Sample for DummyObjectClient:
+ * <pre>
+ * <code>
+ * try (DummyObjectClient dummyObjectClient = DummyObjectClient.create()) {
+ *   DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+ *   dummyObjectClient.deleteDummyObject(dummyObject);
  * }
  * </code>
  * </pre>
@@ -10949,6 +12706,111 @@ public class AddressClientTest {
       Address addressResource = Address.newBuilder().build();
 
       client.updateAddress(address, requestId, addressResource);
+      Assert.fail("No exception raised");
+    } catch (InvalidArgumentException e) {
+      // Expected exception
+    }
+  }
+
+}
+============== file: src/test/java/com/google/cloud/simplecompute/v1/DummyObjectClientTest.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1;
+
+import com.google.api.gax.httpjson.ApiMessage;
+import com.google.api.gax.httpjson.ApiMethodDescriptor;
+import com.google.api.gax.httpjson.HttpResponseParser;
+import com.google.api.gax.httpjson.testing.MockHttpService;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.ApiExceptionFactory;
+import com.google.api.gax.rpc.InvalidArgumentException;
+import com.google.api.gax.rpc.StatusCode.Code;
+import com.google.api.gax.rpc.testing.FakeStatusCode;
+import com.google.cloud.simplecompute.v1.stub.DummyObjectStubSettings;
+import static com.google.cloud.simplecompute.v1.stub.HttpJsonDummyObjectStub.deleteDummyObjectMethodDescriptor;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@javax.annotation.Generated("by GAPIC")
+public class DummyObjectClientTest {
+
+   private static final List<ApiMethodDescriptor> METHOD_DESCRIPTORS = ImmutableList.copyOf(
+        Lists.<ApiMethodDescriptor>newArrayList(
+      ));
+  private static final MockHttpService mockService
+      = new MockHttpService(METHOD_DESCRIPTORS, DummyObjectStubSettings.getDefaultEndpoint());
+
+  private static DummyObjectClient client;
+  private static DummyObjectSettings clientSettings;
+
+  @BeforeClass
+  public static void setUp() throws IOException {
+    clientSettings =
+        DummyObjectSettings.newBuilder()
+           .setTransportChannelProvider(
+               DummyObjectSettings.defaultHttpJsonTransportProviderBuilder()
+                   .setHttpTransport(mockService).build()).build();
+    client =
+       DummyObjectClient.create(clientSettings);
+  }
+
+  @After
+  public void cleanUp() {
+    mockService.reset();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    client.close();
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteDummyObjectTest() {
+
+
+    DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+
+    client.deleteDummyObject(dummyObject);
+
+    List<String> actualRequests = mockService.getRequestPaths();
+    Assert.assertEquals(1, actualRequests.size());
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void deleteDummyObjectExceptionTest() throws Exception {
+    ApiException exception = ApiExceptionFactory.createException(new Exception(), FakeStatusCode.of(Code.INVALID_ARGUMENT), false);
+    mockService.addException(exception);
+
+    try {
+      DummyObjectName dummyObject = DummyObjectName.of("[PROJECT]", "[DUMMY_OBJECT]");
+
+      client.deleteDummyObject(dummyObject);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -2290,6 +2290,272 @@ public final class Data implements ApiMessage {
   }
 }
 
+============== file: src/main/java/com/google/cloud/simplecompute/v1/DummyObject.java ==============
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.simplecompute.v1;
+
+import com.google.api.core.BetaApi;
+import com.google.api.gax.httpjson.ApiMessage;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Generated;
+import javax.annotation.Nullable;
+
+@Generated("by GAPIC")
+@BetaApi
+public final class DummyObject implements ApiMessage {
+  private final Float floatie;
+  private final Double precisionFloatie;
+  private final Address primaryAddress;
+  private final Address secondaryAddress;
+
+  private DummyObject() {
+    this.floatie = null;
+    this.precisionFloatie = null;
+    this.primaryAddress = null;
+    this.secondaryAddress = null;
+  }
+
+
+  private DummyObject(
+      Float floatie,
+      Double precisionFloatie,
+      Address primaryAddress,
+      Address secondaryAddress
+      ) {
+    this.floatie = floatie;
+    this.precisionFloatie = precisionFloatie;
+    this.primaryAddress = primaryAddress;
+    this.secondaryAddress = secondaryAddress;
+  }
+
+  @Override
+  public Map<String, List<String>> populateFieldsInMap(Set<String> fieldNames) {
+    Map<String, List<String>> fieldMap = new HashMap<>();
+    if (fieldNames.contains("floatie") && floatie != null) {
+      fieldMap.put("floatie", Collections.singletonList(String.valueOf(floatie)));
+    }
+    if (fieldNames.contains("precisionFloatie") && precisionFloatie != null) {
+      fieldMap.put("precisionFloatie", Collections.singletonList(String.valueOf(precisionFloatie)));
+    }
+    if (fieldNames.contains("primaryAddress") && primaryAddress != null) {
+      fieldMap.put("primaryAddress", Collections.singletonList(String.valueOf(primaryAddress)));
+    }
+    if (fieldNames.contains("secondaryAddress") && secondaryAddress != null) {
+      fieldMap.put("secondaryAddress", Collections.singletonList(String.valueOf(secondaryAddress)));
+    }
+    return fieldMap;
+  }
+
+  @Override
+  public String getFieldStringValue(String fieldName) {
+    if (fieldName.equals("floatie")) {
+      return String.valueOf(floatie);
+    }
+    if (fieldName.equals("precisionFloatie")) {
+      return String.valueOf(precisionFloatie);
+    }
+    if (fieldName.equals("primaryAddress")) {
+      return String.valueOf(primaryAddress);
+    }
+    if (fieldName.equals("secondaryAddress")) {
+      return String.valueOf(secondaryAddress);
+    }
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ApiMessage getApiMessageRequestBody() {
+    return null;
+  }
+
+  public Float getFloatie() {
+    return floatie;
+  }
+
+  public Double getPrecisionFloatie() {
+    return precisionFloatie;
+  }
+
+  public Address getAddress() {
+    return primaryAddress;
+  }
+
+  public Address getAddress() {
+    return secondaryAddress;
+  }
+
+
+  public static Builder newBuilder() {
+    return DEFAULT_INSTANCE.toBuilder();
+  }
+  public static Builder newBuilder(DummyObject prototype) {
+    return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+  }
+  public Builder toBuilder() {
+    return this == DEFAULT_INSTANCE
+        ? new Builder() : new Builder().mergeFrom(this);
+  }
+
+  public static DummyObject getDefaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+  private static final DummyObject DEFAULT_INSTANCE;
+  static {
+    DEFAULT_INSTANCE = new DummyObject();
+  }
+
+  public static class Builder {
+    private Float floatie;
+    private Double precisionFloatie;
+    private Address primaryAddress;
+    private Address secondaryAddress;
+
+    Builder() {}
+
+    public Builder mergeFrom(DummyObject other) {
+      if (other == DummyObject.getDefaultInstance()) return this;
+      if (other.getFloatie() != null) {
+        this.floatie = other.floatie;
+      }
+      if (other.getPrecisionFloatie() != null) {
+        this.precisionFloatie = other.precisionFloatie;
+      }
+      if (other.getAddress() != null) {
+        this.primaryAddress = other.primaryAddress;
+      }
+      if (other.getAddress() != null) {
+        this.secondaryAddress = other.secondaryAddress;
+      }
+      return this;
+    }
+
+    Builder(DummyObject source) {
+      this.floatie = source.floatie;
+      this.precisionFloatie = source.precisionFloatie;
+      this.primaryAddress = source.primaryAddress;
+      this.secondaryAddress = source.secondaryAddress;
+    }
+
+    public Float getFloatie() {
+      return floatie;
+    }
+
+    public Builder setFloatie(Float floatie) {
+      this.floatie = floatie;
+      return this;
+    }
+
+    public Double getPrecisionFloatie() {
+      return precisionFloatie;
+    }
+
+    public Builder setPrecisionFloatie(Double precisionFloatie) {
+      this.precisionFloatie = precisionFloatie;
+      return this;
+    }
+
+    public Address getAddress() {
+      return primaryAddress;
+    }
+
+    public Builder setAddress(Address primaryAddress) {
+      this.primaryAddress = primaryAddress;
+      return this;
+    }
+
+    public Address getAddress() {
+      return secondaryAddress;
+    }
+
+    public Builder setAddress(Address secondaryAddress) {
+      this.secondaryAddress = secondaryAddress;
+      return this;
+    }
+
+
+    public DummyObject build() {
+
+
+
+      return new DummyObject(
+        floatie,
+        precisionFloatie,
+        primaryAddress,
+        secondaryAddress
+      );
+    }
+
+    public Builder clone() {
+      Builder newBuilder = new Builder();
+      newBuilder.setFloatie(this.floatie);
+      newBuilder.setPrecisionFloatie(this.precisionFloatie);
+      newBuilder.setAddress(this.primaryAddress);
+      newBuilder.setAddress(this.secondaryAddress);
+      return newBuilder;
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "DummyObject{"
+        + "floatie=" + floatie + ", "
+        + "precisionFloatie=" + precisionFloatie + ", "
+        + "primaryAddress=" + primaryAddress + ", "
+        + "secondaryAddress=" + secondaryAddress
+        + "}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof DummyObject) {
+      DummyObject that = (DummyObject) o;
+      return
+          Objects.equals(this.floatie, that.getFloatie()) &&
+          Objects.equals(this.precisionFloatie, that.getPrecisionFloatie()) &&
+          Objects.equals(this.primaryAddress, that.getAddress()) &&
+          Objects.equals(this.secondaryAddress, that.getAddress())
+          ;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      floatie,
+      precisionFloatie,
+      primaryAddress,
+      secondaryAddress
+    );
+  }
+}
+
 ============== file: src/main/java/com/google/cloud/simplecompute/v1/Error.java ==============
 /*
  * Copyright 2018 Google LLC

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/simplecompute.v1.json
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/simplecompute.v1.json
@@ -602,6 +602,10 @@
    "type": "object",
    "description": "A fake object to test discogapic generation.",
    "properties": {
+    "name": {
+     "type": "string",
+     "description": "Name of this object."
+    },
     "floatie": {
      "type": "number",
      "format": "float",
@@ -935,6 +939,40 @@
      "response": {
       "$ref": "Operation"
      },
+     "scopes": [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute"
+     ]
+    }
+   }
+  },
+  "dummyObjects": {
+   "methods": {
+    "delete": {
+     "id": "compute.dummyObjects.delete",
+     "path": "{project}/dummyObjects/{dummyObject}",
+     "httpMethod": "DELETE",
+     "description": "Method with no response object.",
+     "parameters": {
+      "dummyObject": {
+       "type": "string",
+       "description": "Name of the dummyObject resource to delete.",
+       "required": true,
+       "pattern": "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+       "location": "path"
+      },
+      "project": {
+       "type": "string",
+       "description": "Project ID for this request.",
+       "required": true,
+       "pattern": "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+       "location": "path"
+      }
+     },
+     "parameterOrder": [
+      "project",
+      "dummyObject"
+     ],
      "scopes": [
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/compute"

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/simplecompute.v1.json
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/simplecompute.v1.json
@@ -596,6 +596,31 @@
      "description": "[Output Only] The URL of the zone where the operation resides. Only available when performing per-zone operations."
     }
    }
+  },
+  "DummyObject": {
+   "id": "DummyObject",
+   "type": "object",
+   "description": "A fake object to test discogapic generation.",
+   "properties": {
+    "floatie": {
+     "type": "number",
+     "format": "float",
+     "description": "A float type number."
+    },
+    "precisionFloatie": {
+     "type": "number",
+     "format": "double",
+     "description": "A double type number."
+    },
+    "primaryAddress": {
+     "$ref": "Address",
+     "description": "One address."
+    },
+    "secondaryAddress": {
+     "$ref": "Address",
+     "description": "Address two."
+    }
+   }
   }
  },
  "resources": {

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_config.baseline
@@ -285,6 +285,110 @@ interfaces:
       address: projectAddress
     # TODO: Configure the default timeout for a non-retrying call.
     timeout_millis: 60000
+  # The fully qualified name of the API interface.
+- name: google.simplecompute.v1.DummyObjects
+  # A list of resource collection configurations.
+  # Consists of a name_pattern and an entity_name.
+  # The name_pattern is a pattern to describe the names of the resources of this
+  # collection, using the platform's conventions for URI patterns. A generator
+  # may use this to generate methods to compose and decompose such names. The
+  # pattern should use named placeholders as in `shelves/{shelf}/books/{book}`;
+  # those will be taken as hints for the parameter names of the generated
+  # methods. If empty, no name methods are generated.
+  # The entity_name is the name to be used as a basis for generated methods and
+  # classes.
+  collections:
+  - name_pattern: projects/{project}/dummyObjects/{dummyObject}
+    entity_name: dummyObject
+  # Definition for retryable codes.
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  # Definition for retry/backoff parameters.
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  # A list of method configurations.
+  # Common properties:
+  #   name - The simple name of the method.
+  #   flattening - Specifies the configuration for parameter flattening.
+  #       Describes the parameter groups for which a generator should produce
+  #       method overloads which allow a client to directly pass request message
+  #       fields as method parameters. This information may or may not be used,
+  #       depending on the target language.
+  #       Consists of groups, which each represent a list of parameters to be
+  #       flattened. Each parameter listed must be a field of the request
+  #       message.
+  #   required_fields - Fields that are always required for a request to be
+  #       valid.
+  #   request_object_method - Turns on or off the generation of a method whose
+  #       sole parameter is a request object. Not all languages will generate
+  #       this method.
+  #   resource_name_treatment - An enum that specifies how to treat the
+  #       resource name formats defined in the field_name_patterns
+  #       and response_field_name_patterns fields.
+  #       UNSET: default value
+  #       NONE: the collection configs will not be used by the generated code.
+  #       VALIDATE: string fields will be validated by the client against the
+  #           specified resource name formats.
+  #       STATIC_TYPES: the client will use generated types for resource names.
+  #   page_streaming - Specifies the configuration for paging.
+  #       Describes information for generating a method which transforms a
+  #       paging list RPC into a stream of resources.
+  #       Consists of a request and a response.
+  #       The request specifies request information of the list method. It
+  #       defines which fields match the paging pattern in the request. The
+  #       request consists of a page_size_field and a token_field. The
+  #       page_size_field is the name of the optional field specifying the
+  #       maximum number of elements to be returned in the response. The
+  #       token_field is the name of the field in the request containing the
+  #       page token.
+  #       The response specifies response information of the list method. It
+  #       defines which fields match the paging pattern in the response. The
+  #       response consists of a token_field and a resources_field. The
+  #       token_field is the name of the field in the response containing the
+  #       next page token. The resources_field is the name of the field in the
+  #       response containing the list of resources belonging to the page.
+  #   retry_codes_name - Specifies the configuration for retryable codes. The
+  #       name must be defined in interfaces.retry_codes_def.
+  #   retry_params_name - Specifies the configuration for retry/backoff
+  #       parameters. The name must be defined in interfaces.retry_params_def.
+  #   field_name_patterns - Maps the field name of the request type to
+  #       entity_name of interfaces.collections.
+  #       Specifies the string pattern that the field must follow.
+  #   timeout_millis - Specifies the default timeout for a non-retrying call. If
+  #       the call is retrying, refer to retry_params_name instead.
+  methods:
+  - name: compute.dummyObjects.delete
+    # TODO: Configure which groups of fields should be flattened into method
+    # params.
+    flattening:
+      groups:
+      - parameters:
+        - dummyObject
+    # TODO: Configure which fields are required.
+    required_fields:
+    - dummyObject
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    # TODO: Configure the retryable codes for this method.
+    retry_codes_name: idempotent
+    # TODO: Configure the retryable params for this method.
+    retry_params_name: default
+    field_name_patterns:
+      dummyObject: dummyObject
+    # TODO: Configure the default timeout for a non-retrying call.
+    timeout_millis: 60000
 resource_name_generation:
 - message_name: AggregatedListAddressesHttpRequest
   field_entity_map:
@@ -307,3 +411,6 @@ resource_name_generation:
 - message_name: UpdateAddressHttpRequest
   field_entity_map:
     address: projectAddress
+- message_name: DeleteDummyObjectHttpRequest
+  field_entity_map:
+    dummyObject: dummyObject

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_gapic.yaml
@@ -238,6 +238,41 @@ interfaces:
     field_name_patterns:
       address: projectAddress
     timeout_millis: 60000
+- name: google.simplecompute.v1.DummyObjects
+  collections:
+  - name_pattern: projects/{project}/dummyObjects/{dummyObject}
+    entity_name: dummyObject
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  methods:
+  - name: compute.dummyObjects.delete
+    flattening:
+      groups:
+      - parameters:
+        - dummyObject
+    required_fields:
+    - dummyObject
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      dummyObject: dummyObject
+    timeout_millis: 60000
 resource_name_generation:
 - message_name: AggregatedListAddressesHttpRequest
   field_entity_map:
@@ -260,3 +295,6 @@ resource_name_generation:
 - message_name: UpdateAddressHttpRequest
   field_entity_map:
     address: projectAddress
+- message_name: DeleteDummyObjectHttpRequest
+  field_entity_map:
+    dummyObject: dummyObject


### PR DESCRIPTION
See simplecompute.v1.json for test API changes.
- Add a method (`compute.dummyObjects.delete`) with a null response type
- Add a float field and a double field to a message type
- Add, in one message type, two fields with different names but same reference schemas

Changes in simplecompute_gapic.yaml and baseline files were automatically generated from running the test cases.

There are some hacks in the generator code put in just to avoid NPEs, but those will be removed after handling these corner cases is done. (Fixes in https://github.com/googleapis/toolkit/pull/1892).