### PR TITLE
enable running smoke tests in staging repo

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -461,6 +461,7 @@ public class JavaSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("java.util.Arrays");
     typeTable.saveNicknameFor("com.google.common.base.Preconditions");
     typeTable.saveNicknameFor("com.google.common.collect.Lists");
+    typeTable.saveNicknameFor("org.junit.Test");
   }
 
   private void addMockServiceImplImports(InterfaceContext context) {

--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -21,7 +21,9 @@
     compile 'com.google.api:gax:{@metadata.gaxVersionBound.lower}'
     compile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}'
     testCompile 'junit:junit:4.12'
+    testCompile 'commons-lang:commons-lang:2.6'
     testCompile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}:testlib'
+    testCompile 'io.grpc:grpc-netty-shaded:{@metadata.grpcVersionBound.lower}'
     @switch metadata.artifactType.toString
     @case "GAPIC_ONLY"
       @join dependency : metadata.protoPackageDependencies
@@ -35,6 +37,13 @@
     @join dependency : metadata.protoPackageTestDependencies
       testCompile project(':grpc-{@dependency.name}')
     @end
+  }
+
+  task smokeTest(type: Test) {
+    filter {
+      includeTestsMatching "*SmokeTest"
+      setFailOnNoMatchingTests false
+    }
   }
 
   sourceSets {

--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -21,7 +21,6 @@
     compile 'com.google.api:gax:{@metadata.gaxVersionBound.lower}'
     compile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}'
     testCompile 'junit:junit:4.12'
-    testCompile 'commons-lang:commons-lang:2.6'
     testCompile 'com.google.api:gax-grpc:{@metadata.gaxGrpcVersionBound.lower}:testlib'
     testCompile 'io.grpc:grpc-netty-shaded:{@metadata.grpcVersionBound.lower}'
     @switch metadata.artifactType.toString

--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -45,6 +45,10 @@
     }
   }
 
+  test {
+    exclude "**/*SmokeTest*"
+  }
+
   sourceSets {
     main {
       java {

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -11,6 +11,11 @@
     private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
     private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
 
+    @@Test
+    public void run() {
+      main(null);
+    }
+
     public static void main(String args[]) {
       Logger.getLogger("").setLevel(Level.WARNING);
       try {

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
@@ -47,7 +47,7 @@ grpc_version:
     lower: '1.0.0'
     upper: '2.0.0dev'
   java:
-    lower: '1.0.1'
+    lower: '1.9.0'
 
 gax_grpc_version:
   java:

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -22,9 +22,21 @@ dependencies {
   compile 'com.google.api:gax-grpc:0.18.0'
   testCompile 'junit:junit:4.12'
   testCompile 'com.google.api:gax-grpc:0.18.0:testlib'
+  testCompile 'io.grpc:grpc-netty-shaded:1.9.0'
   compile project(':proto-google-cloud-library-v1')
   testCompile project(':grpc-google-cloud-library-v1')
   testCompile project(':grpc-google-some-test-package-v1')
+}
+
+task smokeTest(type: Test) {
+  filter {
+    includeTestsMatching "*SmokeTest"
+    setFailOnNoMatchingTests false
+  }
+}
+
+test {
+  exclude "**/*SmokeTest*"
 }
 
 sourceSets {

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -9106,11 +9106,17 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
 public class LibrarySmokeTest {
   private static final String PROJECT_ENV_NAME = "GOOGLE_CLOUD_PROJECT";
   private static final String LEGACY_PROJECT_ENV_NAME = "GCLOUD_PROJECT";
+
+  @Test
+  public void run() {
+    main(null);
+  }
 
   public static void main(String args[]) {
     Logger.getLogger("").setLevel(Level.WARNING);

--- a/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_no_path_templates.baseline
@@ -22,8 +22,20 @@ dependencies {
   compile 'com.google.api:gax-grpc:0.18.0'
   testCompile 'junit:junit:4.12'
   testCompile 'com.google.api:gax-grpc:0.18.0:testlib'
+  testCompile 'io.grpc:grpc-netty-shaded:1.9.0'
   compile project(':proto-google-cloud-library-v1')
   testCompile project(':grpc-google-cloud-library-v1')
+}
+
+task smokeTest(type: Test) {
+  filter {
+    includeTestsMatching "*SmokeTest"
+    setFailOnNoMatchingTests false
+  }
+}
+
+test {
+  exclude "**/*SmokeTest*"
 }
 
 sourceSets {

--- a/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_pkg.yaml
@@ -78,6 +78,8 @@ grpc_version:
     lower: '0.14.1'
   ruby:
     lower: '1.0'
+  java:
+    lower: '1.9.0'
 
 proto_version:
   python:

--- a/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/no_path_templates_pkg.yaml
@@ -70,6 +70,8 @@ grpc_version:
     lower: '0.14.1'
   ruby:
     lower: '1.0'
+  java:
+    lower: '1.9.0'
 
 proto_version:
   python:


### PR DESCRIPTION
This change is to enable running smoke tests in staging repo (by invoking "./gradlew smokeTest").