### PR TITLE
Discogapic: Set a CredentialsProvider in generated unit tests

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -397,6 +397,7 @@ public class JavaSurfaceTestTransformer implements ModelToViewTransformer {
 
   private void addUnitTestImports(InterfaceContext context) {
     ImportTypeTable typeTable = context.getImportTypeTable();
+    typeTable.saveNicknameFor("com.google.api.gax.core.NoCredentialsProvider");
     typeTable.saveNicknameFor("com.google.api.gax.rpc.InvalidArgumentException");
     typeTable.saveNicknameFor("com.google.common.collect.Lists");
     typeTable.saveNicknameFor("java.io.IOException");
@@ -412,7 +413,6 @@ public class JavaSurfaceTestTransformer implements ModelToViewTransformer {
     }
     switch (context.getProductConfig().getTransportProtocol()) {
       case GRPC:
-        typeTable.saveNicknameFor("com.google.api.gax.core.NoCredentialsProvider");
         typeTable.saveNicknameFor("com.google.api.gax.rpc.ApiClientHeaderProvider");
         typeTable.saveNicknameFor("com.google.api.gax.rpc.StatusCode");
         typeTable.saveNicknameFor("com.google.api.gax.grpc.GaxGrpcProperties");

--- a/src/main/resources/com/google/api/codegen/java/http_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/http_test.snip
@@ -25,7 +25,9 @@
           {@apiTest.testClass.apiSettingsClassName}.newBuilder()
              .setTransportChannelProvider(
                  {@apiTest.testClass.apiSettingsClassName}.defaultHttpJsonTransportProviderBuilder()
-                     .setHttpTransport(mockService).build()).build();
+                     .setHttpTransport(mockService).build())
+             .setCredentialsProvider(NoCredentialsProvider.create())
+             .build();
       client =
          {@apiTest.testClass.apiClassName}.create(clientSettings);
     }

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -12179,6 +12179,7 @@ package com.google.cloud.simplecompute.v1;
  */
 package com.google.cloud.simplecompute.v1;
 
+import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.testing.MockHttpService;
@@ -12234,7 +12235,9 @@ public class AddressClientTest {
         AddressSettings.newBuilder()
            .setTransportChannelProvider(
                AddressSettings.defaultHttpJsonTransportProviderBuilder()
-                   .setHttpTransport(mockService).build()).build();
+                   .setHttpTransport(mockService).build())
+           .setCredentialsProvider(NoCredentialsProvider.create())
+           .build();
     client =
        AddressClient.create(clientSettings);
   }
@@ -12761,6 +12764,7 @@ public class AddressClientTest {
  */
 package com.google.cloud.simplecompute.v1;
 
+import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.httpjson.ApiMethodDescriptor;
 import com.google.api.gax.httpjson.GaxHttpJsonProperties;
 import com.google.api.gax.httpjson.testing.MockHttpService;
@@ -12802,7 +12806,9 @@ public class DummyObjectClientTest {
         DummyObjectSettings.newBuilder()
            .setTransportChannelProvider(
                DummyObjectSettings.defaultHttpJsonTransportProviderBuilder()
-                   .setHttpTransport(mockService).build()).build();
+                   .setHttpTransport(mockService).build())
+           .setCredentialsProvider(NoCredentialsProvider.create())
+           .build();
     client =
        DummyObjectClient.create(clientSettings);
   }


### PR DESCRIPTION
By default, the ClientContext object will try to fetch the application default credentials in its static constructor. This will throw an `IOException` on systems, notably the CI build env, that don't have the application default credentials set up. This PR overrides that credentials fetch by setting a noop NoCredentialsProvider in the settings object.