### PR TITLE
Generate resources field in page streaming config.proto

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoGapicMethodConfig.java
@@ -89,7 +89,9 @@ public abstract class DiscoGapicMethodConfig extends MethodConfig {
     PageStreamingConfig pageStreaming = null;
     if (!PageStreamingConfigProto.getDefaultInstance()
         .equals(methodConfigProto.getPageStreaming())) {
-      pageStreaming = PageStreamingConfig.createPageStreaming(apiModel, method);
+      pageStreaming =
+          PageStreamingConfig.createPageStreaming(
+              diagCollector, messageConfigs, resourceNameConfigs, methodConfigProto, methodModel);
       if (pageStreaming == null) {
         error = true;
       }

--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -20,16 +20,13 @@ import com.google.api.codegen.discovery.Method;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.discovery.Schema.Format;
 import com.google.api.codegen.discovery.Schema.Type;
-import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.tools.framework.model.Oneof;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -208,16 +205,6 @@ public class DiscoveryField implements FieldModel, TypeModel {
   @Override
   public Oneof getOneof() {
     return null;
-  }
-
-  @Override
-  public List<String> getPagedResponseResourceMethods(
-      FeatureConfig featureConfig, FieldConfig startingFieldConfig, SurfaceNamer namer) {
-    List<String> methodNames = new LinkedList<>();
-    for (FieldModel field : startingFieldConfig.getFieldPath()) {
-      methodNames.add(0, namer.getFieldGetFunctionName(field));
-    }
-    return ImmutableList.copyOf(methodNames);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -87,7 +87,10 @@ public final class DiscoveryMethodModel implements MethodModel {
 
   @Override
   public DiscoveryField getOutputField(String fieldName) {
-    return null;
+    if (outputType.isEmptyType() || outputType.isPrimitive()) {
+      return null;
+    }
+    return ((DiscoveryField) outputType).getField(fieldName);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/FieldConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FieldConfig.java
@@ -21,11 +21,9 @@ import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Function;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
@@ -33,9 +31,6 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class FieldConfig {
   public abstract FieldModel getField();
-
-  /** The list of fields that must be traversed to reach the field in getField(). */
-  public abstract List<FieldModel> getFieldPath();
 
   @Nullable
   public abstract ResourceNameTreatment getResourceNameTreatment();
@@ -58,20 +53,6 @@ public abstract class FieldConfig {
       ResourceNameTreatment resourceNameTreatment,
       ResourceNameConfig resourceNameConfig,
       ResourceNameConfig messageResourceNameConfig) {
-    return createFieldConfig(
-        field,
-        ImmutableList.of(field),
-        resourceNameTreatment,
-        resourceNameConfig,
-        messageResourceNameConfig);
-  }
-
-  private static FieldConfig createFieldConfig(
-      FieldModel field,
-      List<FieldModel> fieldPath,
-      ResourceNameTreatment resourceNameTreatment,
-      ResourceNameConfig resourceNameConfig,
-      ResourceNameConfig messageResourceNameConfig) {
     if (resourceNameTreatment != ResourceNameTreatment.NONE && resourceNameConfig == null) {
       throw new IllegalArgumentException(
           "resourceName may only be null if resourceNameTreatment is NONE");
@@ -82,15 +63,11 @@ public abstract class FieldConfig {
           "FieldConfig may not contain a ResourceNameConfig of type " + ResourceNameType.FIXED);
     }
     return new AutoValue_FieldConfig(
-        field, fieldPath, resourceNameTreatment, resourceNameConfig, messageResourceNameConfig);
+        field, resourceNameTreatment, resourceNameConfig, messageResourceNameConfig);
   }
 
   static FieldConfig createFieldConfig(FieldModel field) {
     return FieldConfig.createFieldConfig(field, ResourceNameTreatment.NONE, null, null);
-  }
-
-  static FieldConfig createFieldConfig(FieldModel field, List<FieldModel> fieldPath) {
-    return FieldConfig.createFieldConfig(field, fieldPath, ResourceNameTreatment.NONE, null, null);
   }
 
   /** Creates a FieldConfig for the given Field with ResourceNameTreatment set to None. */

--- a/src/main/java/com/google/api/codegen/config/FieldModel.java
+++ b/src/main/java/com/google/api/codegen/config/FieldModel.java
@@ -14,14 +14,11 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
-import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.tools.framework.model.Oneof;
 import com.google.api.tools.framework.model.TypeRef.Cardinality;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /**
@@ -99,12 +96,6 @@ public interface FieldModel {
 
   @Nullable
   Oneof getOneof();
-
-  /* The ordered list of method calls necessary to reach the object representing the resource array
-   * in the response of paged RPCs.
-   */
-  List<String> getPagedResponseResourceMethods(
-      FeatureConfig featureConfig, FieldConfig startingFieldConfig, SurfaceNamer namer);
 
   TypeModel getType();
 }

--- a/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
@@ -14,23 +14,14 @@
  */
 package com.google.api.codegen.config;
 
-import static com.google.api.codegen.configgen.HttpPagingParameters.PARAMETER_MAX_RESULTS;
-import static com.google.api.codegen.configgen.HttpPagingParameters.PARAMETER_NEXT_PAGE_TOKEN;
-import static com.google.api.codegen.configgen.HttpPagingParameters.PARAMETER_PAGE_TOKEN;
-
 import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.PageStreamingConfigProto;
-import com.google.api.codegen.discovery.Schema;
-import com.google.api.codegen.discovery.Schema.Type;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.LinkedList;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /** PageStreamingConfig represents the page streaming configuration for a method. */
@@ -124,119 +115,6 @@ public abstract class PageStreamingConfig {
     }
     return new AutoValue_PageStreamingConfig(
         requestTokenField, pageSizeField, responseTokenField, resourcesFieldConfig);
-  }
-
-  /**
-   * Creates an instance of PageStreamingConfig based on Discovery Doc, linking it up with the
-   * provided method. On errors, null will be returned, and diagnostics are reported to the diag
-   * collector.
-   *
-   * @param method Method descriptor for the method to create config for.
-   */
-  @Nullable
-  // TODO(andrealin): Merge this function into the createPageStreaming(... Method protoMethod) function.
-  static PageStreamingConfig createPageStreaming(
-      DiscoApiModel apiModel, com.google.api.codegen.discovery.Method method) {
-    Schema requestTokenField = method.parameters().get(PARAMETER_PAGE_TOKEN);
-    DiagCollector diagCollector = apiModel.getDiagCollector();
-    if (requestTokenField == null) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Request field missing for page streaming: method = %s, message type = %s, field = %s",
-              method.id(),
-              method.id(),
-              PARAMETER_PAGE_TOKEN));
-    }
-
-    Schema pageSizeField = method.parameters().get(PARAMETER_MAX_RESULTS);
-    if (pageSizeField != null) {
-      pageSizeField = method.parameters().get(PARAMETER_MAX_RESULTS);
-      if (pageSizeField == null) {
-        diagCollector.addDiag(
-            Diag.error(
-                SimpleLocation.TOPLEVEL,
-                "Request field missing for page streaming: method = %s, message type = %s, field = %s",
-                method.id(),
-                method.id(),
-                PARAMETER_MAX_RESULTS));
-      }
-    }
-
-    Schema responseTokenField = null;
-    Schema responseSchema = method.response().dereference();
-    if (responseSchema.hasProperty(PARAMETER_NEXT_PAGE_TOKEN)) {
-      responseTokenField = responseSchema.properties().get(PARAMETER_NEXT_PAGE_TOKEN);
-    }
-
-    if (responseTokenField == null) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Response field missing for page streaming: method = %s, message type = %s, field = %s",
-              method.id(),
-              method.id(),
-              PARAMETER_NEXT_PAGE_TOKEN));
-    }
-
-    Schema responseField = method.response().dereference();
-    ImmutableList<FieldModel> resourcesFieldPath =
-        ImmutableList.copyOf(getResourcesGetterPath(responseField, apiModel));
-
-    FieldConfig resourcesFieldConfig;
-    if (resourcesFieldPath.isEmpty()) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Resources field missing for page streaming: method = %s, message type = %s, response field = %s",
-              method.id(),
-              method.id(),
-              method.response() == null ? "null" : method.response().toString()));
-      resourcesFieldConfig = null;
-    } else {
-      FieldModel resourcesField = resourcesFieldPath.get(resourcesFieldPath.size() - 1);
-      resourcesFieldConfig =
-          FieldConfig.createFieldConfig(resourcesField, ImmutableList.copyOf(resourcesFieldPath));
-    }
-
-    if (requestTokenField == null || responseTokenField == null || resourcesFieldConfig == null) {
-      return null;
-    }
-    return new AutoValue_PageStreamingConfig(
-        DiscoveryField.create(requestTokenField, apiModel),
-        DiscoveryField.create(pageSizeField, apiModel),
-        DiscoveryField.create(responseTokenField, apiModel),
-        resourcesFieldConfig);
-  }
-
-  private static List<FieldModel> getResourcesGetterPath(
-      Schema responseField, DiscoApiModel apiModel) {
-    List<FieldModel> resourcesFieldPath = new LinkedList<>();
-    for (Schema property : responseField.properties().values()) {
-      // Assume the List response has exactly one Array property.
-      if (property.type().equals(Type.ARRAY)) {
-        resourcesFieldPath.add(DiscoveryField.create(property, apiModel));
-        break;
-      } else if (property.additionalProperties() != null
-          && !Strings.isNullOrEmpty(property.additionalProperties().reference())) {
-        Schema additionalProperties = property.additionalProperties().dereference();
-        if (additionalProperties.type().equals(Type.ARRAY)) {
-          resourcesFieldPath.add(DiscoveryField.create(additionalProperties, apiModel));
-          break;
-        }
-        for (Schema subProperty : additionalProperties.properties().values()) {
-          if (subProperty.type().equals(Type.ARRAY)) {
-            resourcesFieldPath.add(DiscoveryField.create(property, apiModel));
-            resourcesFieldPath.add(DiscoveryField.create(subProperty, apiModel));
-            break;
-          }
-        }
-        if (!resourcesFieldPath.isEmpty()) {
-          break;
-        }
-      }
-    }
-    return resourcesFieldPath;
   }
 
   /** Returns whether there is a field for page size. */

--- a/src/main/java/com/google/api/codegen/config/ProtoField.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoField.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.config;
 import static com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES;
 import static com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING;
 
-import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.ImportTypeTable;
 import com.google.api.codegen.transformer.ModelTypeNameConverter;
 import com.google.api.codegen.transformer.SurfaceNamer;
@@ -30,7 +29,6 @@ import com.google.api.tools.framework.model.TypeRef.Cardinality;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import java.util.List;
 import javax.annotation.Nullable;
 
 /** A field declaration wrapper around a protobuf Field. */
@@ -189,14 +187,6 @@ public class ProtoField implements FieldModel {
   @Override
   public Oneof getOneof() {
     return protoField.getOneof();
-  }
-
-  @Override
-  public List<String> getPagedResponseResourceMethods(
-      FeatureConfig featureConfig, FieldConfig startingFieldConfig, SurfaceNamer namer) {
-    String resourceFieldGetFunctionName =
-        namer.getFieldGetFunctionName(featureConfig, startingFieldConfig);
-    return ImmutableList.of(resourceFieldGetFunctionName);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoveryMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoveryMethodTransformer.java
@@ -29,6 +29,9 @@ import javax.annotation.Nullable;
 public class DiscoveryMethodTransformer implements InputSpecificMethodTransformer {
   private final PagingParameters pagingParameters = new HttpPagingParameters();
 
+  // For Discovery doc configgen, assume that paged resource field name is "items".
+  private static String PAGING_RESOURCE_FIELD_NAME = "items";
+
   @Override
   public PagingParameters getPagingParameters() {
     return pagingParameters;
@@ -47,28 +50,37 @@ public class DiscoveryMethodTransformer implements InputSpecificMethodTransforme
   @Override
   public PageStreamingResponseView generatePageStreamingResponse(MethodModel methodModel) {
     DiscoveryMethodModel method = (DiscoveryMethodModel) methodModel;
-    String resourcesField = null;
+    String resourcesName = null;
     boolean hasNextPageToken = false;
+
+    // Find the paged resource object from inside the response object.
     for (DiscoveryField field : method.getOutputFields()) {
-      String fieldName = field.getSimpleName();
-      if (!fieldName.equals(pagingParameters.getNameForNextPageToken())) {
-        for (Schema property : field.getDiscoveryField().properties().values()) {
-          if (property.getIdentifier().equals(pagingParameters.getNameForNextPageToken())) {
-            hasNextPageToken = true;
-            resourcesField = Name.anyCamel(fieldName).toUpperCamel();
-            break;
-          }
+      if (field.getDiscoveryField().properties() == null) {
+        continue;
+      }
+      // Verify that the paging response object contains a paging token.
+      for (Schema property : field.getDiscoveryField().properties().values()) {
+        if (property.getIdentifier().equals(pagingParameters.getNameForNextPageToken())) {
+          hasNextPageToken = true;
+          break;
         }
       }
+
+      Schema itemCollectionSchema =
+          field.getDiscoveryField().properties().get(PAGING_RESOURCE_FIELD_NAME);
+      if (itemCollectionSchema == null) {
+        continue;
+      }
+      resourcesName = PAGING_RESOURCE_FIELD_NAME;
     }
 
-    if (resourcesField == null || !hasNextPageToken) {
+    if (!hasNextPageToken) {
       return null;
     }
 
     return PageStreamingResponseView.newBuilder()
         .tokenField(pagingParameters.getNameForNextPageToken())
-        .resourcesField(resourcesField)
+        .resourcesField(Name.anyCamel(resourcesName).toLowerCamel())
         .build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -22,7 +22,6 @@ import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.viewmodel.PageStreamingDescriptorClassView;
 import com.google.api.codegen.viewmodel.PageStreamingDescriptorView;
 import com.google.api.codegen.viewmodel.PagedListResponseFactoryClassView;
-import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -112,11 +111,7 @@ public class PageStreamingTransformer {
     desc.responseTokenGetFunction(
         namer.getFieldGetFunctionName(pageStreaming.getResponseTokenField()));
 
-    ImmutableList.Builder<String> resourcesFieldGetFunctionList = new ImmutableList.Builder<>();
-    for (FieldModel field : resourceFieldConfig.getFieldPath()) {
-      resourcesFieldGetFunctionList.add(namer.getFieldGetFunctionName(field));
-    }
-    desc.resourcesFieldGetFunctions(resourcesFieldGetFunctionList.build());
+    desc.resourcesFieldGetFunction(namer.getFieldGetFunctionName(resourceField));
 
     return desc.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -552,14 +552,11 @@ public class StaticLangApiMethodTransformer {
     }
 
     String iterateMethodName =
-        context
-            .getNamer()
-            .getPagedResponseIterateMethod(context.getFeatureConfig(), resourceFieldConfig);
+        namer.getPagedResponseIterateMethod(context.getFeatureConfig(), resourceFieldConfig);
 
-    String resourceFieldName = context.getNamer().getFieldName(resourceField);
-    List<String> resourceFieldGetFunctionNames =
-        resourceField.getPagedResponseResourceMethods(
-            context.getFeatureConfig(), resourceFieldConfig, context.getNamer());
+    String resourceFieldName = namer.getFieldName(resourceField);
+    String resourceFieldGetterName =
+        namer.getFieldGetFunctionName(context.getFeatureConfig(), resourceFieldConfig);
 
     methodViewBuilder.listMethod(
         ListMethodDetailView.newBuilder()
@@ -568,7 +565,7 @@ public class StaticLangApiMethodTransformer {
             .resourceTypeName(resourceTypeName)
             .iterateMethodName(iterateMethodName)
             .resourceFieldName(resourceFieldName)
-            .resourcesFieldGetFunctions(resourceFieldGetFunctionNames)
+            .resourcesFieldGetFunction(resourceFieldGetterName)
             .build());
 
     switch (synchronicity) {

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -748,12 +748,6 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return privateFieldName(method.asName().join(Name.from("page", "streaming", "descriptor")));
   }
 
-  /** The page streaming factory name for the given method. */
-  public String getPagedListResponseFactoryName(MethodModel method) {
-    return privateFieldName(
-        method.asName().join(Name.from("paged", "list", "response", "factory")));
-  }
-
   /** The variable name of the gRPC request object. */
   public String getRequestVariableName(MethodModel method) {
     return getNotImplementedString("SurfaceNamer.getRequestVariableName");

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -250,16 +250,10 @@ public class TestCaseTransformer {
     String resourceTypeName =
         methodContext.getTypeTable().getAndSaveNicknameForElementType(resourcesField);
 
-    // Construct the list of function calls needed to retrieve paged resource from response object.
-    ImmutableList.Builder<String> resourcesFieldGetFunctionList = new ImmutableList.Builder<>();
-    for (FieldModel field : resourcesFieldConfig.getFieldPath()) {
-      resourcesFieldGetFunctionList.add(namer.getFieldGetFunctionName(field));
-    }
-
     pageStreamingResponseViews.add(
         PageStreamingResponseView.newBuilder()
             .resourceTypeName(resourceTypeName)
-            .resourcesFieldGetterNames(resourcesFieldGetFunctionList.build())
+            .resourcesFieldGetterName(namer.getFieldGetFunctionName(resourcesField))
             .resourcesIterateMethod(namer.getPagedResponseIterateMethod())
             .resourcesVarName(namer.localVarName(Name.from("resources")))
             .build());
@@ -271,11 +265,8 @@ public class TestCaseTransformer {
               .getAndSaveElementResourceTypeName(
                   methodContext.getTypeTable(), resourcesFieldConfig);
 
-      resourcesFieldGetFunctionList = new ImmutableList.Builder<>();
-      for (FieldModel field : resourcesFieldConfig.getFieldPath()) {
-        resourcesFieldGetFunctionList.add(
-            namer.getFieldGetFunctionName(methodContext.getFeatureConfig(), resourcesFieldConfig));
-      }
+      String resourceGetterName =
+          namer.getFieldGetFunctionName(methodContext.getFeatureConfig(), resourcesFieldConfig);
 
       String expectedTransformFunction = null;
       if (methodContext.getFeatureConfig().useResourceNameConverters(resourcesFieldConfig)) {
@@ -286,7 +277,7 @@ public class TestCaseTransformer {
       pageStreamingResponseViews.add(
           PageStreamingResponseView.newBuilder()
               .resourceTypeName(resourceTypeName)
-              .resourcesFieldGetterNames(resourcesFieldGetFunctionList.build())
+              .resourcesFieldGetterName(resourceGetterName)
               .resourcesIterateMethod(
                   namer.getPagedResponseIterateMethod(
                       methodContext.getFeatureConfig(), resourcesFieldConfig))

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSchemaTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSchemaTypeNameConverter.java
@@ -16,7 +16,6 @@ package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FieldModel;
-import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.discogapic.transformer.DiscoGapicNamer;
 import com.google.api.codegen.discovery.Schema;
 import com.google.api.codegen.discovery.Schema.Type;
@@ -265,8 +264,7 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
     return getSnippetZeroValue(type);
   }
 
-  private TypeName getTypeNameForTypedResourceName(
-      ResourceNameConfig resourceNameConfig, FieldModel type, String typedResourceShortName) {
+  private TypeName getTypeNameForTypedResourceName(FieldModel type, String typedResourceShortName) {
     String packageName = implicitPackageName;
     String longName = packageName + "." + typedResourceShortName;
 
@@ -286,14 +284,12 @@ public class JavaSchemaTypeNameConverter extends SchemaTypeNameConverter {
   @Override
   public TypeName getTypeNameForTypedResourceName(
       FieldConfig fieldConfig, String typedResourceShortName) {
-    return getTypeNameForTypedResourceName(
-        fieldConfig.getResourceNameConfig(), fieldConfig.getField(), typedResourceShortName);
+    return getTypeNameForTypedResourceName(fieldConfig.getField(), typedResourceShortName);
   }
 
   @Override
   public TypeName getTypeNameForResourceNameElementType(
       FieldConfig fieldConfig, String typedResourceShortName) {
-    return getTypeNameForTypedResourceName(
-        fieldConfig.getResourceNameConfig(), fieldConfig.getField(), typedResourceShortName);
+    return getTypeNameForTypedResourceName(fieldConfig.getField(), typedResourceShortName);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.transformer.php;
 
 import com.google.api.HttpRule;
-import com.google.api.HttpRule.Builder;
 import com.google.api.Service;
 import com.google.api.codegen.GeneratorVersionProvider;
 import com.google.api.codegen.config.ApiModel;

--- a/src/main/java/com/google/api/codegen/viewmodel/ListMethodDetailView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ListMethodDetailView.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.viewmodel;
 
 import com.google.auto.value.AutoValue;
-import java.util.List;
 
 @AutoValue
 public abstract class ListMethodDetailView {
@@ -29,7 +28,7 @@ public abstract class ListMethodDetailView {
 
   public abstract String iterateMethodName();
 
-  public abstract List<String> resourcesFieldGetFunctions();
+  public abstract String resourcesFieldGetFunction();
 
   public static Builder newBuilder() {
     return new AutoValue_ListMethodDetailView.Builder();
@@ -47,7 +46,7 @@ public abstract class ListMethodDetailView {
 
     public abstract Builder iterateMethodName(String name);
 
-    public abstract Builder resourcesFieldGetFunctions(List<String> name);
+    public abstract Builder resourcesFieldGetFunction(String name);
 
     public abstract ListMethodDetailView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/PageStreamingDescriptorClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/PageStreamingDescriptorClassView.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.viewmodel;
 
 import com.google.auto.value.AutoValue;
-import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -44,7 +43,7 @@ public abstract class PageStreamingDescriptorClassView {
 
   public abstract String responseTokenGetFunction();
 
-  public abstract List<String> resourcesFieldGetFunctions();
+  public abstract String resourcesFieldGetFunction();
 
   public boolean requestHasPageSize() {
     return requestPageSizeSetFunction() != null && requestPageSizeGetFunction() != null;
@@ -79,7 +78,7 @@ public abstract class PageStreamingDescriptorClassView {
 
     public abstract Builder responseTokenGetFunction(String val);
 
-    public abstract Builder resourcesFieldGetFunctions(List<String> val);
+    public abstract Builder resourcesFieldGetFunction(String val);
 
     public abstract PageStreamingDescriptorClassView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/PageStreamingResponseView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/PageStreamingResponseView.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.viewmodel.testing;
 
 import com.google.auto.value.AutoValue;
-import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -25,8 +24,7 @@ public abstract class PageStreamingResponseView {
 
   public abstract String resourceTypeName();
 
-  // The sequence of method calls to retrieve the paged resource field from the RPC response object.
-  public abstract List<String> resourcesFieldGetterNames();
+  public abstract String resourcesFieldGetterName();
 
   public abstract String resourcesIterateMethod();
 
@@ -48,7 +46,7 @@ public abstract class PageStreamingResponseView {
 
     public abstract Builder resourceTypeName(String val);
 
-    public abstract Builder resourcesFieldGetterNames(List<String> val);
+    public abstract Builder resourcesFieldGetterName(String val);
 
     public abstract Builder resourcesIterateMethod(String val);
 

--- a/src/main/resources/com/google/api/codegen/csharp/gapic_client.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/gapic_client.snip
@@ -1063,7 +1063,7 @@
             /// <summary>
             /// Returns an enumerator that iterates through the resources in this response.
             /// </summary>
-            public IEnumerator<{@method.listMethod.resourceTypeName}> GetEnumerator() => {@method.listMethod.resourcesFieldGetFunctions.get(0)}.GetEnumerator();
+            public IEnumerator<{@method.listMethod.resourceTypeName}> GetEnumerator() => {@method.listMethod.resourcesFieldGetFunction}.GetEnumerator();
 
             /// <inheritdoc/>
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/main/resources/com/google/api/codegen/go/mock.snip
+++ b/src/main/resources/com/google/api/codegen/go/mock.snip
@@ -222,7 +222,7 @@
 
         @if test.clientMethodType == "PagedRequestObjectMethod"
             @join pageStreamingResponseView : test.pageStreamingResponseViews
-                want := (interface{})(expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterNames.get(0)}[0])
+                want := (interface{})(expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}[0])
                 got := (interface{})(resp)
                 var ok bool
 

--- a/src/main/resources/com/google/api/codegen/java/grpc_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/grpc_test.snip
@@ -242,10 +242,10 @@
       Assert.assertEquals(1, {@pageStreamingResponseView.resourcesVarName}.size());
       @if pageStreamingResponseView.hasExpectedValueTransformFunction
         Assert.assertEquals({@pageStreamingResponseView.expectedValueTransformFunction}(\
-            expectedResponse.{@functionChain(pageStreamingResponseView.resourcesFieldGetterNames)}.get(0)),
+            expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0)),
             {@pageStreamingResponseView.resourcesVarName}.get(0));
       @else
-        Assert.assertEquals(expectedResponse.{@functionChain(pageStreamingResponseView.resourcesFieldGetterNames)}.get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
+        Assert.assertEquals(expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
       @end
     @end
   @case "FlattenedMethod"

--- a/src/main/resources/com/google/api/codegen/java/http_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/http_test.snip
@@ -112,7 +112,7 @@
     @join pageStreamingResponseView : test.pageStreamingResponseViews
       List<{@pageStreamingResponseView.resourceTypeName}> {@pageStreamingResponseView.resourcesVarName} = Lists.newArrayList(pagedListResponse.{@pageStreamingResponseView.resourcesIterateMethod}());
       Assert.assertEquals(1, {@pageStreamingResponseView.resourcesVarName}.size());
-      Assert.assertEquals(expectedResponse.{@functionChain(pageStreamingResponseView.resourcesFieldGetterNames)}.get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
+      Assert.assertEquals(expectedResponse.{@pageStreamingResponseView.resourcesFieldGetterName}().get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
     @end
   @case "FlattenedMethod"
     @if test.hasReturnValue

--- a/src/main/resources/com/google/api/codegen/java/stub_settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub_settings.snip
@@ -271,7 +271,7 @@
           }
           @@Override
           public Iterable<{@desc.resourceTypeName}> extractResources({@desc.responseTypeName} payload) {
-            return payload.{@functionChain(desc.resourcesFieldGetFunctions)};
+            return payload.{@desc.resourcesFieldGetFunction}();
           }
         };
     {@""}

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -225,14 +225,14 @@
       client._innerApiCalls.{@test.clientMethodName} = (actualRequest, options, callback) => {
         assert.deepStrictEqual(actualRequest, request);
         @join pagedResponse : test.pageStreamingResponseViews
-          callback(null, expectedResponse.{@pagedResponse.resourcesFieldGetterNames.get(0)});
+          callback(null, expectedResponse.{@pagedResponse.resourcesFieldGetterName});
         @end
       };
 
       client.{@test.clientMethodName}(request, (err, response) => {
         assert.ifError(err);
         @join pagedResponse : test.pageStreamingResponseViews
-          assert.deepStrictEqual(response, expectedResponse.{@pagedResponse.resourcesFieldGetterNames.get(0)});
+          assert.deepStrictEqual(response, expectedResponse.{@pagedResponse.resourcesFieldGetterName});
         @end
         done();
       });

--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -290,7 +290,7 @@
         @join pageStreamingResponseView : test.pageStreamingResponseViews
             ${@pageStreamingResponseView.resourcesVarName} = iterator_to_array($response->{@pageStreamingResponseView.resourcesIterateMethod}());
             $this->assertSame(1, count(${@pageStreamingResponseView.resourcesVarName}));
-            $this->assertEquals($expectedResponse->{@pageStreamingResponseView.resourcesFieldGetterNames.get(0)}()[0], ${@pageStreamingResponseView.resourcesVarName}[0]);
+            $this->assertEquals($expectedResponse->{@pageStreamingResponseView.resourcesFieldGetterName}()[0], ${@pageStreamingResponseView.resourcesVarName}[0]);
         @end
 
         {@singleCallSuccessAsserts(test)}

--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -243,7 +243,7 @@ class CustomException(Exception):
 
             assert \
                 expected_response.\
-                    {@pageStreamingResponseView.resourcesFieldGetterNames.get(0)}[0] == \
+                    {@pageStreamingResponseView.resourcesFieldGetterName}[0] == \
                 {@pageStreamingResponseView.resourcesVarName}[0]
         @end
 

--- a/src/main/resources/com/google/api/codegen/ruby/test.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/test.snip
@@ -190,7 +190,7 @@
         assert_equal(expected_response, response.page.response)
         assert_nil(response.next_page)
         @join pageResponseView : test.pageStreamingResponseViews on BREAK
-          assert_equal(expected_response.{@pageResponseView.resourcesFieldGetterNames.get(0)}.to_a, response.to_a)
+          assert_equal(expected_response.{@pageResponseView.resourcesFieldGetterName}.to_a, response.to_a)
         @end
       end
     end

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -8526,7 +8526,7 @@ public class AddressClient implements BackgroundResource {
    * <pre><code>
    * try (AddressClient addressClient = AddressClient.create()) {
    *   ProjectName project = ProjectName.of("[PROJECT]");
-   *   for (Address element : addressClient.aggregatedListAddresses(project).iterateAll()) {
+   *   for (AddressesScopedList element : addressClient.aggregatedListAddresses(project).iterateAll()) {
    *     // doThingsWith(element);
    *   }
    * }
@@ -8552,7 +8552,7 @@ public class AddressClient implements BackgroundResource {
    * <pre><code>
    * try (AddressClient addressClient = AddressClient.create()) {
    *   ProjectName project = ProjectName.of("[PROJECT]");
-   *   for (Address element : addressClient.aggregatedListAddresses(project.toString()).iterateAll()) {
+   *   for (AddressesScopedList element : addressClient.aggregatedListAddresses(project.toString()).iterateAll()) {
    *     // doThingsWith(element);
    *   }
    * }
@@ -8581,7 +8581,7 @@ public class AddressClient implements BackgroundResource {
    *   AggregatedListAddressesHttpRequest request = AggregatedListAddressesHttpRequest.newBuilder()
    *     .setProject(project.toString())
    *     .build();
-   *   for (Address element : addressClient.aggregatedListAddresses(request).iterateAll()) {
+   *   for (AddressesScopedList element : addressClient.aggregatedListAddresses(request).iterateAll()) {
    *     // doThingsWith(element);
    *   }
    * }
@@ -8609,7 +8609,7 @@ public class AddressClient implements BackgroundResource {
    *     .build();
    *   ApiFuture&lt;AggregatedListAddressesPagedResponse&gt; future = addressClient.aggregatedListAddressesPagedCallable().futureCall(request);
    *   // Do something
-   *   for (Address element : future.get().iterateAll()) {
+   *   for (AddressesScopedList element : future.get().iterateAll()) {
    *     // doThingsWith(element);
    *   }
    * }
@@ -8633,7 +8633,7 @@ public class AddressClient implements BackgroundResource {
    *     .build();
    *   while (true) {
    *     AddressAggregatedList response = addressClient.aggregatedListAddressesCallable().call(request);
-   *     for (Address element : response.getAddressesList()) {
+   *     for (AddressesScopedList element : response.getItems()) {
    *       // doThingsWith(element);
    *     }
    *     String nextPageToken = response.getNextPageToken();
@@ -9368,12 +9368,12 @@ public class AddressClient implements BackgroundResource {
   public static class AggregatedListAddressesPagedResponse extends AbstractPagedListResponse<
       AggregatedListAddressesHttpRequest,
       AddressAggregatedList,
-      Address,
+      AddressesScopedList,
       AggregatedListAddressesPage,
       AggregatedListAddressesFixedSizeCollection> {
 
     public static ApiFuture<AggregatedListAddressesPagedResponse> createAsync(
-        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address> context,
+        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList> context,
         ApiFuture<AddressAggregatedList> futureResponse) {
       ApiFuture<AggregatedListAddressesPage> futurePage =
           AggregatedListAddressesPage.createEmptyPage().createPageAsync(context, futureResponse);
@@ -9397,11 +9397,11 @@ public class AddressClient implements BackgroundResource {
   public static class AggregatedListAddressesPage extends AbstractPage<
       AggregatedListAddressesHttpRequest,
       AddressAggregatedList,
-      Address,
+      AddressesScopedList,
       AggregatedListAddressesPage> {
 
     private AggregatedListAddressesPage(
-        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address> context,
+        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList> context,
         AddressAggregatedList response) {
       super(context, response);
     }
@@ -9412,14 +9412,14 @@ public class AddressClient implements BackgroundResource {
 
     @Override
     protected AggregatedListAddressesPage createPage(
-        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address> context,
+        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList> context,
         AddressAggregatedList response) {
       return new AggregatedListAddressesPage(context, response);
     }
 
     @Override
     public ApiFuture<AggregatedListAddressesPage> createPageAsync(
-        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address> context,
+        PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList> context,
         ApiFuture<AddressAggregatedList> futureResponse) {
       return super.createPageAsync(context, futureResponse);
     }
@@ -9432,7 +9432,7 @@ public class AddressClient implements BackgroundResource {
   public static class AggregatedListAddressesFixedSizeCollection extends AbstractFixedSizeCollection<
       AggregatedListAddressesHttpRequest,
       AddressAggregatedList,
-      Address,
+      AddressesScopedList,
       AggregatedListAddressesPage,
       AggregatedListAddressesFixedSizeCollection> {
 
@@ -9902,6 +9902,7 @@ import com.google.cloud.simplecompute.v1.AddressAggregatedList;
 import static com.google.cloud.simplecompute.v1.AddressClient.AggregatedListAddressesPagedResponse;
 import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
 import com.google.cloud.simplecompute.v1.AddressList;
+import com.google.cloud.simplecompute.v1.AddressesScopedList;
 import com.google.cloud.simplecompute.v1.AggregatedListAddressesHttpRequest;
 import com.google.cloud.simplecompute.v1.DeleteAddressHttpRequest;
 import com.google.cloud.simplecompute.v1.GetAddressHttpRequest;
@@ -10121,8 +10122,8 @@ public class AddressStubSettings extends StubSettings<AddressStubSettings> {
     updateAddressSettings = settingsBuilder.updateAddressSettings().build();
   }
 
-  private static final PagedListDescriptor<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address> AGGREGATED_LIST_ADDRESSES_PAGE_STR_DESC =
-      new PagedListDescriptor<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address>() {
+  private static final PagedListDescriptor<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList> AGGREGATED_LIST_ADDRESSES_PAGE_STR_DESC =
+      new PagedListDescriptor<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList>() {
         @Override
         public String emptyToken() {
           return "";
@@ -10150,8 +10151,8 @@ public class AddressStubSettings extends StubSettings<AddressStubSettings> {
           return payload.getNextPageToken();
         }
         @Override
-        public Iterable<Address> extractResources(AddressAggregatedList payload) {
-          return payload.getItems().getAddressesList();
+        public Iterable<AddressesScopedList> extractResources(AddressAggregatedList payload) {
+          return payload.getItems();
         }
       };
 
@@ -10197,7 +10198,7 @@ public class AddressStubSettings extends StubSettings<AddressStubSettings> {
             AggregatedListAddressesHttpRequest request,
             ApiCallContext context,
             ApiFuture<AddressAggregatedList> futureResponse) {
-          PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, Address> pageContext =
+          PageContext<AggregatedListAddressesHttpRequest, AddressAggregatedList, AddressesScopedList> pageContext =
               PageContext.create(callable, AGGREGATED_LIST_ADDRESSES_PAGE_STR_DESC, request, context);
           return AggregatedListAddressesPagedResponse.createAsync(pageContext, futureResponse);
         }
@@ -10459,6 +10460,7 @@ import static com.google.cloud.simplecompute.v1.AddressClient.AggregatedListAddr
 import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPagedResponse;
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
+import com.google.cloud.simplecompute.v1.AddressesScopedList;
 import com.google.cloud.simplecompute.v1.AggregatedListAddressesHttpRequest;
 import com.google.cloud.simplecompute.v1.DeleteAddressHttpRequest;
 import com.google.cloud.simplecompute.v1.GetAddressHttpRequest;
@@ -10568,6 +10570,7 @@ import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPaged
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
 import com.google.cloud.simplecompute.v1.AddressSettings;
+import com.google.cloud.simplecompute.v1.AddressesScopedList;
 import com.google.cloud.simplecompute.v1.AggregatedListAddressesHttpRequest;
 import com.google.cloud.simplecompute.v1.DeleteAddressHttpRequest;
 import com.google.cloud.simplecompute.v1.GetAddressHttpRequest;
@@ -10944,6 +10947,7 @@ import static com.google.cloud.simplecompute.v1.AddressClient.ListAddressesPaged
 import com.google.cloud.simplecompute.v1.AddressList;
 import com.google.cloud.simplecompute.v1.AddressName;
 import com.google.cloud.simplecompute.v1.AddressSettings;
+import com.google.cloud.simplecompute.v1.AddressesScopedList;
 import com.google.cloud.simplecompute.v1.AggregatedListAddressesHttpRequest;
 import com.google.cloud.simplecompute.v1.DeleteAddressHttpRequest;
 import com.google.cloud.simplecompute.v1.GetAddressHttpRequest;
@@ -12259,11 +12263,7 @@ public class AddressClientTest {
     String nextPageToken = "";
     String id = "id3355";
     String selfLink = "selfLink-1691268851";
-    Address addressesElement = Address.newBuilder().build();
-    List<Address> addresses = Arrays.asList(addressesElement);
-    AddressesScopedList items = AddressesScopedList.newBuilder()
-      .addAllAddresses(addresses)
-      .build();
+    AddressesScopedList items = AddressesScopedList.newBuilder().build();
     AddressAggregatedList expectedResponse = AddressAggregatedList.newBuilder()
       .setKind(kind)
       .setNextPageToken(nextPageToken)
@@ -12277,9 +12277,9 @@ public class AddressClientTest {
 
     AggregatedListAddressesPagedResponse pagedListResponse = client.aggregatedListAddresses(project);
 
-    List<Address> resources = Lists.newArrayList(pagedListResponse.iterateAll());
+    List<AddressesScopedList> resources = Lists.newArrayList(pagedListResponse.iterateAll());
     Assert.assertEquals(1, resources.size());
-    Assert.assertEquals(expectedResponse.getItems().getAddressesList().get(0), resources.get(0));
+    Assert.assertEquals(expectedResponse.getItems().get(0), resources.get(0));
 
     List<String> actualRequests = mockService.getRequestPaths();
     Assert.assertEquals(1, actualRequests.size());

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_config.baseline
@@ -137,7 +137,7 @@ interfaces:
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressAggregatedList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.
@@ -226,7 +226,7 @@ interfaces:
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressList
+        resources_field: items
     # TODO: Configure the retryable codes for this method.
     retry_codes_name: idempotent
     # TODO: Configure the retryable params for this method.

--- a/src/test/java/com/google/api/codegen/testdata/simplecompute_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/simplecompute_gapic.yaml
@@ -129,7 +129,7 @@ interfaces:
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressAggregatedList
+        resources_field: items
     retry_codes_name: idempotent
     retry_params_name: default
     field_name_patterns:
@@ -194,7 +194,7 @@ interfaces:
         token_field: pageToken
       response:
         token_field: nextPageToken
-        resources_field: AddressList
+        resources_field: items
     retry_codes_name: idempotent
     retry_params_name: default
     field_name_patterns:


### PR DESCRIPTION
In discogapic configgen, make `page_streaming.response.resources_field` the name of the field in the response containing the list of resources belonging to the page, as the config.proto has dictated. See simplecompute_gapic.yaml for resulting output changes.

For paged methods, scrap the concept of a list of field getter methods to get from a response object to the paged resource object. It's too complex and hard to determine the series of fields to traverse. Assume the paged resource object is a direct field of the response object.

`PageStreamingConfig` constructor is now same regardless of model type (e.g. proto/discovery)