### PR TITLE
Discogapic: Handle map return type

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.codegen.discogapic.StringTypeModel;
 import com.google.api.codegen.discogapic.transformer.DiscoGapicParser;
 import com.google.api.codegen.discovery.Document;
 import com.google.api.codegen.discovery.Method;
@@ -101,17 +102,24 @@ public class DiscoveryField implements FieldModel, TypeModel {
 
   @Override
   public boolean isMap() {
-    return false;
+    return originalSchema.additionalProperties() != null;
   }
 
   @Override
-  public FieldModel getMapKeyField() {
-    throw new IllegalArgumentException("Discovery model types have no map keys.");
+  public TypeModel getMapKeyType() {
+    if (isMap()) {
+      // Assume that the schema's additionalProperties map keys are Strings.
+      return StringTypeModel.getInstance();
+    }
+    return null;
   }
 
   @Override
-  public FieldModel getMapValueField() {
-    throw new IllegalArgumentException("Discovery model types have no map values.");
+  public TypeModel getMapValueType() {
+    if (isMap()) {
+      return DiscoveryField.create(originalSchema.additionalProperties(), apiModel);
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryMethodModel.java
@@ -53,7 +53,7 @@ public final class DiscoveryMethodModel implements MethodModel {
     if (method.response() != null) {
       this.outputType = DiscoveryField.create(method.response(), apiModel);
     } else {
-      this.outputType = new EmptyTypeModel();
+      this.outputType = EmptyTypeModel.getInstance();
     }
   }
 
@@ -87,7 +87,10 @@ public final class DiscoveryMethodModel implements MethodModel {
 
   @Override
   public DiscoveryField getOutputField(String fieldName) {
-    return null;
+    if (outputType.isEmptyType() || outputType.isPrimitive()) {
+      return null;
+    }
+    return ((DiscoveryField) outputType).getField(fieldName);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/DiscoveryRequestType.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryRequestType.java
@@ -37,13 +37,13 @@ public abstract class DiscoveryRequestType implements TypeModel {
 
   /* @return the resource type of the map key. */
   @Override
-  public FieldModel getMapKeyField() {
+  public TypeModel getMapKeyType() {
     return null;
   }
 
   /* @return the resource type of the map value. */
   @Override
-  public FieldModel getMapValueField() {
+  public TypeModel getMapValueType() {
     return null;
   }
 

--- a/src/main/java/com/google/api/codegen/config/FieldModel.java
+++ b/src/main/java/com/google/api/codegen/config/FieldModel.java
@@ -47,12 +47,6 @@ public interface FieldModel {
   /* @return if the underlying resource is a map type. */
   boolean isMap();
 
-  /* @return the resource type of the map key. */
-  FieldModel getMapKeyField();
-
-  /* @return the resource type of the map value. */
-  FieldModel getMapValueField();
-
   /* @return if the underlying resource is a proto Messsage. */
   boolean isMessage();
 

--- a/src/main/java/com/google/api/codegen/config/ProtoField.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoField.java
@@ -76,16 +76,6 @@ public class ProtoField implements FieldModel {
   }
 
   @Override
-  public ProtoField getMapKeyField() {
-    return new ProtoField(protoField.getType().getMapKeyField());
-  }
-
-  @Override
-  public ProtoField getMapValueField() {
-    return new ProtoField(protoField.getType().getMapValueField());
-  }
-
-  @Override
   public boolean isMessage() {
     return protoField.getType().isMessage();
   }

--- a/src/main/java/com/google/api/codegen/config/ProtoTypeRef.java
+++ b/src/main/java/com/google/api/codegen/config/ProtoTypeRef.java
@@ -49,13 +49,13 @@ public class ProtoTypeRef implements TypeModel {
   }
 
   @Override
-  public FieldModel getMapKeyField() {
-    return new ProtoField(typeRef.getMapKeyField());
+  public TypeModel getMapKeyType() {
+    return new ProtoTypeRef(typeRef.getMapKeyField().getType());
   }
 
   @Override
-  public FieldModel getMapValueField() {
-    return new ProtoField(typeRef.getMapValueField());
+  public TypeModel getMapValueType() {
+    return new ProtoTypeRef(typeRef.getMapValueField().getType());
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/TypeModel.java
+++ b/src/main/java/com/google/api/codegen/config/TypeModel.java
@@ -28,10 +28,10 @@ public interface TypeModel {
   boolean isMap();
 
   /* @return the resource type of the map key. */
-  FieldModel getMapKeyField();
+  TypeModel getMapKeyType();
 
   /* @return the resource type of the map value. */
-  FieldModel getMapValueField();
+  TypeModel getMapValueType();
 
   /* @return if the underlying resource is a proto Messsage. */
   boolean isMessage();

--- a/src/main/java/com/google/api/codegen/discogapic/StringTypeModel.java
+++ b/src/main/java/com/google/api/codegen/discogapic/StringTypeModel.java
@@ -20,14 +20,14 @@ import com.google.api.codegen.config.TypeModel;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
-public class EmptyTypeModel implements TypeModel {
-  private static EmptyTypeModel instance = null;
+public class StringTypeModel implements TypeModel {
+  private static StringTypeModel instance = null;
 
-  private EmptyTypeModel() {}
+  private StringTypeModel() {}
 
-  public static EmptyTypeModel getInstance() {
+  public static StringTypeModel getInstance() {
     if (instance == null) {
-      instance = new EmptyTypeModel();
+      instance = new StringTypeModel();
     }
     return instance;
   }
@@ -51,7 +51,7 @@ public class EmptyTypeModel implements TypeModel {
 
   @Override
   public boolean isMessage() {
-    return true;
+    return false;
   }
 
   @Override
@@ -71,7 +71,7 @@ public class EmptyTypeModel implements TypeModel {
 
   @Override
   public boolean isEmptyType() {
-    return true;
+    return false;
   }
 
   @Override
@@ -104,7 +104,7 @@ public class EmptyTypeModel implements TypeModel {
 
   @Override
   public boolean isStringType() {
-    return false;
+    return true;
   }
 
   @Override
@@ -124,7 +124,7 @@ public class EmptyTypeModel implements TypeModel {
 
   @Override
   public String getTypeName() {
-    return "EmptyTypeModel";
+    return "StringTypeModel";
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/discovery/Schema.java
+++ b/src/main/java/com/google/api/codegen/discovery/Schema.java
@@ -167,6 +167,9 @@ public abstract class Schema implements Node {
     boolean required = root.getBoolean("required");
     Type type = Type.getEnum(root.getString("type"));
 
+    // additionalProperties is a dynamically-keyed map in Discovery docs.
+    boolean isMap = additionalProperties != null;
+
     Schema thisSchema =
         new AutoValue_Schema(
             additionalProperties,
@@ -183,6 +186,7 @@ public abstract class Schema implements Node {
             reference,
             repeated,
             required,
+            isMap,
             type);
     thisSchema.parent = parent;
     if (items != null) {
@@ -200,7 +204,7 @@ public abstract class Schema implements Node {
 
   /** @return a non-null identifier for this schema. */
   public String getIdentifier() {
-    return id().isEmpty() ? key() : id();
+    return Strings.isNullOrEmpty(id()) ? key() : id();
   }
 
   public static Schema empty() {
@@ -217,6 +221,7 @@ public abstract class Schema implements Node {
         "",
         new HashMap<String, Schema>(),
         "",
+        false,
         false,
         false,
         Type.EMPTY);
@@ -279,6 +284,9 @@ public abstract class Schema implements Node {
 
   /** @return whether or not the schema is required. */
   public abstract boolean required();
+
+  /** @return whether or not the schema is a map. */
+  public abstract boolean isMap();
 
   /** @return the type. */
   public abstract Type type();

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -352,7 +352,7 @@ public class InitCodeNode {
 
   private static void validateKeyValue(TypeModel parentType, String key) {
     if (parentType.isMap()) {
-      TypeModel keyType = parentType.getMapKeyField().getType();
+      TypeModel keyType = parentType.getMapKeyType();
       validateValue(keyType, key);
     } else if (parentType.isRepeated()) {
       validateValue(INT_TYPE, key);
@@ -363,7 +363,7 @@ public class InitCodeNode {
 
   private static TypeModel getChildType(TypeModel parentType, String key) {
     if (parentType.isMap()) {
-      return parentType.getMapValueField().getType();
+      return parentType.getMapValueType();
     } else if (parentType.isRepeated()) {
       // Using the Optional cardinality replaces the Repeated cardinality
       return parentType.makeOptional();

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -393,13 +393,13 @@ public class InitCodeTransformer {
     surfaceLine.lineType(InitCodeLineType.MapInitLine);
     surfaceLine.identifier(namer.localVarName(item.getIdentifier()));
 
-    surfaceLine.keyTypeName(typeTable.getAndSaveNicknameFor(item.getType().getMapKeyField()));
-    surfaceLine.valueTypeName(typeTable.getAndSaveNicknameFor(item.getType().getMapValueField()));
+    surfaceLine.keyTypeName(typeTable.getAndSaveNicknameFor(item.getType().getMapKeyType()));
+    surfaceLine.valueTypeName(typeTable.getAndSaveNicknameFor(item.getType().getMapValueType()));
 
     List<MapEntryView> entries = new ArrayList<>();
     for (Map.Entry<String, InitCodeNode> entry : item.getChildren().entrySet()) {
       MapEntryView.Builder mapEntry = MapEntryView.newBuilder();
-      mapEntry.key(typeTable.renderPrimitiveValue(item.getType().getMapKeyField(), entry.getKey()));
+      mapEntry.key(typeTable.renderPrimitiveValue(item.getType().getMapKeyType(), entry.getKey()));
       mapEntry.valueString(context.getNamer().localVarName(entry.getValue().getIdentifier()));
       mapEntry.value(generateSurfaceInitCodeLine(context, entry.getValue(), entries.isEmpty()));
       entries.add(mapEntry.build());

--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -118,6 +118,8 @@ public class PageStreamingTransformer {
     }
     desc.resourcesFieldGetFunctions(resourcesFieldGetFunctionList.build());
 
+    desc.resourcesFieldIsMap(resourceField.isMap());
+
     return desc.build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeFormatterImpl.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeFormatterImpl.java
@@ -60,7 +60,7 @@ public class SchemaTypeFormatterImpl implements SchemaTypeFormatter {
 
   @Override
   public String renderPrimitiveValue(TypeModel type, String key) {
-    return renderPrimitiveValue(((DiscoveryField) type).getDiscoveryField(), key);
+    return typeNameConverter.renderPrimitiveValue(type, key);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeNameConverter.java
@@ -71,8 +71,13 @@ public abstract class SchemaTypeNameConverter implements TypeNameConverter {
   /** Renders the given value if it is a primitive type. */
   public abstract String renderPrimitiveValue(Schema schema, String value);
 
+  /** Renders the given value if it is a primitive type. */
+  public abstract String renderPrimitiveValue(TypeModel type, String value);
+
   /** Renders the value as a string. */
   public abstract String renderValueAsString(String value);
+
+  protected abstract TypeName getTypeNameForStringType();
 
   @Override
   public TypeName getTypeName(InterfaceModel interfaceModel) {
@@ -86,13 +91,12 @@ public abstract class SchemaTypeNameConverter implements TypeNameConverter {
 
   @Override
   public TypeName getTypeName(TypeModel type) {
-    // TODO(andrealin): Remove this hack when null response types are implemented.
-    if (type == null) {
-      return new TypeName("nullTypeName");
-    }
     if (type instanceof DiscoveryRequestType) {
       Method method = ((DiscoveryRequestType) type).parentMethod().getDiscoMethod();
       return getDiscoGapicNamer().getRequestTypeName(method, getNamer());
+    }
+    if (type.isStringType()) {
+      return getTypeNameForStringType();
     }
     Schema schema = type.isEmptyType() ? null : ((DiscoveryField) type).getDiscoveryField();
     return getTypeNameForElementType(schema);

--- a/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/SchemaTypeTable.java
@@ -178,9 +178,8 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
 
   @Override
   public String getFullNameFor(TypeModel type) {
-    // TODO(andrealin): Remove this hack when null response types are implemented.
-    if (type == null) {
-      return "nullFullName";
+    if (type.isEmptyType()) {
+      return "java.lang.Void";
     }
     if (type instanceof DiscoveryRequestType) {
       Method method = ((DiscoveryRequestType) type).parentMethod().getDiscoMethod();
@@ -229,12 +228,12 @@ public class SchemaTypeTable implements ImportTypeTable, SchemaTypeFormatter {
   /** Renders the primitive value of the given type. */
   @Override
   public String renderPrimitiveValue(FieldModel type, String key) {
-    return renderPrimitiveValue(((DiscoveryField) type).getDiscoveryField(), key);
+    return typeNameConverter.renderPrimitiveValue(type, key);
   }
 
   @Override
   public String renderPrimitiveValue(TypeModel type, String key) {
-    return renderPrimitiveValue(((DiscoveryField) type).getDiscoveryField(), key);
+    return typeFormatter.renderPrimitiveValue(type, key);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -14,8 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
-import static com.google.api.codegen.metacode.InitCodeLineType.ListInitLine;
-import static com.google.api.codegen.metacode.InitCodeLineType.StructureInitLine;
+import static com.google.api.codegen.metacode.InitCodeLineType.MapInitLine;
 
 import com.google.api.codegen.config.BatchingConfig;
 import com.google.api.codegen.config.FieldConfig;
@@ -56,7 +55,6 @@ import com.google.api.tools.framework.model.Oneof;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -264,6 +262,7 @@ public class TestCaseTransformer {
         PageStreamingResponseView.newBuilder()
             .resourceTypeName(resourceTypeName)
             .resourcesFieldGetterNames(resourcesFieldGetFunctionList.build())
+            .resourcesFieldIsMap(resourcesField.isMap())
             .resourcesIterateMethod(namer.getPagedResponseIterateMethod())
             .resourcesVarName(namer.localVarName(Name.from("resources")))
             .build());
@@ -291,6 +290,7 @@ public class TestCaseTransformer {
           PageStreamingResponseView.newBuilder()
               .resourceTypeName(resourceTypeName)
               .resourcesFieldGetterNames(resourcesFieldGetFunctionList.build())
+              .resourcesFieldIsMap(resourcesField.isMap())
               .resourcesIterateMethod(
                   namer.getPagedResponseIterateMethod(
                       methodContext.getFeatureConfig(), resourcesFieldConfig))
@@ -375,28 +375,19 @@ public class TestCaseTransformer {
     if (context.getMethodConfig().isPageStreaming()) {
       // Initialize one resource element if it is page-streaming.
       PageStreamingConfig config = context.getMethodConfig().getPageStreaming();
-      if (config.getResourcesFieldConfig().getFieldPath().size() == 1) {
-        String resourceFieldName = config.getResourcesFieldName();
-        additionalSubTrees.add(InitCodeNode.createSingletonList(resourceFieldName));
+      FieldModel field = config.getResourcesField();
+      InitCodeNode initCodeNode;
+      if (field.isRepeated()) {
+        initCodeNode = InitCodeNode.createSingletonList(config.getResourcesFieldName());
       } else {
-        //  Initialize all the objects between the response type and the resource element.
-        List<FieldModel> fieldGetters =
-            Lists.reverse(config.getResourcesFieldConfig().getFieldPath());
-        InitCodeNode initCodeNode = null;
-
-        for (FieldModel field : fieldGetters) {
-          if (config.getResourcesField().isRepeated()) {
-            initCodeNode = InitCodeNode.createSingletonList(config.getResourcesFieldName());
-          } else {
-            initCodeNode = InitCodeNode.create(config.getResourcesFieldName());
-          }
-
-          InitCodeLineType lineType = field.isRepeated() ? ListInitLine : StructureInitLine;
-          initCodeNode =
-              InitCodeNode.createWithChildren(field.getSimpleName(), lineType, initCodeNode);
-        }
-        additionalSubTrees.add(initCodeNode);
+        initCodeNode = InitCodeNode.create(field.getNameAsParameter());
       }
+      if (config.getResourcesField().isMap()) {
+        initCodeNode =
+            InitCodeNode.createWithChildren(
+                config.getResourcesField().getNameAsParameter(), MapInitLine, initCodeNode);
+      }
+      additionalSubTrees.add(initCodeNode);
 
       // Set the initial value of the page token to empty, in order to indicate that no more pages
       // are available

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceTestTransformer.java
@@ -438,6 +438,8 @@ public class JavaSurfaceTestTransformer implements ModelToViewTransformer {
         typeTable.saveNicknameFor("com.google.api.gax.rpc.StatusCode.Code");
         typeTable.saveNicknameFor("com.google.api.gax.rpc.testing.FakeStatusCode");
         typeTable.saveNicknameFor("com.google.common.collect.ImmutableList");
+        typeTable.saveNicknameFor("java.util.Map");
+        typeTable.saveNicknameFor("java.util.HashMap");
 
         // Import stub settings class in unit test file.
         SurfaceNamer stubNamer =

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -332,8 +332,8 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
     String cardinalityComment = "";
     if (type.isRepeated()) {
       if (type.isMap()) {
-        String keyType = getParamTypeName(typeTable, type.getMapKeyField().getType());
-        String valueType = getParamTypeName(typeTable, type.getMapValueField().getType());
+        String keyType = getParamTypeName(typeTable, type.getMapKeyType());
+        String valueType = getParamTypeName(typeTable, type.getMapValueType());
         return String.format("Object.<%s, %s>", keyType, valueType);
       } else {
         cardinalityComment = "[]";

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java
@@ -127,12 +127,13 @@ public class PythonApiMethodParamTransformer implements ApiMethodParamTransforme
       } else {
         docLines.addAll(namer.getDocLines(field));
         boolean isMessageField = field.isMessage() && !field.isMap();
-        boolean isMapContainingMessage = field.isMap() && field.getMapValueField().isMessage();
+        boolean isMapContainingMessage =
+            field.isMap() && field.getType().getMapValueType().isMessage();
         if (isMessageField || isMapContainingMessage) {
           String messageType;
           if (isMapContainingMessage) {
             messageType =
-                context.getTypeTable().getFullNameForElementType(field.getMapValueField());
+                context.getTypeTable().getFullNameForElementType(field.getType().getMapValueType());
           } else {
             messageType = context.getTypeTable().getFullNameForElementType(field);
           }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -163,10 +163,8 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   public String getParamTypeName(ImportTypeTable typeTable, TypeModel type) {
     if (type.isMap()) {
       TypeName mapTypeName = new TypeName("dict");
-      TypeName keyTypeName =
-          new TypeName(getParamTypeNameForElementType(type.getMapKeyField().getType()));
-      TypeName valueTypeName =
-          new TypeName(getParamTypeNameForElementType(type.getMapValueField().getType()));
+      TypeName keyTypeName = new TypeName(getParamTypeNameForElementType(type.getMapKeyType()));
+      TypeName valueTypeName = new TypeName(getParamTypeNameForElementType(type.getMapValueType()));
       return new TypeName(
               mapTypeName.getFullName(),
               mapTypeName.getNickname(),

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
@@ -114,12 +114,13 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
       } else {
         docLines.addAll(namer.getDocLines(field));
         boolean isMessageField = field.isMessage() && !field.isMap();
-        boolean isMapContainingMessage = field.isMap() && field.getMapValueField().isMessage();
+        boolean isMapContainingMessage =
+            field.isMap() && field.getType().getMapValueType().isMessage();
         if (isMessageField || isMapContainingMessage) {
           String messageType;
           if (isMapContainingMessage) {
             messageType =
-                context.getTypeTable().getFullNameForElementType(field.getMapValueField());
+                context.getTypeTable().getFullNameForElementType(field.getType().getMapValueType());
           } else {
             messageType = context.getTypeTable().getFullNameForElementType(field);
           }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -122,9 +122,9 @@ public class RubySurfaceNamer extends SurfaceNamer {
   @Override
   public String getParamTypeName(ImportTypeTable typeTable, TypeModel type) {
     if (type.isMap()) {
-      String keyTypeName = typeTable.getFullNameForElementType(type.getMapKeyField());
-      String valueTypeName = typeTable.getFullNameForElementType(type.getMapValueField());
-      if (type.getMapValueField().isMessage()) {
+      String keyTypeName = typeTable.getFullNameForElementType(type.getMapKeyType());
+      String valueTypeName = typeTable.getFullNameForElementType(type.getMapValueType());
+      if (type.getMapValueType().isMessage()) {
         valueTypeName += " | Hash";
       }
       return new TypeName(
@@ -156,9 +156,10 @@ public class RubySurfaceNamer extends SurfaceNamer {
   @Override
   public String getMessagePropertyTypeName(ImportTypeTable importTypeTable, FieldModel fieldModel) {
     if (fieldModel.isMap()) {
-      String keyTypeName = importTypeTable.getFullNameForElementType(fieldModel.getMapKeyField());
+      String keyTypeName =
+          importTypeTable.getFullNameForElementType(fieldModel.getType().getMapKeyType());
       String valueTypeName =
-          importTypeTable.getFullNameForElementType(fieldModel.getMapValueField());
+          importTypeTable.getFullNameForElementType(fieldModel.getType().getMapValueType());
       return new TypeName(
               importTypeTable.getFullNameFor(fieldModel),
               importTypeTable.getNicknameFor(fieldModel),

--- a/src/main/java/com/google/api/codegen/viewmodel/PageStreamingDescriptorClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/PageStreamingDescriptorClassView.java
@@ -46,6 +46,8 @@ public abstract class PageStreamingDescriptorClassView {
 
   public abstract List<String> resourcesFieldGetFunctions();
 
+  public abstract boolean resourcesFieldIsMap();
+
   public boolean requestHasPageSize() {
     return requestPageSizeSetFunction() != null && requestPageSizeGetFunction() != null;
   }
@@ -80,6 +82,8 @@ public abstract class PageStreamingDescriptorClassView {
     public abstract Builder responseTokenGetFunction(String val);
 
     public abstract Builder resourcesFieldGetFunctions(List<String> val);
+
+    public abstract Builder resourcesFieldIsMap(boolean val);
 
     public abstract PageStreamingDescriptorClassView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/PageStreamingResponseView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/PageStreamingResponseView.java
@@ -30,6 +30,8 @@ public abstract class PageStreamingResponseView {
 
   public abstract String resourcesIterateMethod();
 
+  public abstract Boolean resourcesFieldIsMap();
+
   @Nullable
   public abstract String expectedValueTransformFunction();
 
@@ -49,6 +51,8 @@ public abstract class PageStreamingResponseView {
     public abstract Builder resourceTypeName(String val);
 
     public abstract Builder resourcesFieldGetterNames(List<String> val);
+
+    public abstract Builder resourcesFieldIsMap(Boolean val);
 
     public abstract Builder resourcesIterateMethod(String val);
 

--- a/src/main/resources/com/google/api/codegen/java/http_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/http_test.snip
@@ -112,7 +112,12 @@
     @join pageStreamingResponseView : test.pageStreamingResponseViews
       List<{@pageStreamingResponseView.resourceTypeName}> {@pageStreamingResponseView.resourcesVarName} = Lists.newArrayList(pagedListResponse.{@pageStreamingResponseView.resourcesIterateMethod}());
       Assert.assertEquals(1, {@pageStreamingResponseView.resourcesVarName}.size());
-      Assert.assertEquals(expectedResponse.{@functionChain(pageStreamingResponseView.resourcesFieldGetterNames)}.get(0), {@pageStreamingResponseView.resourcesVarName}.get(0));
+      @if pageStreamingResponseView.resourcesFieldIsMap
+        Assert.assertEquals(expectedResponse.{@functionChain(pageStreamingResponseView.resourcesFieldGetterNames)}.values().iterator().next(),
+      @else
+        Assert.assertEquals(expectedResponse.{@functionChain(pageStreamingResponseView.resourcesFieldGetterNames)}.get(0),
+      @end
+          {@pageStreamingResponseView.resourcesVarName}.get(0));
     @end
   @case "FlattenedMethod"
     @if test.hasReturnValue
@@ -130,7 +135,6 @@
 @end
 
 # TODO(andrealin) comparison of request content.
-# TODO(andrealin) check for header being sent.
 @private unarySuccessAsserts(test)
   List<String> actualRequests = mockService.getRequestPaths();
   Assert.assertEquals(1, actualRequests.size());

--- a/src/main/resources/com/google/api/codegen/java/stub_settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/stub_settings.snip
@@ -271,7 +271,11 @@
           }
           @@Override
           public Iterable<{@desc.resourceTypeName}> extractResources({@desc.responseTypeName} payload) {
-            return payload.{@functionChain(desc.resourcesFieldGetFunctions)};
+            @if desc.resourcesFieldIsMap
+              return payload.{@functionChain(desc.resourcesFieldGetFunctions)}.values();
+            @else
+              return payload.{@functionChain(desc.resourcesFieldGetFunctions)};
+            @end
           }
         };
     {@""}

--- a/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discogapic/java/java_simplecompute.v1.json.baseline
@@ -1461,7 +1461,7 @@ import javax.annotation.Nullable;
 @BetaApi
 public final class AddressAggregatedList implements ApiMessage {
   private final String id;
-  private final AddressesScopedList items;
+  private final Map<String, AddressesScopedList> items;
   private final String kind;
   private final String nextPageToken;
   private final String selfLink;
@@ -1479,7 +1479,7 @@ public final class AddressAggregatedList implements ApiMessage {
 
   private AddressAggregatedList(
       String id,
-      AddressesScopedList items,
+      Map<String, AddressesScopedList> items,
       String kind,
       String nextPageToken,
       String selfLink,
@@ -1550,7 +1550,7 @@ public final class AddressAggregatedList implements ApiMessage {
     return id;
   }
 
-  public AddressesScopedList getItems() {
+  public Map<String, AddressesScopedList> getItemsMap() {
     return items;
   }
 
@@ -1592,7 +1592,7 @@ public final class AddressAggregatedList implements ApiMessage {
 
   public static class Builder {
     private String id;
-    private AddressesScopedList items;
+    private Map<String, AddressesScopedList> items;
     private String kind;
     private String nextPageToken;
     private String selfLink;
@@ -1605,7 +1605,7 @@ public final class AddressAggregatedList implements ApiMessage {
       if (other.getId() != null) {
         this.id = other.id;
       }
-      if (other.getItems() != null) {
+      if (other.getItemsMap() != null) {
         this.items = other.items;
       }
       if (other.getKind() != null) {
@@ -1641,11 +1641,11 @@ public final class AddressAggregatedList implements ApiMessage {
       return this;
     }
 
-    public AddressesScopedList getItems() {
+    public Map<String, AddressesScopedList> getItemsMap() {
       return items;
     }
 
-    public Builder setItems(AddressesScopedList items) {
+    public Builder putAllItems(Map<String, AddressesScopedList> items) {
       this.items = items;
       return this;
     }
@@ -1706,7 +1706,7 @@ public final class AddressAggregatedList implements ApiMessage {
     public Builder clone() {
       Builder newBuilder = new Builder();
       newBuilder.setId(this.id);
-      newBuilder.setItems(this.items);
+      newBuilder.putAllItems(this.items);
       newBuilder.setKind(this.kind);
       newBuilder.setNextPageToken(this.nextPageToken);
       newBuilder.setSelfLink(this.selfLink);
@@ -1736,7 +1736,7 @@ public final class AddressAggregatedList implements ApiMessage {
       AddressAggregatedList that = (AddressAggregatedList) o;
       return
           Objects.equals(this.id, that.getId()) &&
-          Objects.equals(this.items, that.getItems()) &&
+          Objects.equals(this.items, that.getItemsMap()) &&
           Objects.equals(this.kind, that.getKind()) &&
           Objects.equals(this.nextPageToken, that.getNextPageToken()) &&
           Objects.equals(this.selfLink, that.getSelfLink()) &&
@@ -10151,7 +10151,7 @@ public class AddressStubSettings extends StubSettings<AddressStubSettings> {
         }
         @Override
         public Iterable<Address> extractResources(AddressAggregatedList payload) {
-          return payload.getItems().getAddressesList();
+          return payload.getItemsMap().getAddressesList();
         }
       };
 
@@ -12203,7 +12203,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -12261,15 +12263,12 @@ public class AddressClientTest {
     String selfLink = "selfLink-1691268851";
     Address addressesElement = Address.newBuilder().build();
     List<Address> addresses = Arrays.asList(addressesElement);
-    AddressesScopedList items = AddressesScopedList.newBuilder()
-      .addAllAddresses(addresses)
-      .build();
     AddressAggregatedList expectedResponse = AddressAggregatedList.newBuilder()
       .setKind(kind)
       .setNextPageToken(nextPageToken)
       .setId(id)
       .setSelfLink(selfLink)
-      .setItems(items)
+      .addAllAddresses(addresses)
       .build();
     mockService.addResponse(expectedResponse);
 
@@ -12279,7 +12278,8 @@ public class AddressClientTest {
 
     List<Address> resources = Lists.newArrayList(pagedListResponse.iterateAll());
     Assert.assertEquals(1, resources.size());
-    Assert.assertEquals(expectedResponse.getItems().getAddressesList().get(0), resources.get(0));
+    Assert.assertEquals(expectedResponse.getItemsMap().getAddressesList().get(0),
+        resources.get(0));
 
     List<String> actualRequests = mockService.getRequestPaths();
     Assert.assertEquals(1, actualRequests.size());
@@ -12548,7 +12548,8 @@ public class AddressClientTest {
 
     List<Address> resources = Lists.newArrayList(pagedListResponse.iterateAll());
     Assert.assertEquals(1, resources.size());
-    Assert.assertEquals(expectedResponse.getItemsList().get(0), resources.get(0));
+    Assert.assertEquals(expectedResponse.getItemsList().get(0),
+        resources.get(0));
 
     List<String> actualRequests = mockService.getRequestPaths();
     Assert.assertEquals(1, actualRequests.size());
@@ -12780,7 +12781,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;


### PR DESCRIPTION
In Discovery doc schemas, the `additionalProperties` field is a [dynamically-keyed map type](https://developers.google.com/discovery/v1/reference/apis). For now, assume the keys are Strings. There are pageable methods, e.g. `compute.addresses.aggregatedList`, that must page over this `Map<String, ? extends ApiMessage>` type.