### PR TITLE
Make Discogapic a gradle executable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -385,6 +385,19 @@ task runCodeGen(type: JavaExec) {
   }
 }
 
+// Task to run CodeGeneratorTool
+// =============================
+//
+// Command line args can be passed to the tool as a comma-separated list:
+//   ./gradlew runCodeGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+task runDiscoCodeGen(type: JavaExec) {
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.google.api.codegen.DiscoGapicGeneratorTool'
+  if (project.hasProperty('clargs')) {
+    args = clargs.split(',').toList()
+  }
+}
+
 // Task to run SynchronizerTool
 // =============================
 //
@@ -442,8 +455,8 @@ task runConfigGen(type: JavaExec) {
 // =============================
 //
 // Command line args can be passed to the tool as a comma-separated list:
-//   ./gradlew runConfigGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
-task runDiscoveryConfigGen(type: JavaExec) {
+//   ./gradlew runDiscoConfigGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+task runDiscoConfigGen(type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath
   main = 'com.google.api.codegen.configgen.DiscoConfigGeneratorTool'
   if (project.hasProperty('clargs')) {

--- a/build.gradle
+++ b/build.gradle
@@ -438,6 +438,19 @@ task runConfigGen(type: JavaExec) {
   }
 }
 
+// Task to run DiscoveryConfigGeneratorTool
+// =============================
+//
+// Command line args can be passed to the tool as a comma-separated list:
+//   ./gradlew runConfigGen '-Pclargs=--arg1=val1,--arg2=val2,--arg3=val3'
+task runDiscoveryConfigGen(type: JavaExec) {
+  classpath = sourceSets.main.runtimeClasspath
+  main = 'com.google.api.codegen.configgen.DiscoConfigGeneratorTool'
+  if (project.hasProperty('clargs')) {
+    args = clargs.split(',').toList()
+  }
+}
+
 // Task to run GrpcMetadataGeneratorTool
 // =============================
 //

--- a/src/main/java/com/google/api/codegen/DiscoGapicGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoGapicGeneratorTool.java
@@ -106,14 +106,12 @@ public class DiscoGapicGeneratorTool {
 
   private static void generate(
       String discoveryDoc,
-      //      String[] configs,
       String[] generatorConfigs,
       String packageConfig,
       String outputDirectory,
       String[] enabledArtifacts)
       throws Exception {
     ToolOptions options = ToolOptions.create();
-    //    options.set(ToolOptions.CONFIG_FILES, Lists.newArrayList(configs));
     options.set(DiscoGapicGeneratorApi.DISCOVERY_DOC, discoveryDoc);
     options.set(CodeGeneratorApi.OUTPUT_FILE, outputDirectory);
     options.set(CodeGeneratorApi.GENERATOR_CONFIG_FILES, Lists.newArrayList(generatorConfigs));

--- a/src/main/java/com/google/api/codegen/grpcmetadatagen/ArtifactType.java
+++ b/src/main/java/com/google/api/codegen/grpcmetadatagen/ArtifactType.java
@@ -17,7 +17,9 @@ package com.google.api.codegen.grpcmetadatagen;
 public enum ArtifactType {
   UNKNOWN,
   GAPIC,
+  DISCOGAPIC,
   GAPIC_CONFIG,
+  DISCOGAPIC_CONFIG,
   GRPC,
   GRPC_COMMON,
   PROTOBUF,


### PR DESCRIPTION
Expose the Discogapic client library and config generator methods as runnable gradle tasks.