### PR TITLE
Inflector.singularize() cases and tests

### DIFF
--- a/src/main/java/com/google/api/codegen/Inflector.java
+++ b/src/main/java/com/google/api/codegen/Inflector.java
@@ -25,8 +25,26 @@ public class Inflector {
     } else if (in.endsWith("ies")) {
       return in.substring(0, in.length() - 3) + "y";
 
+    } else if (in.endsWith("sses")) {
+      return in.substring(0, in.length() - 2);
+
+    } else if (in.endsWith("shes")) {
+      return in.substring(0, in.length() - 2);
+
+    } else if (in.endsWith("zzes")) {
+      return in.substring(0, in.length() - 2);
+
     } else if (in.endsWith("ses")) {
-      return in.substring(0, in.length() - 3) + "s";
+      return in.substring(0, in.length() - 1);
+
+    } else if (in.endsWith("ces")) {
+      return in.substring(0, in.length() - 1);
+
+    } else if (in.endsWith("res")) {
+      return in.substring(0, in.length() - 1);
+
+    } else if (in.endsWith("zes")) {
+      return in.substring(0, in.length() - 1);
 
     } else if (in.charAt(in.length() - 1) == 's' && in.charAt(in.length() - 2) != 's') {
       return in.substring(0, in.length() - 1);

--- a/src/test/java/com/google/api/codegen/InflectorTest.java
+++ b/src/test/java/com/google/api/codegen/InflectorTest.java
@@ -1,0 +1,35 @@
+/* Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import com.google.common.truth.Truth;
+import org.junit.Test;
+
+public class InflectorTest {
+
+  @Test
+  public void testSingularize() {
+    Truth.assertThat(Inflector.singularize("scarves")).isEqualTo("scarf");
+    Truth.assertThat(Inflector.singularize("halves")).isEqualTo("half");
+    Truth.assertThat(Inflector.singularize("cars")).isEqualTo("car");
+    Truth.assertThat(Inflector.singularize("fuzzes")).isEqualTo("fuzz");
+    Truth.assertThat(Inflector.singularize("sneezes")).isEqualTo("sneeze");
+    Truth.assertThat(Inflector.singularize("blesses")).isEqualTo("bless");
+    Truth.assertThat(Inflector.singularize("scarves")).isEqualTo("scarf");
+    Truth.assertThat(Inflector.singularize("licenses")).isEqualTo("license");
+    Truth.assertThat(Inflector.singularize("cares")).isEqualTo("care");
+    Truth.assertThat(Inflector.singularize("fishes")).isEqualTo("fish");
+  }
+}


### PR DESCRIPTION
Add more cases to the `singularize()` method and add an InflectorTest.java to check it.

Context: a compute.v1.json resource is named "licenses", which currently gets truncated to "licens" when singularizing it.