### PR TITLE
Set page_streaming.resources_object to non-null value

### DIFF
--- a/src/main/java/com/google/api/codegen/config/DiscoveryField.java
+++ b/src/main/java/com/google/api/codegen/config/DiscoveryField.java
@@ -283,6 +283,9 @@ public class DiscoveryField implements FieldModel, TypeModel {
 
     Schema parentTypeSchema = getDiscoveryField();
     List<Schema> pathToKeySchema = parentTypeSchema.findChild(key);
+    if (pathToKeySchema.size() == 0) {
+      return null; // key not found.
+    }
     return DiscoveryField.create(pathToKeySchema.get(pathToKeySchema.size() - 1), apiModel);
   }
 

--- a/src/main/java/com/google/api/codegen/config/MethodModel.java
+++ b/src/main/java/com/google/api/codegen/config/MethodModel.java
@@ -27,11 +27,11 @@ import javax.annotation.Nullable;
 /** Input-agnostic model of a method. */
 public interface MethodModel {
 
-  /* @return find a nested field in the method's input type by the nested field's name. */
+  /* @return find a nested field in the method's input type by the nested field's name. Returns null if not found. */
   @Nullable
   FieldModel getInputField(String fieldName);
 
-  /* @return find a nested field in the method's output type by the nested field's name. */
+  /* @return find a nested field in the method's output type by the nested field's name. Returns null if not found. */
   @Nullable
   FieldModel getOutputField(String fieldName);
 

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoveryMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoveryMethodTransformer.java
@@ -51,9 +51,7 @@ public class DiscoveryMethodTransformer implements InputSpecificMethodTransforme
   @Override
   public PageStreamingResponseView generatePageStreamingResponse(MethodModel methodModel) {
     DiscoveryMethodModel method = (DiscoveryMethodModel) methodModel;
-
-    // In the resulting gapic config, the resources_object must be a non-null value for the yaml to be parseable.
-    String resourcesName = "TODO";
+    String resourcesName = null;
     boolean hasNextPageToken = false;
 
     // Find the paged resource object from inside the response object.
@@ -81,9 +79,17 @@ public class DiscoveryMethodTransformer implements InputSpecificMethodTransforme
       return null;
     }
 
+    // In the resulting gapic config, the resources_object must be a non-null value for the yaml to be parseable.
+    String configResourcesName;
+    if (resourcesName == null) {
+      configResourcesName = MethodTransformer.TODO_STRING;
+    } else {
+      configResourcesName = Name.anyCamel(resourcesName).toLowerCamel();
+    }
+
     return PageStreamingResponseView.newBuilder()
         .tokenField(pagingParameters.getNameForNextPageToken())
-        .resourcesField(Name.anyCamel(resourcesName).toLowerCamel())
+        .resourcesField(configResourcesName)
         .build();
   }
 }

--- a/src/main/java/com/google/api/codegen/configgen/transformer/DiscoveryMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/DiscoveryMethodTransformer.java
@@ -51,7 +51,9 @@ public class DiscoveryMethodTransformer implements InputSpecificMethodTransforme
   @Override
   public PageStreamingResponseView generatePageStreamingResponse(MethodModel methodModel) {
     DiscoveryMethodModel method = (DiscoveryMethodModel) methodModel;
-    String resourcesName = null;
+
+    // In the resulting gapic config, the resources_object must be a non-null value for the yaml to be parseable.
+    String resourcesName = "TODO";
     boolean hasNextPageToken = false;
 
     // Find the paged resource object from inside the response object.

--- a/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/configgen/transformer/MethodTransformer.java
@@ -34,6 +34,9 @@ import java.util.Map;
 public class MethodTransformer {
   private final InputSpecificMethodTransformer helperTransformer;
 
+  // Used for empty config field values that require a non-null value in the yaml.
+  public static String TODO_STRING = "_TODO_";
+
   public MethodTransformer(InputSpecificMethodTransformer helperTransformer) {
     this.helperTransformer = helperTransformer;
   }


### PR DESCRIPTION
Currently, if no resources_object is found, configgen renders a null value for `page_streaming.resources_object`. This results in an unparsable gapic config yaml that throws hard-to-diagnose error messages when it is used to generate a GAPIC. 

If an obvious "TODO" is given as an alternative for an unknown page_streaming.resources_object, it is much easier to diagnose a failed GAPIC gen on the concrete string "TODO".

Context: the newest compute.v1.json has one paging resource object named "resources", which didn't follow the pattern of it being "items".