### PR TITLE
C# support for common resource names

### DIFF
--- a/src/main/java/com/google/api/codegen/config/AnyResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/AnyResourceNameConfig.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.config;
 
 import com.google.api.tools.framework.model.ProtoFile;
+import javax.annotation.Nullable;
 
 /**
  * AnyResourceNameConfig is a singleton configuration indicating acceptance of any resource name
@@ -47,6 +48,12 @@ public class AnyResourceNameConfig implements ResourceNameConfig {
   @Override
   public String getEntityName() {
     return ENTITY_NAME;
+  }
+
+  @Override
+  @Nullable
+  public String getCommonResourceName() {
+    return null;
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FixedResourceNameConfig.java
@@ -35,6 +35,12 @@ public abstract class FixedResourceNameConfig implements ResourceNameConfig {
   public abstract ProtoFile getAssignedProtoFile();
 
   @Override
+  @Nullable
+  public String getCommonResourceName() {
+    return null;
+  }
+
+  @Override
   public ResourceNameType getResourceNameType() {
     return ResourceNameType.FIXED;
   }

--- a/src/main/java/com/google/api/codegen/config/ResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameConfig.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.config;
 
 import com.google.api.tools.framework.model.ProtoFile;
+import javax.annotation.Nullable;
 
 public interface ResourceNameConfig {
 
@@ -23,6 +24,9 @@ public interface ResourceNameConfig {
 
   /** Returns the name used as a basis for generating methods. */
   String getEntityName();
+
+  @Nullable
+  String getCommonResourceName();
 
   /** Returns the resource name type. */
   ResourceNameType getResourceNameType();

--- a/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ResourceNameOneofConfig.java
@@ -38,6 +38,12 @@ public abstract class ResourceNameOneofConfig implements ResourceNameConfig {
   @Override
   public abstract ProtoFile getAssignedProtoFile();
 
+  @Override
+  @Nullable
+  public String getCommonResourceName() {
+    return null;
+  }
+
   public Iterable<SingleResourceNameConfig> getSingleResourceNameConfigs() {
     return Iterables.filter(getResourceNameConfigs(), SingleResourceNameConfig.class);
   }

--- a/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
+++ b/src/main/java/com/google/api/codegen/config/SingleResourceNameConfig.java
@@ -24,6 +24,7 @@ import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import javax.annotation.Nullable;
 
 /** SingleResourceNameConfig represents the collection configuration for a method. */
@@ -51,16 +52,22 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
     String entityId = collectionConfigProto.getEntityName();
     String entityName = entityId;
     String language = configProto.getLanguage();
+    String commonResourceName = null;
     if (language != null) {
       for (CollectionLanguageOverridesProto override :
           collectionConfigProto.getLanguageOverridesList()) {
         if (language.equals(override.getLanguage())) {
-          entityName = override.getEntityName();
+          if (!Strings.isNullOrEmpty(override.getEntityName())) {
+            entityName = override.getEntityName();
+          }
+          if (!Strings.isNullOrEmpty(override.getCommonResourceName())) {
+            commonResourceName = override.getCommonResourceName();
+          }
         }
       }
     }
     return new AutoValue_SingleResourceNameConfig(
-        namePattern, nameTemplate, entityId, entityName, file);
+        namePattern, nameTemplate, entityId, entityName, commonResourceName, file);
   }
 
   /** Returns the name pattern for the resource name config. */
@@ -76,6 +83,10 @@ public abstract class SingleResourceNameConfig implements ResourceNameConfig {
   /** Returns the name used as a basis for generating methods. */
   @Override
   public abstract String getEntityName();
+
+  @Override
+  @Nullable
+  public abstract String getCommonResourceName();
 
   @Override
   @Nullable

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -123,7 +123,8 @@ public class PathTemplateTransformer {
             .enumName(namer.getResourceEnumName(config))
             .docName(config.getEntityName())
             .index(index)
-            .pattern(config.getNamePattern());
+            .pattern(config.getNamePattern())
+            .commonResourceName(config.getCommonResourceName());
     List<ResourceNameParamView> params = new ArrayList<>();
     int varIndex = 0;
     for (String var : config.getNameTemplate().vars()) {

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -883,7 +883,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   public String getResourceTypeName(ResourceNameConfig resourceNameConfig) {
-    return publicClassName(getResourceTypeNameObject(resourceNameConfig));
+    String commonResourceName = resourceNameConfig.getCommonResourceName();
+    return commonResourceName != null
+        ? commonResourceName
+        : publicClassName(getResourceTypeNameObject(resourceNameConfig));
   }
 
   /**
@@ -1083,8 +1086,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The class name of the generated resource type from the entity name. */
   public String getAndSaveResourceTypeName(ImportTypeTable typeTable, FieldConfig fieldConfig) {
+    String commonResourceName = fieldConfig.getResourceNameConfig().getCommonResourceName();
     String resourceClassName =
-        publicClassName(getResourceTypeNameObject(fieldConfig.getResourceNameConfig()));
+        commonResourceName != null
+            ? commonResourceName
+            : publicClassName(getResourceTypeNameObject(fieldConfig.getResourceNameConfig()));
     return typeTable.getAndSaveNicknameForTypedResourceName(fieldConfig, resourceClassName);
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpModelTypeNameConverter.java
@@ -269,7 +269,8 @@ public class CSharpModelTypeNameConverter extends ModelTypeNameConverter {
 
   private TypeName getTypeNameForTypedResourceName(
       FieldConfig fieldConfig, TypeModel type, String typedResourceShortName) {
-    TypeName simpleTypeName = new TypeName(typedResourceShortName);
+    String nickName = typeNameConverter.getAndSaveNicknameFor(typedResourceShortName);
+    TypeName simpleTypeName = new TypeName(typedResourceShortName, nickName);
     if (type.isMap()) {
       throw new IllegalArgumentException("Map type not supported for typed resource name");
     } else if (type.isRepeated()) {

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -137,7 +137,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
     return keywords.contains(name) ? "@" + name : name;
   }
 
-  private CSharpAliasMode aliasMode;
+  private final CSharpAliasMode aliasMode;
 
   public CSharpSurfaceNamer(String packageName, CSharpAliasMode aliasMode) {
     this(packageName, aliasMode, new CSharpTypeTable(packageName, aliasMode));
@@ -634,10 +634,9 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
     FieldModel type = fieldConfig.getField();
     if (context.getFeatureConfig().useResourceNameFormatOption(fieldConfig)) {
       if (type.isRepeated()) {
-        TypeName elementTypeName =
-            new TypeName(
-                getResourceTypeNameObject(fieldConfig.getResourceNameConfig()).toUpperCamel());
         TypeNameConverter typeNameConverter = getTypeNameConverter();
+        TypeName elementTypeName =
+            typeNameConverter.getTypeName(getResourceTypeName(fieldConfig.getResourceNameConfig()));
         TypeName enumerableTypeName = typeNameConverter.getTypeName("System.Linq.Enumerable");
         TypeName emptyTypeName =
             new TypeName(

--- a/src/main/java/com/google/api/codegen/util/csharp/CSharpTypeTable.java
+++ b/src/main/java/com/google/api/codegen/util/csharp/CSharpTypeTable.java
@@ -34,6 +34,7 @@ public class CSharpTypeTable implements TypeTable {
       ImmutableMap.<String, String>builder()
           .put("Google.Api.Gax", "gax")
           .put("Google.Api.Gax.Grpc", "gaxgrpc")
+          .put("Google.Api.Gax.ResourceNames", "gaxres")
           .put("Google.Protobuf", "proto")
           .put("Google.Protobuf.WellKnownTypes", "protowkt")
           .put("Grpc.Core", "grpccore")

--- a/src/main/java/com/google/api/codegen/viewmodel/ResourceNameSingleView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ResourceNameSingleView.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.viewmodel;
 
 import com.google.auto.value.AutoValue;
 import java.util.List;
+import javax.annotation.Nullable;
 
 @AutoValue
 public abstract class ResourceNameSingleView implements ResourceNameView {
@@ -45,6 +46,9 @@ public abstract class ResourceNameSingleView implements ResourceNameView {
 
   public abstract String pattern();
 
+  @Nullable
+  public abstract String commonResourceName();
+
   public abstract List<ResourceNameParamView> params();
 
   public static Builder newBuilder() {
@@ -66,6 +70,8 @@ public abstract class ResourceNameSingleView implements ResourceNameView {
     public abstract Builder index(int val);
 
     public abstract Builder pattern(String val);
+
+    public abstract Builder commonResourceName(String val);
 
     public abstract Builder params(List<ResourceNameParamView> val);
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -217,6 +217,9 @@ message CollectionLanguageOverridesProto {
 
   // The entity name to override the default with
   string entity_name = 2;
+
+  // Optional fully-qualified type-name of a common resource-name
+  string common_resource_name = 3;
 }
 
 message CollectionOneofProto {

--- a/src/test/java/com/google/api/codegen/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp/csharp_library.baseline
@@ -119,6 +119,7 @@ namespace Google.Example.Library.V1.Snippets
 {
     using Google.Api.Gax;
     using Google.Api.Gax.Grpc;
+    using Google.Api.Gax.ResourceNames;
     using apis = Google.Example.Library.V1;
     using Google.LongRunning;
     using Google.Protobuf;
@@ -2550,8 +2551,8 @@ namespace Google.Example.Library.V1.Snippets
         /// <summary>Snippet for TestOptionalRequiredFlatteningParamsAsync</summary>
         public async Task TestOptionalRequiredFlatteningParamsAsync2()
         {
-            // Snippet: TestOptionalRequiredFlatteningParamsAsync(int,long,float,double,bool,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,int,long,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,int?,long?,float?,double?,bool?,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum?,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,int?,long?,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,CallSettings)
-            // Additional: TestOptionalRequiredFlatteningParamsAsync(int,long,float,double,bool,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,int,long,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,int?,long?,float?,double?,bool?,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum?,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,int?,long?,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,CancellationToken)
+            // Snippet: TestOptionalRequiredFlatteningParamsAsync(int,long,float,double,bool,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,ProjectName,int,long,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<ProjectName>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,int?,long?,float?,double?,bool?,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum?,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,ProjectName,int?,long?,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<ProjectName>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,CallSettings)
+            // Additional: TestOptionalRequiredFlatteningParamsAsync(int,long,float,double,bool,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,ProjectName,int,long,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<ProjectName>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,int?,long?,float?,double?,bool?,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum?,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,ProjectName,int?,long?,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<ProjectName>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,CancellationToken)
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
@@ -2566,6 +2567,7 @@ namespace Google.Example.Library.V1.Snippets
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
             IEnumerable<int> requiredRepeatedInt32 = new List<int>();
@@ -2579,6 +2581,7 @@ namespace Google.Example.Library.V1.Snippets
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> requiredRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> requiredRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> requiredRepeatedFixed32 = new List<int>();
             IEnumerable<long> requiredRepeatedFixed64 = new List<long>();
             IDictionary<int, string> requiredMap = new Dictionary<int, string>();
@@ -2593,6 +2596,7 @@ namespace Google.Example.Library.V1.Snippets
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
             IEnumerable<int> optionalRepeatedInt32 = new List<int>();
@@ -2606,18 +2610,19 @@ namespace Google.Example.Library.V1.Snippets
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> optionalRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> optionalRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> optionalRepeatedFixed32 = new List<int>();
             IEnumerable<long> optionalRepeatedFixed64 = new List<long>();
             IDictionary<int, string> optionalMap = new Dictionary<int, string>();
             // Make the request
-            TestOptionalRequiredFlatteningParamsResponse response = await libraryServiceClient.TestOptionalRequiredFlatteningParamsAsync(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+            TestOptionalRequiredFlatteningParamsResponse response = await libraryServiceClient.TestOptionalRequiredFlatteningParamsAsync(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
             // End snippet
         }
 
         /// <summary>Snippet for TestOptionalRequiredFlatteningParams</summary>
         public void TestOptionalRequiredFlatteningParams2()
         {
-            // Snippet: TestOptionalRequiredFlatteningParams(int,long,float,double,bool,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,int,long,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,int?,long?,float?,double?,bool?,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum?,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,int?,long?,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,CallSettings)
+            // Snippet: TestOptionalRequiredFlatteningParams(int,long,float,double,bool,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,ProjectName,int,long,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<ProjectName>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,int?,long?,float?,double?,bool?,TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum?,string,ByteString,TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage,BookName,BookNameOneof,ProjectName,int?,long?,IEnumerable<int>,IEnumerable<long>,IEnumerable<float>,IEnumerable<double>,IEnumerable<bool>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerEnum>,IEnumerable<string>,IEnumerable<ByteString>,IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>,IEnumerable<BookName>,IEnumerable<BookNameOneof>,IEnumerable<ProjectName>,IEnumerable<int>,IEnumerable<long>,IDictionary<int, string>,CallSettings)
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
@@ -2632,6 +2637,7 @@ namespace Google.Example.Library.V1.Snippets
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 0;
             long requiredSingularFixed64 = 0L;
             IEnumerable<int> requiredRepeatedInt32 = new List<int>();
@@ -2645,6 +2651,7 @@ namespace Google.Example.Library.V1.Snippets
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> requiredRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> requiredRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> requiredRepeatedFixed32 = new List<int>();
             IEnumerable<long> requiredRepeatedFixed64 = new List<long>();
             IDictionary<int, string> requiredMap = new Dictionary<int, string>();
@@ -2659,6 +2666,7 @@ namespace Google.Example.Library.V1.Snippets
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 0;
             long optionalSingularFixed64 = 0L;
             IEnumerable<int> optionalRepeatedInt32 = new List<int>();
@@ -2672,11 +2680,12 @@ namespace Google.Example.Library.V1.Snippets
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> optionalRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> optionalRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> optionalRepeatedFixed32 = new List<int>();
             IEnumerable<long> optionalRepeatedFixed64 = new List<long>();
             IDictionary<int, string> optionalMap = new Dictionary<int, string>();
             // Make the request
-            TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+            TestOptionalRequiredFlatteningParamsResponse response = libraryServiceClient.TestOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
             // End snippet
         }
 
@@ -2701,6 +2710,7 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
                 RequiredRepeatedInt32 = { },
@@ -2714,6 +2724,7 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredRepeatedMessage = { },
                 RequiredRepeatedResourceNameAsBookNames = { },
                 RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
                 RequiredRepeatedFixed32 = { },
                 RequiredRepeatedFixed64 = { },
                 RequiredMap = { },
@@ -2743,6 +2754,7 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 0,
                 RequiredSingularFixed64 = 0L,
                 RequiredRepeatedInt32 = { },
@@ -2756,6 +2768,7 @@ namespace Google.Example.Library.V1.Snippets
                 RequiredRepeatedMessage = { },
                 RequiredRepeatedResourceNameAsBookNames = { },
                 RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
                 RequiredRepeatedFixed32 = { },
                 RequiredRepeatedFixed64 = { },
                 RequiredMap = { },
@@ -2810,6 +2823,7 @@ namespace Google.Example.Library.V1.Tests
 {
     using Google.Api.Gax;
     using Google.Api.Gax.Grpc;
+    using Google.Api.Gax.ResourceNames;
     using Google.Cloud.Tagger.V1;
     using apis = Google.Example.Library.V1;
     using Google.LongRunning;
@@ -4836,6 +4850,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
                 RequiredRepeatedInt32 = { },
@@ -4849,6 +4864,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredRepeatedMessage = { },
                 RequiredRepeatedResourceNameAsBookNames = { },
                 RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
                 RequiredRepeatedFixed32 = { },
                 RequiredRepeatedFixed64 = { },
                 RequiredMap = { },
@@ -4863,6 +4879,7 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 OptionalSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                OptionalSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
                 OptionalRepeatedInt32 = { },
@@ -4876,6 +4893,7 @@ namespace Google.Example.Library.V1.Tests
                 OptionalRepeatedMessage = { },
                 OptionalRepeatedResourceNameAsBookNames = { },
                 OptionalRepeatedResourceNameOneofAsBookNameOneofs = { },
+                OptionalRepeatedResourceNameCommonAsProjectNames = { },
                 OptionalRepeatedFixed32 = { },
                 OptionalRepeatedFixed64 = { },
                 OptionalMap = { },
@@ -4895,6 +4913,7 @@ namespace Google.Example.Library.V1.Tests
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
             IEnumerable<int> requiredRepeatedInt32 = new List<int>();
@@ -4908,6 +4927,7 @@ namespace Google.Example.Library.V1.Tests
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> requiredRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> requiredRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> requiredRepeatedFixed32 = new List<int>();
             IEnumerable<long> requiredRepeatedFixed64 = new List<long>();
             IDictionary<int, string> requiredMap = new Dictionary<int, string>();
@@ -4922,6 +4942,7 @@ namespace Google.Example.Library.V1.Tests
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
             IEnumerable<int> optionalRepeatedInt32 = new List<int>();
@@ -4935,10 +4956,11 @@ namespace Google.Example.Library.V1.Tests
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> optionalRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> optionalRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> optionalRepeatedFixed32 = new List<int>();
             IEnumerable<long> optionalRepeatedFixed64 = new List<long>();
             IDictionary<int, string> optionalMap = new Dictionary<int, string>();
-            TestOptionalRequiredFlatteningParamsResponse response = client.TestOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+            TestOptionalRequiredFlatteningParamsResponse response = client.TestOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -4964,6 +4986,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
                 RequiredRepeatedInt32 = { },
@@ -4977,6 +5000,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredRepeatedMessage = { },
                 RequiredRepeatedResourceNameAsBookNames = { },
                 RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
                 RequiredRepeatedFixed32 = { },
                 RequiredRepeatedFixed64 = { },
                 RequiredMap = { },
@@ -4991,6 +5015,7 @@ namespace Google.Example.Library.V1.Tests
                 OptionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 OptionalSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 OptionalSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                OptionalSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 OptionalSingularFixed32 = 1648847958,
                 OptionalSingularFixed64 = 1648847863,
                 OptionalRepeatedInt32 = { },
@@ -5004,6 +5029,7 @@ namespace Google.Example.Library.V1.Tests
                 OptionalRepeatedMessage = { },
                 OptionalRepeatedResourceNameAsBookNames = { },
                 OptionalRepeatedResourceNameOneofAsBookNameOneofs = { },
+                OptionalRepeatedResourceNameCommonAsProjectNames = { },
                 OptionalRepeatedFixed32 = { },
                 OptionalRepeatedFixed64 = { },
                 OptionalMap = { },
@@ -5023,6 +5049,7 @@ namespace Google.Example.Library.V1.Tests
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName requiredSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof requiredSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName requiredSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int requiredSingularFixed32 = 720656715;
             long requiredSingularFixed64 = 720656810;
             IEnumerable<int> requiredRepeatedInt32 = new List<int>();
@@ -5036,6 +5063,7 @@ namespace Google.Example.Library.V1.Tests
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> requiredRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> requiredRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> requiredRepeatedFixed32 = new List<int>();
             IEnumerable<long> requiredRepeatedFixed64 = new List<long>();
             IDictionary<int, string> requiredMap = new Dictionary<int, string>();
@@ -5050,6 +5078,7 @@ namespace Google.Example.Library.V1.Tests
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage();
             BookName optionalSingularResourceName = new BookName("[SHELF_ID]", "[BOOK_ID]");
             BookNameOneof optionalSingularResourceNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]"));
+            ProjectName optionalSingularResourceNameCommon = new ProjectName("[PROJECT]");
             int optionalSingularFixed32 = 1648847958;
             long optionalSingularFixed64 = 1648847863;
             IEnumerable<int> optionalRepeatedInt32 = new List<int>();
@@ -5063,10 +5092,11 @@ namespace Google.Example.Library.V1.Tests
             IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage = new List<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>();
             IEnumerable<BookName> optionalRepeatedResourceName = new List<BookName>();
             IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof = new List<BookNameOneof>();
+            IEnumerable<ProjectName> optionalRepeatedResourceNameCommon = new List<ProjectName>();
             IEnumerable<int> optionalRepeatedFixed32 = new List<int>();
             IEnumerable<long> optionalRepeatedFixed64 = new List<long>();
             IDictionary<int, string> optionalMap = new Dictionary<int, string>();
-            TestOptionalRequiredFlatteningParamsResponse response = await client.TestOptionalRequiredFlatteningParamsAsync(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+            TestOptionalRequiredFlatteningParamsResponse response = await client.TestOptionalRequiredFlatteningParamsAsync(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
             Assert.Same(expectedResponse, response);
             mockGrpcClient.VerifyAll();
         }
@@ -5092,6 +5122,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
                 RequiredRepeatedInt32 = { },
@@ -5105,6 +5136,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredRepeatedMessage = { },
                 RequiredRepeatedResourceNameAsBookNames = { },
                 RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
                 RequiredRepeatedFixed32 = { },
                 RequiredRepeatedFixed64 = { },
                 RequiredMap = { },
@@ -5139,6 +5171,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage(),
                 RequiredSingularResourceNameAsBookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
                 RequiredSingularResourceNameOneofAsBookNameOneof = BookNameOneof.From(new BookName("[SHELF_ID]", "[BOOK_ID]")),
+                RequiredSingularResourceNameCommonAsProjectName = new ProjectName("[PROJECT]"),
                 RequiredSingularFixed32 = 720656715,
                 RequiredSingularFixed64 = 720656810,
                 RequiredRepeatedInt32 = { },
@@ -5152,6 +5185,7 @@ namespace Google.Example.Library.V1.Tests
                 RequiredRepeatedMessage = { },
                 RequiredRepeatedResourceNameAsBookNames = { },
                 RequiredRepeatedResourceNameOneofAsBookNameOneofs = { },
+                RequiredRepeatedResourceNameCommonAsProjectNames = { },
                 RequiredRepeatedFixed32 = { },
                 RequiredRepeatedFixed64 = { },
                 RequiredMap = { },
@@ -5237,6 +5271,7 @@ namespace Google.Example.Library.V1.Tests
 
 using gax = Google.Api.Gax;
 using gaxgrpc = Google.Api.Gax.Grpc;
+using gaxres = Google.Api.Gax.ResourceNames;
 using Google.Cloud.Tagger.V1;
 using lro = Google.LongRunning;
 using proto = Google.Protobuf;
@@ -9631,6 +9666,9 @@ namespace Google.Example.Library.V1
         /// <param name="requiredSingularResourceNameOneof">
         ///
         /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="requiredSingularFixed32">
         ///
         /// </param>
@@ -9668,6 +9706,9 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
         ///
         /// </param>
         /// <param name="requiredRepeatedFixed32">
@@ -9712,6 +9753,9 @@ namespace Google.Example.Library.V1
         /// <param name="optionalSingularResourceNameOneof">
         ///
         /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="optionalSingularFixed32">
         ///
         /// </param>
@@ -9751,6 +9795,9 @@ namespace Google.Example.Library.V1
         /// <param name="optionalRepeatedResourceNameOneof">
         ///
         /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="optionalRepeatedFixed32">
         ///
         /// </param>
@@ -9778,6 +9825,7 @@ namespace Google.Example.Library.V1
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
             BookName requiredSingularResourceName,
             BookNameOneof requiredSingularResourceNameOneof,
+            gaxres::ProjectName requiredSingularResourceNameCommon,
             int requiredSingularFixed32,
             long requiredSingularFixed64,
             scg::IEnumerable<int> requiredRepeatedInt32,
@@ -9791,6 +9839,7 @@ namespace Google.Example.Library.V1
             scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
             scg::IEnumerable<BookName> requiredRepeatedResourceName,
             scg::IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<gaxres::ProjectName> requiredRepeatedResourceNameCommon,
             scg::IEnumerable<int> requiredRepeatedFixed32,
             scg::IEnumerable<long> requiredRepeatedFixed64,
             scg::IDictionary<int, string> requiredMap,
@@ -9805,6 +9854,7 @@ namespace Google.Example.Library.V1
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
             BookName optionalSingularResourceName,
             BookNameOneof optionalSingularResourceNameOneof,
+            gaxres::ProjectName optionalSingularResourceNameCommon,
             int? optionalSingularFixed32,
             long? optionalSingularFixed64,
             scg::IEnumerable<int> optionalRepeatedInt32,
@@ -9818,6 +9868,7 @@ namespace Google.Example.Library.V1
             scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
             scg::IEnumerable<BookName> optionalRepeatedResourceName,
             scg::IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<gaxres::ProjectName> optionalRepeatedResourceNameCommon,
             scg::IEnumerable<int> optionalRepeatedFixed32,
             scg::IEnumerable<long> optionalRepeatedFixed64,
             scg::IDictionary<int, string> optionalMap,
@@ -9835,6 +9886,7 @@ namespace Google.Example.Library.V1
                     RequiredSingularMessage = gax::GaxPreconditions.CheckNotNull(requiredSingularMessage, nameof(requiredSingularMessage)),
                     RequiredSingularResourceNameAsBookName = gax::GaxPreconditions.CheckNotNull(requiredSingularResourceName, nameof(requiredSingularResourceName)),
                     RequiredSingularResourceNameOneofAsBookNameOneof = gax::GaxPreconditions.CheckNotNull(requiredSingularResourceNameOneof, nameof(requiredSingularResourceNameOneof)),
+                    RequiredSingularResourceNameCommonAsProjectName = gax::GaxPreconditions.CheckNotNull(requiredSingularResourceNameCommon, nameof(requiredSingularResourceNameCommon)),
                     RequiredSingularFixed32 = requiredSingularFixed32,
                     RequiredSingularFixed64 = requiredSingularFixed64,
                     RequiredRepeatedInt32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt32, nameof(requiredRepeatedInt32)) },
@@ -9848,6 +9900,7 @@ namespace Google.Example.Library.V1
                     RequiredRepeatedMessage = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedMessage, nameof(requiredRepeatedMessage)) },
                     RequiredRepeatedResourceNameAsBookNames = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceName, nameof(requiredRepeatedResourceName)) },
                     RequiredRepeatedResourceNameOneofAsBookNameOneofs = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameOneof, nameof(requiredRepeatedResourceNameOneof)) },
+                    RequiredRepeatedResourceNameCommonAsProjectNames = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameCommon, nameof(requiredRepeatedResourceNameCommon)) },
                     RequiredRepeatedFixed32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed32, nameof(requiredRepeatedFixed32)) },
                     RequiredRepeatedFixed64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed64, nameof(requiredRepeatedFixed64)) },
                     RequiredMap = { gax::GaxPreconditions.CheckNotNull(requiredMap, nameof(requiredMap)) },
@@ -9862,6 +9915,7 @@ namespace Google.Example.Library.V1
                     OptionalSingularMessage = optionalSingularMessage, // Optional
                     OptionalSingularResourceNameAsBookName = optionalSingularResourceName, // Optional
                     OptionalSingularResourceNameOneofAsBookNameOneof = optionalSingularResourceNameOneof, // Optional
+                    OptionalSingularResourceNameCommonAsProjectName = optionalSingularResourceNameCommon, // Optional
                     OptionalSingularFixed32 = optionalSingularFixed32 ?? 0, // Optional
                     OptionalSingularFixed64 = optionalSingularFixed64 ?? 0L, // Optional
                     OptionalRepeatedInt32 = { optionalRepeatedInt32 ?? Enumerable.Empty<int>() }, // Optional
@@ -9875,6 +9929,7 @@ namespace Google.Example.Library.V1
                     OptionalRepeatedMessage = { optionalRepeatedMessage ?? Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
                     OptionalRepeatedResourceNameAsBookNames = { optionalRepeatedResourceName ?? Enumerable.Empty<BookName>() }, // Optional
                     OptionalRepeatedResourceNameOneofAsBookNameOneofs = { optionalRepeatedResourceNameOneof ?? Enumerable.Empty<BookNameOneof>() }, // Optional
+                    OptionalRepeatedResourceNameCommonAsProjectNames = { optionalRepeatedResourceNameCommon ?? Enumerable.Empty<gaxres::ProjectName>() }, // Optional
                     OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? Enumerable.Empty<int>() }, // Optional
                     OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? Enumerable.Empty<long>() }, // Optional
                     OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
@@ -9917,6 +9972,9 @@ namespace Google.Example.Library.V1
         /// <param name="requiredSingularResourceNameOneof">
         ///
         /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="requiredSingularFixed32">
         ///
         /// </param>
@@ -9954,6 +10012,9 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
         ///
         /// </param>
         /// <param name="requiredRepeatedFixed32">
@@ -9998,6 +10059,9 @@ namespace Google.Example.Library.V1
         /// <param name="optionalSingularResourceNameOneof">
         ///
         /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="optionalSingularFixed32">
         ///
         /// </param>
@@ -10037,6 +10101,9 @@ namespace Google.Example.Library.V1
         /// <param name="optionalRepeatedResourceNameOneof">
         ///
         /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="optionalRepeatedFixed32">
         ///
         /// </param>
@@ -10064,6 +10131,7 @@ namespace Google.Example.Library.V1
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
             BookName requiredSingularResourceName,
             BookNameOneof requiredSingularResourceNameOneof,
+            gaxres::ProjectName requiredSingularResourceNameCommon,
             int requiredSingularFixed32,
             long requiredSingularFixed64,
             scg::IEnumerable<int> requiredRepeatedInt32,
@@ -10077,6 +10145,7 @@ namespace Google.Example.Library.V1
             scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
             scg::IEnumerable<BookName> requiredRepeatedResourceName,
             scg::IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<gaxres::ProjectName> requiredRepeatedResourceNameCommon,
             scg::IEnumerable<int> requiredRepeatedFixed32,
             scg::IEnumerable<long> requiredRepeatedFixed64,
             scg::IDictionary<int, string> requiredMap,
@@ -10091,6 +10160,7 @@ namespace Google.Example.Library.V1
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
             BookName optionalSingularResourceName,
             BookNameOneof optionalSingularResourceNameOneof,
+            gaxres::ProjectName optionalSingularResourceNameCommon,
             int? optionalSingularFixed32,
             long? optionalSingularFixed64,
             scg::IEnumerable<int> optionalRepeatedInt32,
@@ -10104,6 +10174,7 @@ namespace Google.Example.Library.V1
             scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
             scg::IEnumerable<BookName> optionalRepeatedResourceName,
             scg::IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<gaxres::ProjectName> optionalRepeatedResourceNameCommon,
             scg::IEnumerable<int> optionalRepeatedFixed32,
             scg::IEnumerable<long> optionalRepeatedFixed64,
             scg::IDictionary<int, string> optionalMap,
@@ -10119,6 +10190,7 @@ namespace Google.Example.Library.V1
                 requiredSingularMessage,
                 requiredSingularResourceName,
                 requiredSingularResourceNameOneof,
+                requiredSingularResourceNameCommon,
                 requiredSingularFixed32,
                 requiredSingularFixed64,
                 requiredRepeatedInt32,
@@ -10132,6 +10204,7 @@ namespace Google.Example.Library.V1
                 requiredRepeatedMessage,
                 requiredRepeatedResourceName,
                 requiredRepeatedResourceNameOneof,
+                requiredRepeatedResourceNameCommon,
                 requiredRepeatedFixed32,
                 requiredRepeatedFixed64,
                 requiredMap,
@@ -10146,6 +10219,7 @@ namespace Google.Example.Library.V1
                 optionalSingularMessage,
                 optionalSingularResourceName,
                 optionalSingularResourceNameOneof,
+                optionalSingularResourceNameCommon,
                 optionalSingularFixed32,
                 optionalSingularFixed64,
                 optionalRepeatedInt32,
@@ -10159,6 +10233,7 @@ namespace Google.Example.Library.V1
                 optionalRepeatedMessage,
                 optionalRepeatedResourceName,
                 optionalRepeatedResourceNameOneof,
+                optionalRepeatedResourceNameCommon,
                 optionalRepeatedFixed32,
                 optionalRepeatedFixed64,
                 optionalMap,
@@ -10200,6 +10275,9 @@ namespace Google.Example.Library.V1
         /// <param name="requiredSingularResourceNameOneof">
         ///
         /// </param>
+        /// <param name="requiredSingularResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="requiredSingularFixed32">
         ///
         /// </param>
@@ -10237,6 +10315,9 @@ namespace Google.Example.Library.V1
         ///
         /// </param>
         /// <param name="requiredRepeatedResourceNameOneof">
+        ///
+        /// </param>
+        /// <param name="requiredRepeatedResourceNameCommon">
         ///
         /// </param>
         /// <param name="requiredRepeatedFixed32">
@@ -10281,6 +10362,9 @@ namespace Google.Example.Library.V1
         /// <param name="optionalSingularResourceNameOneof">
         ///
         /// </param>
+        /// <param name="optionalSingularResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="optionalSingularFixed32">
         ///
         /// </param>
@@ -10320,6 +10404,9 @@ namespace Google.Example.Library.V1
         /// <param name="optionalRepeatedResourceNameOneof">
         ///
         /// </param>
+        /// <param name="optionalRepeatedResourceNameCommon">
+        ///
+        /// </param>
         /// <param name="optionalRepeatedFixed32">
         ///
         /// </param>
@@ -10347,6 +10434,7 @@ namespace Google.Example.Library.V1
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage requiredSingularMessage,
             BookName requiredSingularResourceName,
             BookNameOneof requiredSingularResourceNameOneof,
+            gaxres::ProjectName requiredSingularResourceNameCommon,
             int requiredSingularFixed32,
             long requiredSingularFixed64,
             scg::IEnumerable<int> requiredRepeatedInt32,
@@ -10360,6 +10448,7 @@ namespace Google.Example.Library.V1
             scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> requiredRepeatedMessage,
             scg::IEnumerable<BookName> requiredRepeatedResourceName,
             scg::IEnumerable<BookNameOneof> requiredRepeatedResourceNameOneof,
+            scg::IEnumerable<gaxres::ProjectName> requiredRepeatedResourceNameCommon,
             scg::IEnumerable<int> requiredRepeatedFixed32,
             scg::IEnumerable<long> requiredRepeatedFixed64,
             scg::IDictionary<int, string> requiredMap,
@@ -10374,6 +10463,7 @@ namespace Google.Example.Library.V1
             TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage optionalSingularMessage,
             BookName optionalSingularResourceName,
             BookNameOneof optionalSingularResourceNameOneof,
+            gaxres::ProjectName optionalSingularResourceNameCommon,
             int? optionalSingularFixed32,
             long? optionalSingularFixed64,
             scg::IEnumerable<int> optionalRepeatedInt32,
@@ -10387,6 +10477,7 @@ namespace Google.Example.Library.V1
             scg::IEnumerable<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage> optionalRepeatedMessage,
             scg::IEnumerable<BookName> optionalRepeatedResourceName,
             scg::IEnumerable<BookNameOneof> optionalRepeatedResourceNameOneof,
+            scg::IEnumerable<gaxres::ProjectName> optionalRepeatedResourceNameCommon,
             scg::IEnumerable<int> optionalRepeatedFixed32,
             scg::IEnumerable<long> optionalRepeatedFixed64,
             scg::IDictionary<int, string> optionalMap,
@@ -10404,6 +10495,7 @@ namespace Google.Example.Library.V1
                     RequiredSingularMessage = gax::GaxPreconditions.CheckNotNull(requiredSingularMessage, nameof(requiredSingularMessage)),
                     RequiredSingularResourceNameAsBookName = gax::GaxPreconditions.CheckNotNull(requiredSingularResourceName, nameof(requiredSingularResourceName)),
                     RequiredSingularResourceNameOneofAsBookNameOneof = gax::GaxPreconditions.CheckNotNull(requiredSingularResourceNameOneof, nameof(requiredSingularResourceNameOneof)),
+                    RequiredSingularResourceNameCommonAsProjectName = gax::GaxPreconditions.CheckNotNull(requiredSingularResourceNameCommon, nameof(requiredSingularResourceNameCommon)),
                     RequiredSingularFixed32 = requiredSingularFixed32,
                     RequiredSingularFixed64 = requiredSingularFixed64,
                     RequiredRepeatedInt32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedInt32, nameof(requiredRepeatedInt32)) },
@@ -10417,6 +10509,7 @@ namespace Google.Example.Library.V1
                     RequiredRepeatedMessage = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedMessage, nameof(requiredRepeatedMessage)) },
                     RequiredRepeatedResourceNameAsBookNames = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceName, nameof(requiredRepeatedResourceName)) },
                     RequiredRepeatedResourceNameOneofAsBookNameOneofs = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameOneof, nameof(requiredRepeatedResourceNameOneof)) },
+                    RequiredRepeatedResourceNameCommonAsProjectNames = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedResourceNameCommon, nameof(requiredRepeatedResourceNameCommon)) },
                     RequiredRepeatedFixed32 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed32, nameof(requiredRepeatedFixed32)) },
                     RequiredRepeatedFixed64 = { gax::GaxPreconditions.CheckNotNull(requiredRepeatedFixed64, nameof(requiredRepeatedFixed64)) },
                     RequiredMap = { gax::GaxPreconditions.CheckNotNull(requiredMap, nameof(requiredMap)) },
@@ -10431,6 +10524,7 @@ namespace Google.Example.Library.V1
                     OptionalSingularMessage = optionalSingularMessage, // Optional
                     OptionalSingularResourceNameAsBookName = optionalSingularResourceName, // Optional
                     OptionalSingularResourceNameOneofAsBookNameOneof = optionalSingularResourceNameOneof, // Optional
+                    OptionalSingularResourceNameCommonAsProjectName = optionalSingularResourceNameCommon, // Optional
                     OptionalSingularFixed32 = optionalSingularFixed32 ?? 0, // Optional
                     OptionalSingularFixed64 = optionalSingularFixed64 ?? 0L, // Optional
                     OptionalRepeatedInt32 = { optionalRepeatedInt32 ?? Enumerable.Empty<int>() }, // Optional
@@ -10444,6 +10538,7 @@ namespace Google.Example.Library.V1
                     OptionalRepeatedMessage = { optionalRepeatedMessage ?? Enumerable.Empty<TestOptionalRequiredFlatteningParamsRequest.Types.InnerMessage>() }, // Optional
                     OptionalRepeatedResourceNameAsBookNames = { optionalRepeatedResourceName ?? Enumerable.Empty<BookName>() }, // Optional
                     OptionalRepeatedResourceNameOneofAsBookNameOneofs = { optionalRepeatedResourceNameOneof ?? Enumerable.Empty<BookNameOneof>() }, // Optional
+                    OptionalRepeatedResourceNameCommonAsProjectNames = { optionalRepeatedResourceNameCommon ?? Enumerable.Empty<gaxres::ProjectName>() }, // Optional
                     OptionalRepeatedFixed32 = { optionalRepeatedFixed32 ?? Enumerable.Empty<int>() }, // Optional
                     OptionalRepeatedFixed64 = { optionalRepeatedFixed64 ?? Enumerable.Empty<long>() }, // Optional
                     OptionalMap = { optionalMap ?? gax::EmptyDictionary<int, string>.Instance }, // Optional
@@ -11981,6 +12076,7 @@ namespace Google.Example.Library.V1
 // Generated code. DO NOT EDIT!
 
 using gax = Google.Api.Gax;
+using gaxres = Google.Api.Gax.ResourceNames;
 using s = System;
 using scg = System.Collections.Generic;
 using System.Linq;
@@ -12671,7 +12767,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12684,7 +12780,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof BookNameOneof
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookNameOneof.Parse(Name, true); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12697,7 +12793,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ArchivedBookName ArchivedBookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ArchivedBookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ArchivedBookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12710,7 +12806,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12723,7 +12819,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12736,7 +12832,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12791,7 +12887,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof BookNameOneof
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookNameOneof.Parse(Name, true); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12800,7 +12896,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof AltBookNameAsBookNameOneof
         {
-            get { return string.IsNullOrEmpty(AltBookName) ? null : Google.Example.Library.V1.BookNameOneof.Parse(AltBookName, true); }
+            get { return string.IsNullOrEmpty(AltBookName) ? null : BookNameOneof.Parse(AltBookName, true); }
             set { AltBookName = value != null ? value.ToString() : ""; }
         }
 
@@ -12813,7 +12909,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ArchivedBookName ArchivedBookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ArchivedBookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ArchivedBookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12826,7 +12922,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12839,7 +12935,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12852,7 +12948,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12889,7 +12985,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12898,7 +12994,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName OtherShelfNameAsShelfName
         {
-            get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
+            get { return string.IsNullOrEmpty(OtherShelfName) ? null : ShelfName.Parse(OtherShelfName); }
             set { OtherShelfName = value != null ? value.ToString() : ""; }
         }
 
@@ -12911,7 +13007,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12920,7 +13016,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName OtherShelfNameAsShelfName
         {
-            get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
+            get { return string.IsNullOrEmpty(OtherShelfName) ? null : ShelfName.Parse(OtherShelfName); }
             set { OtherShelfName = value != null ? value.ToString() : ""; }
         }
 
@@ -12933,7 +13029,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12946,7 +13042,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName RequiredSingularResourceNameAsBookName
         {
-            get { return string.IsNullOrEmpty(RequiredSingularResourceName) ? null : Google.Example.Library.V1.BookName.Parse(RequiredSingularResourceName); }
+            get { return string.IsNullOrEmpty(RequiredSingularResourceName) ? null : BookName.Parse(RequiredSingularResourceName); }
             set { RequiredSingularResourceName = value != null ? value.ToString() : ""; }
         }
 
@@ -12955,8 +13051,17 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof RequiredSingularResourceNameOneofAsBookNameOneof
         {
-            get { return string.IsNullOrEmpty(RequiredSingularResourceNameOneof) ? null : Google.Example.Library.V1.BookNameOneof.Parse(RequiredSingularResourceNameOneof, true); }
+            get { return string.IsNullOrEmpty(RequiredSingularResourceNameOneof) ? null : BookNameOneof.Parse(RequiredSingularResourceNameOneof, true); }
             set { RequiredSingularResourceNameOneof = value != null ? value.ToString() : ""; }
+        }
+
+        /// <summary>
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="RequiredSingularResourceNameCommon"/> resource name property.
+        /// </summary>
+        public gaxres::ProjectName RequiredSingularResourceNameCommonAsProjectName
+        {
+            get { return string.IsNullOrEmpty(RequiredSingularResourceNameCommon) ? null : gaxres::ProjectName.Parse(RequiredSingularResourceNameCommon); }
+            set { RequiredSingularResourceNameCommon = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
@@ -12974,11 +13079,18 @@ namespace Google.Example.Library.V1
                 str => BookNameOneof.Parse(str, true));
 
         /// <summary>
+        /// <see cref="gax::ResourceNameList{gaxres::ProjectName}"/>-typed view over the <see cref="RequiredRepeatedResourceNameCommon"/> resource name property.
+        /// </summary>
+        public gax::ResourceNameList<gaxres::ProjectName> RequiredRepeatedResourceNameCommonAsProjectNames =>
+            new gax::ResourceNameList<gaxres::ProjectName>(RequiredRepeatedResourceNameCommon,
+                str => gaxres::ProjectName.Parse(str));
+
+        /// <summary>
         /// <see cref="BookName"/>-typed view over the <see cref="OptionalSingularResourceName"/> resource name property.
         /// </summary>
         public BookName OptionalSingularResourceNameAsBookName
         {
-            get { return string.IsNullOrEmpty(OptionalSingularResourceName) ? null : Google.Example.Library.V1.BookName.Parse(OptionalSingularResourceName); }
+            get { return string.IsNullOrEmpty(OptionalSingularResourceName) ? null : BookName.Parse(OptionalSingularResourceName); }
             set { OptionalSingularResourceName = value != null ? value.ToString() : ""; }
         }
 
@@ -12987,8 +13099,17 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof OptionalSingularResourceNameOneofAsBookNameOneof
         {
-            get { return string.IsNullOrEmpty(OptionalSingularResourceNameOneof) ? null : Google.Example.Library.V1.BookNameOneof.Parse(OptionalSingularResourceNameOneof, true); }
+            get { return string.IsNullOrEmpty(OptionalSingularResourceNameOneof) ? null : BookNameOneof.Parse(OptionalSingularResourceNameOneof, true); }
             set { OptionalSingularResourceNameOneof = value != null ? value.ToString() : ""; }
+        }
+
+        /// <summary>
+        /// <see cref="gaxres::ProjectName"/>-typed view over the <see cref="OptionalSingularResourceNameCommon"/> resource name property.
+        /// </summary>
+        public gaxres::ProjectName OptionalSingularResourceNameCommonAsProjectName
+        {
+            get { return string.IsNullOrEmpty(OptionalSingularResourceNameCommon) ? null : gaxres::ProjectName.Parse(OptionalSingularResourceNameCommon); }
+            set { OptionalSingularResourceNameCommon = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
@@ -13005,6 +13126,13 @@ namespace Google.Example.Library.V1
             new gax::ResourceNameList<BookNameOneof>(OptionalRepeatedResourceNameOneof,
                 str => BookNameOneof.Parse(str, true));
 
+        /// <summary>
+        /// <see cref="gax::ResourceNameList{gaxres::ProjectName}"/>-typed view over the <see cref="OptionalRepeatedResourceNameCommon"/> resource name property.
+        /// </summary>
+        public gax::ResourceNameList<gaxres::ProjectName> OptionalRepeatedResourceNameCommonAsProjectNames =>
+            new gax::ResourceNameList<gaxres::ProjectName>(OptionalRepeatedResourceNameCommon,
+                str => gaxres::ProjectName.Parse(str));
+
     }
 
     public partial class UpdateBookIndexRequest
@@ -13014,7 +13142,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -13027,7 +13155,7 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 

--- a/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go/go_library.baseline
@@ -3985,6 +3985,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
     var requiredSingularResourceName string = "requiredSingularResourceName-1701575020"
     var requiredSingularResourceNameOneof string = "requiredSingularResourceNameOneof-25303726"
+    var requiredSingularResourceNameCommon string = "requiredSingularResourceNameCommon-1126805002"
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
     var requiredRepeatedInt32 []int32 = nil
@@ -3998,6 +3999,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
     var requiredRepeatedMessage []*librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = nil
     var formattedRequiredRepeatedResourceName []string = nil
     var formattedRequiredRepeatedResourceNameOneof []string = nil
+    var requiredRepeatedResourceNameCommon []string = nil
     var requiredRepeatedFixed32 []int32 = nil
     var requiredRepeatedFixed64 []int64 = nil
     var requiredMap map[int32]string = nil
@@ -4013,6 +4015,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
         RequiredSingularMessage: requiredSingularMessage,
         RequiredSingularResourceName: requiredSingularResourceName,
         RequiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+        RequiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
         RequiredSingularFixed32: requiredSingularFixed32,
         RequiredSingularFixed64: requiredSingularFixed64,
         RequiredRepeatedInt32: requiredRepeatedInt32,
@@ -4026,6 +4029,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParams(t *testing.T) {
         RequiredRepeatedMessage: requiredRepeatedMessage,
         RequiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
         RequiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+        RequiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
         RequiredRepeatedFixed32: requiredRepeatedFixed32,
         RequiredRepeatedFixed64: requiredRepeatedFixed64,
         RequiredMap: requiredMap,
@@ -4066,6 +4070,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     var requiredSingularMessage *librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = &librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage{}
     var requiredSingularResourceName string = "requiredSingularResourceName-1701575020"
     var requiredSingularResourceNameOneof string = "requiredSingularResourceNameOneof-25303726"
+    var requiredSingularResourceNameCommon string = "requiredSingularResourceNameCommon-1126805002"
     var requiredSingularFixed32 int32 = 720656715
     var requiredSingularFixed64 int64 = 720656810
     var requiredRepeatedInt32 []int32 = nil
@@ -4079,6 +4084,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
     var requiredRepeatedMessage []*librarypb.TestOptionalRequiredFlatteningParamsRequest_InnerMessage = nil
     var formattedRequiredRepeatedResourceName []string = nil
     var formattedRequiredRepeatedResourceNameOneof []string = nil
+    var requiredRepeatedResourceNameCommon []string = nil
     var requiredRepeatedFixed32 []int32 = nil
     var requiredRepeatedFixed64 []int64 = nil
     var requiredMap map[int32]string = nil
@@ -4094,6 +4100,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
         RequiredSingularMessage: requiredSingularMessage,
         RequiredSingularResourceName: requiredSingularResourceName,
         RequiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+        RequiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
         RequiredSingularFixed32: requiredSingularFixed32,
         RequiredSingularFixed64: requiredSingularFixed64,
         RequiredRepeatedInt32: requiredRepeatedInt32,
@@ -4107,6 +4114,7 @@ func TestLibraryServiceTestOptionalRequiredFlatteningParamsError(t *testing.T) {
         RequiredRepeatedMessage: requiredRepeatedMessage,
         RequiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
         RequiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+        RequiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
         RequiredRepeatedFixed32: requiredRepeatedFixed32,
         RequiredRepeatedFixed64: requiredRepeatedFixed64,
         RequiredMap: requiredMap,

--- a/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java/java_library.baseline
@@ -129,6 +129,7 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -2954,6 +2955,7 @@ public class LibraryClient implements BackgroundResource {
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
    *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
    *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
    *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
@@ -2967,6 +2969,7 @@ public class LibraryClient implements BackgroundResource {
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
    *   List&lt;ShelfBookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
    *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
    *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
@@ -2981,6 +2984,7 @@ public class LibraryClient implements BackgroundResource {
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
    *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
    *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
    *   List&lt;Integer&gt; optionalRepeatedInt32 = new ArrayList&lt;&gt;();
@@ -2994,10 +2998,11 @@ public class LibraryClient implements BackgroundResource {
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; optionalRepeatedMessage = new ArrayList&lt;&gt;();
    *   List&lt;ShelfBookName&gt; optionalRepeatedResourceName = new ArrayList&lt;&gt;();
    *   List&lt;BookName&gt; optionalRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; optionalRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; optionalRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; optionalRepeatedFixed64 = new ArrayList&lt;&gt;();
    *   Map&lt;Integer, String&gt; optionalMap = new HashMap&lt;&gt;();
-   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
    * }
    * </code></pre>
    *
@@ -3012,6 +3017,7 @@ public class LibraryClient implements BackgroundResource {
    * @param requiredSingularMessage
    * @param requiredSingularResourceName
    * @param requiredSingularResourceNameOneof
+   * @param requiredSingularResourceNameCommon
    * @param requiredSingularFixed32
    * @param requiredSingularFixed64
    * @param requiredRepeatedInt32
@@ -3025,6 +3031,7 @@ public class LibraryClient implements BackgroundResource {
    * @param requiredRepeatedMessage
    * @param requiredRepeatedResourceName
    * @param requiredRepeatedResourceNameOneof
+   * @param requiredRepeatedResourceNameCommon
    * @param requiredRepeatedFixed32
    * @param requiredRepeatedFixed64
    * @param requiredMap
@@ -3039,6 +3046,7 @@ public class LibraryClient implements BackgroundResource {
    * @param optionalSingularMessage
    * @param optionalSingularResourceName
    * @param optionalSingularResourceNameOneof
+   * @param optionalSingularResourceNameCommon
    * @param optionalSingularFixed32
    * @param optionalSingularFixed64
    * @param optionalRepeatedInt32
@@ -3052,12 +3060,13 @@ public class LibraryClient implements BackgroundResource {
    * @param optionalRepeatedMessage
    * @param optionalRepeatedResourceName
    * @param optionalRepeatedResourceNameOneof
+   * @param optionalRepeatedResourceNameCommon
    * @param optionalRepeatedFixed32
    * @param optionalRepeatedFixed64
    * @param optionalMap
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, ShelfBookName requiredSingularResourceName, BookName requiredSingularResourceNameOneof, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<ShelfBookName> requiredRepeatedResourceName, List<BookName> requiredRepeatedResourceNameOneof, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, ShelfBookName optionalSingularResourceName, BookName optionalSingularResourceNameOneof, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<ShelfBookName> optionalRepeatedResourceName, List<BookName> optionalRepeatedResourceNameOneof, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap) {
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, ShelfBookName requiredSingularResourceName, BookName requiredSingularResourceNameOneof, ProjectName requiredSingularResourceNameCommon, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<ShelfBookName> requiredRepeatedResourceName, List<BookName> requiredRepeatedResourceNameOneof, List<ProjectName> requiredRepeatedResourceNameCommon, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, ShelfBookName optionalSingularResourceName, BookName optionalSingularResourceNameOneof, ProjectName optionalSingularResourceNameCommon, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<ShelfBookName> optionalRepeatedResourceName, List<BookName> optionalRepeatedResourceNameOneof, List<ProjectName> optionalRepeatedResourceNameCommon, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap) {
 
     TestOptionalRequiredFlatteningParamsRequest request =
         TestOptionalRequiredFlatteningParamsRequest.newBuilder()
@@ -3072,6 +3081,7 @@ public class LibraryClient implements BackgroundResource {
         .setRequiredSingularMessage(requiredSingularMessage)
         .setRequiredSingularResourceName(requiredSingularResourceName == null ? null : requiredSingularResourceName.toString())
         .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof == null ? null : requiredSingularResourceNameOneof.toString())
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon == null ? null : requiredSingularResourceNameCommon.toString())
         .setRequiredSingularFixed32(requiredSingularFixed32)
         .setRequiredSingularFixed64(requiredSingularFixed64)
         .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
@@ -3085,6 +3095,7 @@ public class LibraryClient implements BackgroundResource {
         .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
         .addAllRequiredRepeatedResourceName(requiredRepeatedResourceName == null ? null : ShelfBookName.toStringList(requiredRepeatedResourceName))
         .addAllRequiredRepeatedResourceNameOneof(requiredRepeatedResourceNameOneof == null ? null : BookName.toStringList(requiredRepeatedResourceNameOneof))
+        .addAllRequiredRepeatedResourceNameCommon(requiredRepeatedResourceNameCommon == null ? null : ProjectName.toStringList(requiredRepeatedResourceNameCommon))
         .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
         .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
         .putAllRequiredMap(requiredMap)
@@ -3099,6 +3110,7 @@ public class LibraryClient implements BackgroundResource {
         .setOptionalSingularMessage(optionalSingularMessage)
         .setOptionalSingularResourceName(optionalSingularResourceName == null ? null : optionalSingularResourceName.toString())
         .setOptionalSingularResourceNameOneof(optionalSingularResourceNameOneof == null ? null : optionalSingularResourceNameOneof.toString())
+        .setOptionalSingularResourceNameCommon(optionalSingularResourceNameCommon == null ? null : optionalSingularResourceNameCommon.toString())
         .setOptionalSingularFixed32(optionalSingularFixed32)
         .setOptionalSingularFixed64(optionalSingularFixed64)
         .addAllOptionalRepeatedInt32(optionalRepeatedInt32)
@@ -3112,6 +3124,7 @@ public class LibraryClient implements BackgroundResource {
         .addAllOptionalRepeatedMessage(optionalRepeatedMessage)
         .addAllOptionalRepeatedResourceName(optionalRepeatedResourceName == null ? null : ShelfBookName.toStringList(optionalRepeatedResourceName))
         .addAllOptionalRepeatedResourceNameOneof(optionalRepeatedResourceNameOneof == null ? null : BookName.toStringList(optionalRepeatedResourceNameOneof))
+        .addAllOptionalRepeatedResourceNameCommon(optionalRepeatedResourceNameCommon == null ? null : ProjectName.toStringList(optionalRepeatedResourceNameCommon))
         .addAllOptionalRepeatedFixed32(optionalRepeatedFixed32)
         .addAllOptionalRepeatedFixed64(optionalRepeatedFixed64)
         .putAllOptionalMap(optionalMap)
@@ -3137,6 +3150,7 @@ public class LibraryClient implements BackgroundResource {
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
    *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
    *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
    *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
@@ -3150,6 +3164,7 @@ public class LibraryClient implements BackgroundResource {
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
    *   List&lt;ShelfBookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
    *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
    *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
@@ -3164,6 +3179,7 @@ public class LibraryClient implements BackgroundResource {
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
    *   ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
    *   BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int optionalSingularFixed32 = 0;
    *   long optionalSingularFixed64 = 0L;
    *   List&lt;Integer&gt; optionalRepeatedInt32 = new ArrayList&lt;&gt;();
@@ -3177,10 +3193,11 @@ public class LibraryClient implements BackgroundResource {
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; optionalRepeatedMessage = new ArrayList&lt;&gt;();
    *   List&lt;ShelfBookName&gt; optionalRepeatedResourceName = new ArrayList&lt;&gt;();
    *   List&lt;BookName&gt; optionalRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; optionalRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; optionalRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; optionalRepeatedFixed64 = new ArrayList&lt;&gt;();
    *   Map&lt;Integer, String&gt; optionalMap = new HashMap&lt;&gt;();
-   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName.toString(), requiredSingularResourceNameOneof.toString(), requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, ShelfBookName.toStringList(requiredRepeatedResourceName), BookName.toStringList(requiredRepeatedResourceNameOneof), requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName.toString(), optionalSingularResourceNameOneof.toString(), optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, ShelfBookName.toStringList(optionalRepeatedResourceName), BookName.toStringList(optionalRepeatedResourceNameOneof), optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+   *   TestOptionalRequiredFlatteningParamsResponse response = libraryClient.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName.toString(), requiredSingularResourceNameOneof.toString(), requiredSingularResourceNameCommon.toString(), requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, ShelfBookName.toStringList(requiredRepeatedResourceName), BookName.toStringList(requiredRepeatedResourceNameOneof), ProjectName.toStringList(requiredRepeatedResourceNameCommon), requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName.toString(), optionalSingularResourceNameOneof.toString(), optionalSingularResourceNameCommon.toString(), optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, ShelfBookName.toStringList(optionalRepeatedResourceName), BookName.toStringList(optionalRepeatedResourceNameOneof), ProjectName.toStringList(optionalRepeatedResourceNameCommon), optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
    * }
    * </code></pre>
    *
@@ -3195,6 +3212,7 @@ public class LibraryClient implements BackgroundResource {
    * @param requiredSingularMessage
    * @param requiredSingularResourceName
    * @param requiredSingularResourceNameOneof
+   * @param requiredSingularResourceNameCommon
    * @param requiredSingularFixed32
    * @param requiredSingularFixed64
    * @param requiredRepeatedInt32
@@ -3208,6 +3226,7 @@ public class LibraryClient implements BackgroundResource {
    * @param requiredRepeatedMessage
    * @param requiredRepeatedResourceName
    * @param requiredRepeatedResourceNameOneof
+   * @param requiredRepeatedResourceNameCommon
    * @param requiredRepeatedFixed32
    * @param requiredRepeatedFixed64
    * @param requiredMap
@@ -3222,6 +3241,7 @@ public class LibraryClient implements BackgroundResource {
    * @param optionalSingularMessage
    * @param optionalSingularResourceName
    * @param optionalSingularResourceNameOneof
+   * @param optionalSingularResourceNameCommon
    * @param optionalSingularFixed32
    * @param optionalSingularFixed64
    * @param optionalRepeatedInt32
@@ -3235,12 +3255,13 @@ public class LibraryClient implements BackgroundResource {
    * @param optionalRepeatedMessage
    * @param optionalRepeatedResourceName
    * @param optionalRepeatedResourceNameOneof
+   * @param optionalRepeatedResourceNameCommon
    * @param optionalRepeatedFixed32
    * @param optionalRepeatedFixed64
    * @param optionalMap
    * @throws com.google.api.gax.rpc.ApiException if the remote call fails
    */
-  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, String requiredSingularResourceName, String requiredSingularResourceNameOneof, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<String> requiredRepeatedResourceName, List<String> requiredRepeatedResourceNameOneof, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, String optionalSingularResourceName, String optionalSingularResourceNameOneof, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<String> optionalRepeatedResourceName, List<String> optionalRepeatedResourceNameOneof, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap) {
+  public final TestOptionalRequiredFlatteningParamsResponse testOptionalRequiredFlatteningParams(int requiredSingularInt32, long requiredSingularInt64, float requiredSingularFloat, double requiredSingularDouble, boolean requiredSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum requiredSingularEnum, String requiredSingularString, ByteString requiredSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage, String requiredSingularResourceName, String requiredSingularResourceNameOneof, String requiredSingularResourceNameCommon, int requiredSingularFixed32, long requiredSingularFixed64, List<Integer> requiredRepeatedInt32, List<Long> requiredRepeatedInt64, List<Float> requiredRepeatedFloat, List<Double> requiredRepeatedDouble, List<Boolean> requiredRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> requiredRepeatedEnum, List<String> requiredRepeatedString, List<ByteString> requiredRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage, List<String> requiredRepeatedResourceName, List<String> requiredRepeatedResourceNameOneof, List<String> requiredRepeatedResourceNameCommon, List<Integer> requiredRepeatedFixed32, List<Long> requiredRepeatedFixed64, Map<Integer, String> requiredMap, int optionalSingularInt32, long optionalSingularInt64, float optionalSingularFloat, double optionalSingularDouble, boolean optionalSingularBool, TestOptionalRequiredFlatteningParamsRequest.InnerEnum optionalSingularEnum, String optionalSingularString, ByteString optionalSingularBytes, TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage, String optionalSingularResourceName, String optionalSingularResourceNameOneof, String optionalSingularResourceNameCommon, int optionalSingularFixed32, long optionalSingularFixed64, List<Integer> optionalRepeatedInt32, List<Long> optionalRepeatedInt64, List<Float> optionalRepeatedFloat, List<Double> optionalRepeatedDouble, List<Boolean> optionalRepeatedBool, List<TestOptionalRequiredFlatteningParamsRequest.InnerEnum> optionalRepeatedEnum, List<String> optionalRepeatedString, List<ByteString> optionalRepeatedBytes, List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage, List<String> optionalRepeatedResourceName, List<String> optionalRepeatedResourceNameOneof, List<String> optionalRepeatedResourceNameCommon, List<Integer> optionalRepeatedFixed32, List<Long> optionalRepeatedFixed64, Map<Integer, String> optionalMap) {
 
     TestOptionalRequiredFlatteningParamsRequest request =
         TestOptionalRequiredFlatteningParamsRequest.newBuilder()
@@ -3255,6 +3276,7 @@ public class LibraryClient implements BackgroundResource {
         .setRequiredSingularMessage(requiredSingularMessage)
         .setRequiredSingularResourceName(requiredSingularResourceName)
         .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof)
+        .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon)
         .setRequiredSingularFixed32(requiredSingularFixed32)
         .setRequiredSingularFixed64(requiredSingularFixed64)
         .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
@@ -3268,6 +3290,7 @@ public class LibraryClient implements BackgroundResource {
         .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
         .addAllRequiredRepeatedResourceName(requiredRepeatedResourceName)
         .addAllRequiredRepeatedResourceNameOneof(requiredRepeatedResourceNameOneof)
+        .addAllRequiredRepeatedResourceNameCommon(requiredRepeatedResourceNameCommon)
         .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
         .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
         .putAllRequiredMap(requiredMap)
@@ -3282,6 +3305,7 @@ public class LibraryClient implements BackgroundResource {
         .setOptionalSingularMessage(optionalSingularMessage)
         .setOptionalSingularResourceName(optionalSingularResourceName)
         .setOptionalSingularResourceNameOneof(optionalSingularResourceNameOneof)
+        .setOptionalSingularResourceNameCommon(optionalSingularResourceNameCommon)
         .setOptionalSingularFixed32(optionalSingularFixed32)
         .setOptionalSingularFixed64(optionalSingularFixed64)
         .addAllOptionalRepeatedInt32(optionalRepeatedInt32)
@@ -3295,6 +3319,7 @@ public class LibraryClient implements BackgroundResource {
         .addAllOptionalRepeatedMessage(optionalRepeatedMessage)
         .addAllOptionalRepeatedResourceName(optionalRepeatedResourceName)
         .addAllOptionalRepeatedResourceNameOneof(optionalRepeatedResourceNameOneof)
+        .addAllOptionalRepeatedResourceNameCommon(optionalRepeatedResourceNameCommon)
         .addAllOptionalRepeatedFixed32(optionalRepeatedFixed32)
         .addAllOptionalRepeatedFixed64(optionalRepeatedFixed64)
         .putAllOptionalMap(optionalMap)
@@ -3320,6 +3345,7 @@ public class LibraryClient implements BackgroundResource {
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
    *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
    *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
    *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
@@ -3333,6 +3359,7 @@ public class LibraryClient implements BackgroundResource {
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
    *   List&lt;ShelfBookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
    *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
    *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
@@ -3348,6 +3375,7 @@ public class LibraryClient implements BackgroundResource {
    *     .setRequiredSingularMessage(requiredSingularMessage)
    *     .setRequiredSingularResourceName(requiredSingularResourceName.toString())
    *     .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof.toString())
+   *     .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon.toString())
    *     .setRequiredSingularFixed32(requiredSingularFixed32)
    *     .setRequiredSingularFixed64(requiredSingularFixed64)
    *     .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
@@ -3361,6 +3389,7 @@ public class LibraryClient implements BackgroundResource {
    *     .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
    *     .addAllRequiredRepeatedResourceName(ShelfBookName.toStringList(requiredRepeatedResourceName))
    *     .addAllRequiredRepeatedResourceNameOneof(BookName.toStringList(requiredRepeatedResourceNameOneof))
+   *     .addAllRequiredRepeatedResourceNameCommon(ProjectName.toStringList(requiredRepeatedResourceNameCommon))
    *     .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
    *     .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
    *     .putAllRequiredMap(requiredMap)
@@ -3394,6 +3423,7 @@ public class LibraryClient implements BackgroundResource {
    *   TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
    *   ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
    *   BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+   *   ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
    *   int requiredSingularFixed32 = 0;
    *   long requiredSingularFixed64 = 0L;
    *   List&lt;Integer&gt; requiredRepeatedInt32 = new ArrayList&lt;&gt;();
@@ -3407,6 +3437,7 @@ public class LibraryClient implements BackgroundResource {
    *   List&lt;TestOptionalRequiredFlatteningParamsRequest.InnerMessage&gt; requiredRepeatedMessage = new ArrayList&lt;&gt;();
    *   List&lt;ShelfBookName&gt; requiredRepeatedResourceName = new ArrayList&lt;&gt;();
    *   List&lt;BookName&gt; requiredRepeatedResourceNameOneof = new ArrayList&lt;&gt;();
+   *   List&lt;ProjectName&gt; requiredRepeatedResourceNameCommon = new ArrayList&lt;&gt;();
    *   List&lt;Integer&gt; requiredRepeatedFixed32 = new ArrayList&lt;&gt;();
    *   List&lt;Long&gt; requiredRepeatedFixed64 = new ArrayList&lt;&gt;();
    *   Map&lt;Integer, String&gt; requiredMap = new HashMap&lt;&gt;();
@@ -3422,6 +3453,7 @@ public class LibraryClient implements BackgroundResource {
    *     .setRequiredSingularMessage(requiredSingularMessage)
    *     .setRequiredSingularResourceName(requiredSingularResourceName.toString())
    *     .setRequiredSingularResourceNameOneof(requiredSingularResourceNameOneof.toString())
+   *     .setRequiredSingularResourceNameCommon(requiredSingularResourceNameCommon.toString())
    *     .setRequiredSingularFixed32(requiredSingularFixed32)
    *     .setRequiredSingularFixed64(requiredSingularFixed64)
    *     .addAllRequiredRepeatedInt32(requiredRepeatedInt32)
@@ -3435,6 +3467,7 @@ public class LibraryClient implements BackgroundResource {
    *     .addAllRequiredRepeatedMessage(requiredRepeatedMessage)
    *     .addAllRequiredRepeatedResourceName(ShelfBookName.toStringList(requiredRepeatedResourceName))
    *     .addAllRequiredRepeatedResourceNameOneof(BookName.toStringList(requiredRepeatedResourceNameOneof))
+   *     .addAllRequiredRepeatedResourceNameCommon(ProjectName.toStringList(requiredRepeatedResourceNameCommon))
    *     .addAllRequiredRepeatedFixed32(requiredRepeatedFixed32)
    *     .addAllRequiredRepeatedFixed64(requiredRepeatedFixed64)
    *     .putAllRequiredMap(requiredMap)
@@ -4709,6 +4742,7 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -4875,6 +4909,7 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -5581,6 +5616,7 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -7296,6 +7332,7 @@ import com.google.example.library.v1.ListStringsRequest;
 import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.ProjectName;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.SeriesUuid;
@@ -8923,6 +8960,7 @@ public class LibraryClientTest {
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
     ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
     int requiredSingularFixed32 = 720656715;
     long requiredSingularFixed64 = 720656810;
     List<Integer> requiredRepeatedInt32 = new ArrayList<>();
@@ -8936,6 +8974,7 @@ public class LibraryClientTest {
     List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
     List<ShelfBookName> requiredRepeatedResourceName = new ArrayList<>();
     List<BookName> requiredRepeatedResourceNameOneof = new ArrayList<>();
+    List<ProjectName> requiredRepeatedResourceNameCommon = new ArrayList<>();
     List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
     List<Long> requiredRepeatedFixed64 = new ArrayList<>();
     Map<Integer, String> requiredMap = new HashMap<>();
@@ -8950,6 +8989,7 @@ public class LibraryClientTest {
     TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
     ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
     BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+    ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
     int optionalSingularFixed32 = 1648847958;
     long optionalSingularFixed64 = 1648847863;
     List<Integer> optionalRepeatedInt32 = new ArrayList<>();
@@ -8963,12 +9003,13 @@ public class LibraryClientTest {
     List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage = new ArrayList<>();
     List<ShelfBookName> optionalRepeatedResourceName = new ArrayList<>();
     List<BookName> optionalRepeatedResourceNameOneof = new ArrayList<>();
+    List<ProjectName> optionalRepeatedResourceNameCommon = new ArrayList<>();
     List<Integer> optionalRepeatedFixed32 = new ArrayList<>();
     List<Long> optionalRepeatedFixed64 = new ArrayList<>();
     Map<Integer, String> optionalMap = new HashMap<>();
 
     TestOptionalRequiredFlatteningParamsResponse actualResponse =
-        client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+        client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
@@ -8986,6 +9027,7 @@ public class LibraryClientTest {
     Assert.assertEquals(requiredSingularMessage, actualRequest.getRequiredSingularMessage());
     Assert.assertEquals(requiredSingularResourceName, ShelfBookName.parse(actualRequest.getRequiredSingularResourceName()));
     Assert.assertEquals(requiredSingularResourceNameOneof, BookNames.parse(actualRequest.getRequiredSingularResourceNameOneof()));
+    Assert.assertEquals(requiredSingularResourceNameCommon, ProjectName.parse(actualRequest.getRequiredSingularResourceNameCommon()));
     Assert.assertEquals(requiredSingularFixed32, actualRequest.getRequiredSingularFixed32());
     Assert.assertEquals(requiredSingularFixed64, actualRequest.getRequiredSingularFixed64());
     Assert.assertEquals(requiredRepeatedInt32, actualRequest.getRequiredRepeatedInt32List());
@@ -8999,6 +9041,7 @@ public class LibraryClientTest {
     Assert.assertEquals(requiredRepeatedMessage, actualRequest.getRequiredRepeatedMessageList());
     Assert.assertEquals(requiredRepeatedResourceName, ShelfBookName.parseList(actualRequest.getRequiredRepeatedResourceNameList()));
     Assert.assertEquals(requiredRepeatedResourceNameOneof, BookName.parseList(actualRequest.getRequiredRepeatedResourceNameOneofList()));
+    Assert.assertEquals(requiredRepeatedResourceNameCommon, ProjectName.parseList(actualRequest.getRequiredRepeatedResourceNameCommonList()));
     Assert.assertEquals(requiredRepeatedFixed32, actualRequest.getRequiredRepeatedFixed32List());
     Assert.assertEquals(requiredRepeatedFixed64, actualRequest.getRequiredRepeatedFixed64List());
     Assert.assertEquals(requiredMap, actualRequest.getRequiredMapMap());
@@ -9013,6 +9056,7 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalSingularMessage, actualRequest.getOptionalSingularMessage());
     Assert.assertEquals(optionalSingularResourceName, ShelfBookName.parse(actualRequest.getOptionalSingularResourceName()));
     Assert.assertEquals(optionalSingularResourceNameOneof, BookNames.parse(actualRequest.getOptionalSingularResourceNameOneof()));
+    Assert.assertEquals(optionalSingularResourceNameCommon, ProjectName.parse(actualRequest.getOptionalSingularResourceNameCommon()));
     Assert.assertEquals(optionalSingularFixed32, actualRequest.getOptionalSingularFixed32());
     Assert.assertEquals(optionalSingularFixed64, actualRequest.getOptionalSingularFixed64());
     Assert.assertEquals(optionalRepeatedInt32, actualRequest.getOptionalRepeatedInt32List());
@@ -9026,6 +9070,7 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalRepeatedMessage, actualRequest.getOptionalRepeatedMessageList());
     Assert.assertEquals(optionalRepeatedResourceName, ShelfBookName.parseList(actualRequest.getOptionalRepeatedResourceNameList()));
     Assert.assertEquals(optionalRepeatedResourceNameOneof, BookName.parseList(actualRequest.getOptionalRepeatedResourceNameOneofList()));
+    Assert.assertEquals(optionalRepeatedResourceNameCommon, ProjectName.parseList(actualRequest.getOptionalRepeatedResourceNameCommonList()));
     Assert.assertEquals(optionalRepeatedFixed32, actualRequest.getOptionalRepeatedFixed32List());
     Assert.assertEquals(optionalRepeatedFixed64, actualRequest.getOptionalRepeatedFixed64List());
     Assert.assertEquals(optionalMap, actualRequest.getOptionalMapMap());
@@ -9053,6 +9098,7 @@ public class LibraryClientTest {
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage requiredSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
       ShelfBookName requiredSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
       BookName requiredSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName requiredSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int requiredSingularFixed32 = 720656715;
       long requiredSingularFixed64 = 720656810;
       List<Integer> requiredRepeatedInt32 = new ArrayList<>();
@@ -9066,6 +9112,7 @@ public class LibraryClientTest {
       List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> requiredRepeatedMessage = new ArrayList<>();
       List<ShelfBookName> requiredRepeatedResourceName = new ArrayList<>();
       List<BookName> requiredRepeatedResourceNameOneof = new ArrayList<>();
+      List<ProjectName> requiredRepeatedResourceNameCommon = new ArrayList<>();
       List<Integer> requiredRepeatedFixed32 = new ArrayList<>();
       List<Long> requiredRepeatedFixed64 = new ArrayList<>();
       Map<Integer, String> requiredMap = new HashMap<>();
@@ -9080,6 +9127,7 @@ public class LibraryClientTest {
       TestOptionalRequiredFlatteningParamsRequest.InnerMessage optionalSingularMessage = TestOptionalRequiredFlatteningParamsRequest.InnerMessage.newBuilder().build();
       ShelfBookName optionalSingularResourceName = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
       BookName optionalSingularResourceNameOneof = ShelfBookName.of("[SHELF_ID]", "[BOOK_ID]");
+      ProjectName optionalSingularResourceNameCommon = ProjectName.of("[PROJECT]");
       int optionalSingularFixed32 = 1648847958;
       long optionalSingularFixed64 = 1648847863;
       List<Integer> optionalRepeatedInt32 = new ArrayList<>();
@@ -9093,11 +9141,12 @@ public class LibraryClientTest {
       List<TestOptionalRequiredFlatteningParamsRequest.InnerMessage> optionalRepeatedMessage = new ArrayList<>();
       List<ShelfBookName> optionalRepeatedResourceName = new ArrayList<>();
       List<BookName> optionalRepeatedResourceNameOneof = new ArrayList<>();
+      List<ProjectName> optionalRepeatedResourceNameCommon = new ArrayList<>();
       List<Integer> optionalRepeatedFixed32 = new ArrayList<>();
       List<Long> optionalRepeatedFixed64 = new ArrayList<>();
       Map<Integer, String> optionalMap = new HashMap<>();
 
-      client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
+      client.testOptionalRequiredFlatteningParams(requiredSingularInt32, requiredSingularInt64, requiredSingularFloat, requiredSingularDouble, requiredSingularBool, requiredSingularEnum, requiredSingularString, requiredSingularBytes, requiredSingularMessage, requiredSingularResourceName, requiredSingularResourceNameOneof, requiredSingularResourceNameCommon, requiredSingularFixed32, requiredSingularFixed64, requiredRepeatedInt32, requiredRepeatedInt64, requiredRepeatedFloat, requiredRepeatedDouble, requiredRepeatedBool, requiredRepeatedEnum, requiredRepeatedString, requiredRepeatedBytes, requiredRepeatedMessage, requiredRepeatedResourceName, requiredRepeatedResourceNameOneof, requiredRepeatedResourceNameCommon, requiredRepeatedFixed32, requiredRepeatedFixed64, requiredMap, optionalSingularInt32, optionalSingularInt64, optionalSingularFloat, optionalSingularDouble, optionalSingularBool, optionalSingularEnum, optionalSingularString, optionalSingularBytes, optionalSingularMessage, optionalSingularResourceName, optionalSingularResourceNameOneof, optionalSingularResourceNameCommon, optionalSingularFixed32, optionalSingularFixed64, optionalRepeatedInt32, optionalRepeatedInt64, optionalRepeatedFloat, optionalRepeatedDouble, optionalRepeatedBool, optionalRepeatedEnum, optionalRepeatedString, optionalRepeatedBytes, optionalRepeatedMessage, optionalRepeatedResourceName, optionalRepeatedResourceNameOneof, optionalRepeatedResourceNameCommon, optionalRepeatedFixed32, optionalRepeatedFixed64, optionalMap);
       Assert.fail("No exception raised");
     } catch (InvalidArgumentException e) {
       // Expected exception

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -657,6 +657,7 @@ interfaces:
     - required_singular_message
     - required_singular_resource_name
     - required_singular_resource_name_oneof
+    - required_singular_resource_name_common
     - required_singular_fixed32
     - required_singular_fixed64
     - required_repeated_int32
@@ -670,6 +671,7 @@ interfaces:
     - required_repeated_message
     - required_repeated_resource_name
     - required_repeated_resource_name_oneof
+    - required_repeated_resource_name_common
     - required_repeated_fixed32
     - required_repeated_fixed64
     - required_map
@@ -684,6 +686,7 @@ interfaces:
     - optional_singular_message
     - optional_singular_resource_name
     - optional_singular_resource_name_oneof
+    - optional_singular_resource_name_common
     - optional_singular_fixed32
     - optional_singular_fixed64
     - optional_repeated_int32
@@ -697,6 +700,7 @@ interfaces:
     - optional_repeated_message
     - optional_repeated_resource_name
     - optional_repeated_resource_name_oneof
+    - optional_repeated_resource_name_common
     - optional_repeated_fixed32
     - optional_repeated_fixed64
     - optional_map

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_doc_library.baseline
@@ -1169,6 +1169,8 @@ var GetBigBookMetadata = {
  *
  * @property {string} requiredSingularResourceNameOneof
  *
+ * @property {string} requiredSingularResourceNameCommon
+ *
  * @property {number} requiredSingularFixed32
  *
  * @property {number} requiredSingularFixed64
@@ -1196,6 +1198,8 @@ var GetBigBookMetadata = {
  * @property {string[]} requiredRepeatedResourceName
  *
  * @property {string[]} requiredRepeatedResourceNameOneof
+ *
+ * @property {string[]} requiredRepeatedResourceNameCommon
  *
  * @property {number[]} requiredRepeatedFixed32
  *
@@ -1227,6 +1231,8 @@ var GetBigBookMetadata = {
  *
  * @property {string} optionalSingularResourceNameOneof
  *
+ * @property {string} optionalSingularResourceNameCommon
+ *
  * @property {number} optionalSingularFixed32
  *
  * @property {number} optionalSingularFixed64
@@ -1254,6 +1260,8 @@ var GetBigBookMetadata = {
  * @property {string[]} optionalRepeatedResourceName
  *
  * @property {string[]} optionalRepeatedResourceNameOneof
+ *
+ * @property {string[]} optionalRepeatedResourceNameCommon
  *
  * @property {number[]} optionalRepeatedFixed32
  *
@@ -2435,6 +2443,9 @@ class LibraryServiceClient {
       ),
       returnPathTemplate: new gax.PathTemplate(
         'shelves/{shelf}/books/{book}/returns/{return}'
+      ),
+      projectPathTemplate: new gax.PathTemplate(
+        'projects/{project}'
       ),
       archivedBookPathTemplate: new gax.PathTemplate(
         'archives/{archive_path}/books/{book_id=**}'
@@ -4519,6 +4530,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} request.requiredSingularResourceName
    * @param {string} request.requiredSingularResourceNameOneof
+   * @param {string} request.requiredSingularResourceNameCommon
    * @param {number} request.requiredSingularFixed32
    * @param {number} request.requiredSingularFixed64
    * @param {number[]} request.requiredRepeatedInt32
@@ -4534,6 +4546,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} request.requiredRepeatedResourceName
    * @param {string[]} request.requiredRepeatedResourceNameOneof
+   * @param {string[]} request.requiredRepeatedResourceNameCommon
    * @param {number[]} request.requiredRepeatedFixed32
    * @param {number[]} request.requiredRepeatedFixed64
    * @param {Object.<number, string>} request.requiredMap
@@ -4550,6 +4563,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} [request.optionalSingularResourceName]
    * @param {string} [request.optionalSingularResourceNameOneof]
+   * @param {string} [request.optionalSingularResourceNameCommon]
    * @param {number} [request.optionalSingularFixed32]
    * @param {number} [request.optionalSingularFixed64]
    * @param {number[]} [request.optionalRepeatedInt32]
@@ -4565,6 +4579,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} [request.optionalRepeatedResourceName]
    * @param {string[]} [request.optionalRepeatedResourceNameOneof]
+   * @param {string[]} [request.optionalRepeatedResourceNameCommon]
    * @param {number[]} [request.optionalRepeatedFixed32]
    * @param {number[]} [request.optionalRepeatedFixed64]
    * @param {Object.<number, string>} [request.optionalMap]
@@ -4598,6 +4613,7 @@ class LibraryServiceClient {
    * var requiredSingularMessage = {};
    * var requiredSingularResourceName = '';
    * var requiredSingularResourceNameOneof = '';
+   * var requiredSingularResourceNameCommon = '';
    * var requiredSingularFixed32 = 0;
    * var requiredSingularFixed64 = 0;
    * var requiredRepeatedInt32 = [];
@@ -4611,6 +4627,7 @@ class LibraryServiceClient {
    * var requiredRepeatedMessage = [];
    * var formattedRequiredRepeatedResourceName = [];
    * var formattedRequiredRepeatedResourceNameOneof = [];
+   * var requiredRepeatedResourceNameCommon = [];
    * var requiredRepeatedFixed32 = [];
    * var requiredRepeatedFixed64 = [];
    * var requiredMap = {};
@@ -4626,6 +4643,7 @@ class LibraryServiceClient {
    *   requiredSingularMessage: requiredSingularMessage,
    *   requiredSingularResourceName: requiredSingularResourceName,
    *   requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+   *   requiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
    *   requiredSingularFixed32: requiredSingularFixed32,
    *   requiredSingularFixed64: requiredSingularFixed64,
    *   requiredRepeatedInt32: requiredRepeatedInt32,
@@ -4639,6 +4657,7 @@ class LibraryServiceClient {
    *   requiredRepeatedMessage: requiredRepeatedMessage,
    *   requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
    *   requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+   *   requiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
    *   requiredRepeatedFixed32: requiredRepeatedFixed32,
    *   requiredRepeatedFixed64: requiredRepeatedFixed64,
    *   requiredMap: requiredMap,
@@ -4705,6 +4724,18 @@ class LibraryServiceClient {
       shelf: shelf,
       book: book,
       return: return_,
+    });
+  }
+
+  /**
+   * Return a fully-qualified project resource name string.
+   *
+   * @param {String} project
+   * @returns {String}
+   */
+  projectPath(project) {
+    return this._pathTemplates.projectPathTemplate.render({
+      project: project,
     });
   }
 
@@ -4798,6 +4829,19 @@ class LibraryServiceClient {
     return this._pathTemplates.returnPathTemplate
       .match(returnName)
       .return;
+  }
+
+  /**
+   * Parse the projectName from a project resource.
+   *
+   * @param {String} projectName
+   *   A fully-qualified path representing a project resources.
+   * @returns {String} - A string representing the project.
+   */
+  matchProjectFromProjectName(projectName) {
+    return this._pathTemplates.projectPathTemplate
+      .match(projectName)
+      .project;
   }
 
   /**
@@ -6738,6 +6782,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularMessage = {};
       var requiredSingularResourceName = 'requiredSingularResourceName-1701575020';
       var requiredSingularResourceNameOneof = 'requiredSingularResourceNameOneof-25303726';
+      var requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       var requiredSingularFixed32 = 720656715;
       var requiredSingularFixed64 = 720656810;
       var requiredRepeatedInt32 = [];
@@ -6751,6 +6796,7 @@ describe('LibraryServiceClient', () => {
       var requiredRepeatedMessage = [];
       var formattedRequiredRepeatedResourceName = [];
       var formattedRequiredRepeatedResourceNameOneof = [];
+      var requiredRepeatedResourceNameCommon = [];
       var requiredRepeatedFixed32 = [];
       var requiredRepeatedFixed64 = [];
       var requiredMap = {};
@@ -6766,6 +6812,7 @@ describe('LibraryServiceClient', () => {
         requiredSingularMessage: requiredSingularMessage,
         requiredSingularResourceName: requiredSingularResourceName,
         requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+        requiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
         requiredSingularFixed32: requiredSingularFixed32,
         requiredSingularFixed64: requiredSingularFixed64,
         requiredRepeatedInt32: requiredRepeatedInt32,
@@ -6779,6 +6826,7 @@ describe('LibraryServiceClient', () => {
         requiredRepeatedMessage: requiredRepeatedMessage,
         requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
         requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+        requiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
         requiredRepeatedFixed32: requiredRepeatedFixed32,
         requiredRepeatedFixed64: requiredRepeatedFixed64,
         requiredMap: requiredMap,
@@ -6818,6 +6866,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularMessage = {};
       var requiredSingularResourceName = 'requiredSingularResourceName-1701575020';
       var requiredSingularResourceNameOneof = 'requiredSingularResourceNameOneof-25303726';
+      var requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       var requiredSingularFixed32 = 720656715;
       var requiredSingularFixed64 = 720656810;
       var requiredRepeatedInt32 = [];
@@ -6831,6 +6880,7 @@ describe('LibraryServiceClient', () => {
       var requiredRepeatedMessage = [];
       var formattedRequiredRepeatedResourceName = [];
       var formattedRequiredRepeatedResourceNameOneof = [];
+      var requiredRepeatedResourceNameCommon = [];
       var requiredRepeatedFixed32 = [];
       var requiredRepeatedFixed64 = [];
       var requiredMap = {};
@@ -6846,6 +6896,7 @@ describe('LibraryServiceClient', () => {
         requiredSingularMessage: requiredSingularMessage,
         requiredSingularResourceName: requiredSingularResourceName,
         requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+        requiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
         requiredSingularFixed32: requiredSingularFixed32,
         requiredSingularFixed64: requiredSingularFixed64,
         requiredRepeatedInt32: requiredRepeatedInt32,
@@ -6859,6 +6910,7 @@ describe('LibraryServiceClient', () => {
         requiredRepeatedMessage: requiredRepeatedMessage,
         requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
         requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+        requiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
         requiredRepeatedFixed32: requiredRepeatedFixed32,
         requiredRepeatedFixed64: requiredRepeatedFixed64,
         requiredMap: requiredMap,

--- a/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs/nodejs_library.baseline
@@ -399,6 +399,9 @@ class LibraryServiceClient {
       returnPathTemplate: new gax.PathTemplate(
         'shelves/{shelf}/books/{book}/returns/{return}'
       ),
+      projectPathTemplate: new gax.PathTemplate(
+        'projects/{project}'
+      ),
       archivedBookPathTemplate: new gax.PathTemplate(
         'archives/{archive_path}/books/{book_id=**}'
       ),
@@ -2482,6 +2485,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} request.requiredSingularResourceName
    * @param {string} request.requiredSingularResourceNameOneof
+   * @param {string} request.requiredSingularResourceNameCommon
    * @param {number} request.requiredSingularFixed32
    * @param {number} request.requiredSingularFixed64
    * @param {number[]} request.requiredRepeatedInt32
@@ -2497,6 +2501,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} request.requiredRepeatedResourceName
    * @param {string[]} request.requiredRepeatedResourceNameOneof
+   * @param {string[]} request.requiredRepeatedResourceNameCommon
    * @param {number[]} request.requiredRepeatedFixed32
    * @param {number[]} request.requiredRepeatedFixed64
    * @param {Object.<number, string>} request.requiredMap
@@ -2513,6 +2518,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string} [request.optionalSingularResourceName]
    * @param {string} [request.optionalSingularResourceNameOneof]
+   * @param {string} [request.optionalSingularResourceNameCommon]
    * @param {number} [request.optionalSingularFixed32]
    * @param {number} [request.optionalSingularFixed64]
    * @param {number[]} [request.optionalRepeatedInt32]
@@ -2528,6 +2534,7 @@ class LibraryServiceClient {
    *   This object should have the same structure as [InnerMessage]{@link google.example.library.v1.InnerMessage}
    * @param {string[]} [request.optionalRepeatedResourceName]
    * @param {string[]} [request.optionalRepeatedResourceNameOneof]
+   * @param {string[]} [request.optionalRepeatedResourceNameCommon]
    * @param {number[]} [request.optionalRepeatedFixed32]
    * @param {number[]} [request.optionalRepeatedFixed64]
    * @param {Object.<number, string>} [request.optionalMap]
@@ -2561,6 +2568,7 @@ class LibraryServiceClient {
    * var requiredSingularMessage = {};
    * var requiredSingularResourceName = '';
    * var requiredSingularResourceNameOneof = '';
+   * var requiredSingularResourceNameCommon = '';
    * var requiredSingularFixed32 = 0;
    * var requiredSingularFixed64 = 0;
    * var requiredRepeatedInt32 = [];
@@ -2574,6 +2582,7 @@ class LibraryServiceClient {
    * var requiredRepeatedMessage = [];
    * var formattedRequiredRepeatedResourceName = [];
    * var formattedRequiredRepeatedResourceNameOneof = [];
+   * var requiredRepeatedResourceNameCommon = [];
    * var requiredRepeatedFixed32 = [];
    * var requiredRepeatedFixed64 = [];
    * var requiredMap = {};
@@ -2589,6 +2598,7 @@ class LibraryServiceClient {
    *   requiredSingularMessage: requiredSingularMessage,
    *   requiredSingularResourceName: requiredSingularResourceName,
    *   requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+   *   requiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
    *   requiredSingularFixed32: requiredSingularFixed32,
    *   requiredSingularFixed64: requiredSingularFixed64,
    *   requiredRepeatedInt32: requiredRepeatedInt32,
@@ -2602,6 +2612,7 @@ class LibraryServiceClient {
    *   requiredRepeatedMessage: requiredRepeatedMessage,
    *   requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
    *   requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+   *   requiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
    *   requiredRepeatedFixed32: requiredRepeatedFixed32,
    *   requiredRepeatedFixed64: requiredRepeatedFixed64,
    *   requiredMap: requiredMap,
@@ -2668,6 +2679,18 @@ class LibraryServiceClient {
       shelf: shelf,
       book: book,
       return: return_,
+    });
+  }
+
+  /**
+   * Return a fully-qualified project resource name string.
+   *
+   * @param {String} project
+   * @returns {String}
+   */
+  projectPath(project) {
+    return this._pathTemplates.projectPathTemplate.render({
+      project: project,
     });
   }
 
@@ -2761,6 +2784,19 @@ class LibraryServiceClient {
     return this._pathTemplates.returnPathTemplate
       .match(returnName)
       .return;
+  }
+
+  /**
+   * Parse the projectName from a project resource.
+   *
+   * @param {String} projectName
+   *   A fully-qualified path representing a project resources.
+   * @returns {String} - A string representing the project.
+   */
+  matchProjectFromProjectName(projectName) {
+    return this._pathTemplates.projectPathTemplate
+      .match(projectName)
+      .project;
   }
 
   /**
@@ -4701,6 +4737,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularMessage = {};
       var requiredSingularResourceName = 'requiredSingularResourceName-1701575020';
       var requiredSingularResourceNameOneof = 'requiredSingularResourceNameOneof-25303726';
+      var requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       var requiredSingularFixed32 = 720656715;
       var requiredSingularFixed64 = 720656810;
       var requiredRepeatedInt32 = [];
@@ -4714,6 +4751,7 @@ describe('LibraryServiceClient', () => {
       var requiredRepeatedMessage = [];
       var formattedRequiredRepeatedResourceName = [];
       var formattedRequiredRepeatedResourceNameOneof = [];
+      var requiredRepeatedResourceNameCommon = [];
       var requiredRepeatedFixed32 = [];
       var requiredRepeatedFixed64 = [];
       var requiredMap = {};
@@ -4729,6 +4767,7 @@ describe('LibraryServiceClient', () => {
         requiredSingularMessage: requiredSingularMessage,
         requiredSingularResourceName: requiredSingularResourceName,
         requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+        requiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
         requiredSingularFixed32: requiredSingularFixed32,
         requiredSingularFixed64: requiredSingularFixed64,
         requiredRepeatedInt32: requiredRepeatedInt32,
@@ -4742,6 +4781,7 @@ describe('LibraryServiceClient', () => {
         requiredRepeatedMessage: requiredRepeatedMessage,
         requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
         requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+        requiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
         requiredRepeatedFixed32: requiredRepeatedFixed32,
         requiredRepeatedFixed64: requiredRepeatedFixed64,
         requiredMap: requiredMap,
@@ -4781,6 +4821,7 @@ describe('LibraryServiceClient', () => {
       var requiredSingularMessage = {};
       var requiredSingularResourceName = 'requiredSingularResourceName-1701575020';
       var requiredSingularResourceNameOneof = 'requiredSingularResourceNameOneof-25303726';
+      var requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
       var requiredSingularFixed32 = 720656715;
       var requiredSingularFixed64 = 720656810;
       var requiredRepeatedInt32 = [];
@@ -4794,6 +4835,7 @@ describe('LibraryServiceClient', () => {
       var requiredRepeatedMessage = [];
       var formattedRequiredRepeatedResourceName = [];
       var formattedRequiredRepeatedResourceNameOneof = [];
+      var requiredRepeatedResourceNameCommon = [];
       var requiredRepeatedFixed32 = [];
       var requiredRepeatedFixed64 = [];
       var requiredMap = {};
@@ -4809,6 +4851,7 @@ describe('LibraryServiceClient', () => {
         requiredSingularMessage: requiredSingularMessage,
         requiredSingularResourceName: requiredSingularResourceName,
         requiredSingularResourceNameOneof: requiredSingularResourceNameOneof,
+        requiredSingularResourceNameCommon: requiredSingularResourceNameCommon,
         requiredSingularFixed32: requiredSingularFixed32,
         requiredSingularFixed64: requiredSingularFixed64,
         requiredRepeatedInt32: requiredRepeatedInt32,
@@ -4822,6 +4865,7 @@ describe('LibraryServiceClient', () => {
         requiredRepeatedMessage: requiredRepeatedMessage,
         requiredRepeatedResourceName: formattedRequiredRepeatedResourceName,
         requiredRepeatedResourceNameOneof: formattedRequiredRepeatedResourceNameOneof,
+        requiredRepeatedResourceNameCommon: requiredRepeatedResourceNameCommon,
         requiredRepeatedFixed32: requiredRepeatedFixed32,
         requiredRepeatedFixed64: requiredRepeatedFixed64,
         requiredMap: requiredMap,

--- a/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php/php_library.baseline
@@ -200,6 +200,7 @@ class LibraryServiceGapicClient
     private static $shelfNameTemplate;
     private static $bookNameTemplate;
     private static $returnNameTemplate;
+    private static $projectNameTemplate;
     private static $archivedBookNameTemplate;
     private static $pathTemplateMap;
 
@@ -248,6 +249,15 @@ class LibraryServiceGapicClient
         return self::$returnNameTemplate;
     }
 
+    private static function getProjectNameTemplate()
+    {
+        if (self::$projectNameTemplate == null) {
+            self::$projectNameTemplate = new PathTemplate('projects/{project}');
+        }
+
+        return self::$projectNameTemplate;
+    }
+
     private static function getArchivedBookNameTemplate()
     {
         if (self::$archivedBookNameTemplate == null) {
@@ -265,6 +275,7 @@ class LibraryServiceGapicClient
                 'shelf' => self::getShelfNameTemplate(),
                 'book' => self::getBookNameTemplate(),
                 'return' => self::getReturnNameTemplate(),
+                'project' => self::getProjectNameTemplate(),
                 'archivedBook' => self::getArchivedBookNameTemplate(),
             ];
         }
@@ -323,6 +334,21 @@ class LibraryServiceGapicClient
 
     /**
      * Formats a string containing the fully-qualified path to represent
+     * a project resource.
+     *
+     * @param string $project
+     * @return string The formatted project resource.
+     * @experimental
+     */
+    public static function projectName($project)
+    {
+        return self::getProjectNameTemplate()->render([
+            'project' => $project,
+        ]);
+    }
+
+    /**
+     * Formats a string containing the fully-qualified path to represent
      * a archived_book resource.
      *
      * @param string $archivePath
@@ -345,6 +371,7 @@ class LibraryServiceGapicClient
      * - shelf: shelves/{shelf_id}
      * - book: shelves/{shelf_id}/books/{book_id}
      * - return: shelves/{shelf}/books/{book}/returns/{return}
+     * - project: projects/{project}
      * - archivedBook: archives/{archive_path}/books/{book_id=**}
      *
      * The optional $template argument can be supplied to specify a particular pattern, and must
@@ -1920,6 +1947,7 @@ class LibraryServiceGapicClient
      *     $requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest_InnerMessage();
      *     $requiredSingularResourceName = '';
      *     $requiredSingularResourceNameOneof = '';
+     *     $requiredSingularResourceNameCommon = '';
      *     $requiredSingularFixed32 = 0;
      *     $requiredSingularFixed64 = 0;
      *     $requiredRepeatedInt32 = [];
@@ -1933,10 +1961,11 @@ class LibraryServiceGapicClient
      *     $requiredRepeatedMessage = [];
      *     $formattedRequiredRepeatedResourceName = [];
      *     $formattedRequiredRepeatedResourceNameOneof = [];
+     *     $requiredRepeatedResourceNameCommon = [];
      *     $requiredRepeatedFixed32 = [];
      *     $requiredRepeatedFixed64 = [];
      *     $requiredMap = [];
-     *     $response = $libraryServiceClient->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
+     *     $response = $libraryServiceClient->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
      * } finally {
      *     $libraryServiceClient->close();
      * }
@@ -1953,6 +1982,7 @@ class LibraryServiceGapicClient
      * @param TestOptionalRequiredFlatteningParamsRequest_InnerMessage $requiredSingularMessage
      * @param string $requiredSingularResourceName
      * @param string $requiredSingularResourceNameOneof
+     * @param string $requiredSingularResourceNameCommon
      * @param int $requiredSingularFixed32
      * @param int $requiredSingularFixed64
      * @param int[] $requiredRepeatedInt32
@@ -1966,6 +1996,7 @@ class LibraryServiceGapicClient
      * @param TestOptionalRequiredFlatteningParamsRequest_InnerMessage[] $requiredRepeatedMessage
      * @param string[] $requiredRepeatedResourceName
      * @param string[] $requiredRepeatedResourceNameOneof
+     * @param string[] $requiredRepeatedResourceNameCommon
      * @param int[] $requiredRepeatedFixed32
      * @param int[] $requiredRepeatedFixed64
      * @param array $requiredMap
@@ -1983,6 +2014,7 @@ class LibraryServiceGapicClient
      *     @type TestOptionalRequiredFlatteningParamsRequest_InnerMessage $optionalSingularMessage
      *     @type string $optionalSingularResourceName
      *     @type string $optionalSingularResourceNameOneof
+     *     @type string $optionalSingularResourceNameCommon
      *     @type int $optionalSingularFixed32
      *     @type int $optionalSingularFixed64
      *     @type int[] $optionalRepeatedInt32
@@ -1997,6 +2029,7 @@ class LibraryServiceGapicClient
      *     @type TestOptionalRequiredFlatteningParamsRequest_InnerMessage[] $optionalRepeatedMessage
      *     @type string[] $optionalRepeatedResourceName
      *     @type string[] $optionalRepeatedResourceNameOneof
+     *     @type string[] $optionalRepeatedResourceNameCommon
      *     @type int[] $optionalRepeatedFixed32
      *     @type int[] $optionalRepeatedFixed64
      *     @type array $optionalMap
@@ -2012,7 +2045,7 @@ class LibraryServiceGapicClient
      * @throws ApiException if the remote call fails
      * @experimental
      */
-    public function testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $requiredRepeatedResourceName, $requiredRepeatedResourceNameOneof, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, $optionalArgs = [])
+    public function testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $requiredRepeatedResourceName, $requiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, $optionalArgs = [])
     {
         $request = new TestOptionalRequiredFlatteningParamsRequest();
         $request->setRequiredSingularInt32($requiredSingularInt32);
@@ -2026,6 +2059,7 @@ class LibraryServiceGapicClient
         $request->setRequiredSingularMessage($requiredSingularMessage);
         $request->setRequiredSingularResourceName($requiredSingularResourceName);
         $request->setRequiredSingularResourceNameOneof($requiredSingularResourceNameOneof);
+        $request->setRequiredSingularResourceNameCommon($requiredSingularResourceNameCommon);
         $request->setRequiredSingularFixed32($requiredSingularFixed32);
         $request->setRequiredSingularFixed64($requiredSingularFixed64);
         $request->setRequiredRepeatedInt32($requiredRepeatedInt32);
@@ -2039,6 +2073,7 @@ class LibraryServiceGapicClient
         $request->setRequiredRepeatedMessage($requiredRepeatedMessage);
         $request->setRequiredRepeatedResourceName($requiredRepeatedResourceName);
         $request->setRequiredRepeatedResourceNameOneof($requiredRepeatedResourceNameOneof);
+        $request->setRequiredRepeatedResourceNameCommon($requiredRepeatedResourceNameCommon);
         $request->setRequiredRepeatedFixed32($requiredRepeatedFixed32);
         $request->setRequiredRepeatedFixed64($requiredRepeatedFixed64);
         $request->setRequiredMap($requiredMap);
@@ -2074,6 +2109,9 @@ class LibraryServiceGapicClient
         }
         if (isset($optionalArgs['optionalSingularResourceNameOneof'])) {
             $request->setOptionalSingularResourceNameOneof($optionalArgs['optionalSingularResourceNameOneof']);
+        }
+        if (isset($optionalArgs['optionalSingularResourceNameCommon'])) {
+            $request->setOptionalSingularResourceNameCommon($optionalArgs['optionalSingularResourceNameCommon']);
         }
         if (isset($optionalArgs['optionalSingularFixed32'])) {
             $request->setOptionalSingularFixed32($optionalArgs['optionalSingularFixed32']);
@@ -2113,6 +2151,9 @@ class LibraryServiceGapicClient
         }
         if (isset($optionalArgs['optionalRepeatedResourceNameOneof'])) {
             $request->setOptionalRepeatedResourceNameOneof($optionalArgs['optionalRepeatedResourceNameOneof']);
+        }
+        if (isset($optionalArgs['optionalRepeatedResourceNameCommon'])) {
+            $request->setOptionalRepeatedResourceNameCommon($optionalArgs['optionalRepeatedResourceNameCommon']);
         }
         if (isset($optionalArgs['optionalRepeatedFixed32'])) {
             $request->setOptionalRepeatedFixed32($optionalArgs['optionalRepeatedFixed32']);
@@ -5158,6 +5199,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest_InnerMessage();
         $requiredSingularResourceName = 'requiredSingularResourceName-1701575020';
         $requiredSingularResourceNameOneof = 'requiredSingularResourceNameOneof-25303726';
+        $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
         $requiredRepeatedInt32 = [];
@@ -5171,11 +5213,12 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredRepeatedMessage = [];
         $formattedRequiredRepeatedResourceName = [];
         $formattedRequiredRepeatedResourceNameOneof = [];
+        $requiredRepeatedResourceNameCommon = [];
         $requiredRepeatedFixed32 = [];
         $requiredRepeatedFixed64 = [];
         $requiredMap = [];
 
-        $response = $client->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
+        $response = $client->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $transport->popReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -5216,6 +5259,9 @@ class LibraryServiceClientTest extends GeneratedTest
         $actualValue = $actualRequestObject->getRequiredSingularResourceNameOneof();
 
         $this->assertProtobufEquals($requiredSingularResourceNameOneof, $actualValue);
+        $actualValue = $actualRequestObject->getRequiredSingularResourceNameCommon();
+
+        $this->assertProtobufEquals($requiredSingularResourceNameCommon, $actualValue);
         $actualValue = $actualRequestObject->getRequiredSingularFixed32();
 
         $this->assertProtobufEquals($requiredSingularFixed32, $actualValue);
@@ -5255,6 +5301,9 @@ class LibraryServiceClientTest extends GeneratedTest
         $actualValue = $actualRequestObject->getRequiredRepeatedResourceNameOneof();
 
         $this->assertProtobufEquals($formattedRequiredRepeatedResourceNameOneof, $actualValue);
+        $actualValue = $actualRequestObject->getRequiredRepeatedResourceNameCommon();
+
+        $this->assertProtobufEquals($requiredRepeatedResourceNameCommon, $actualValue);
         $actualValue = $actualRequestObject->getRequiredRepeatedFixed32();
 
         $this->assertProtobufEquals($requiredRepeatedFixed32, $actualValue);
@@ -5302,6 +5351,7 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredSingularMessage = new TestOptionalRequiredFlatteningParamsRequest_InnerMessage();
         $requiredSingularResourceName = 'requiredSingularResourceName-1701575020';
         $requiredSingularResourceNameOneof = 'requiredSingularResourceNameOneof-25303726';
+        $requiredSingularResourceNameCommon = 'requiredSingularResourceNameCommon-1126805002';
         $requiredSingularFixed32 = 720656715;
         $requiredSingularFixed64 = 720656810;
         $requiredRepeatedInt32 = [];
@@ -5315,12 +5365,13 @@ class LibraryServiceClientTest extends GeneratedTest
         $requiredRepeatedMessage = [];
         $formattedRequiredRepeatedResourceName = [];
         $formattedRequiredRepeatedResourceNameOneof = [];
+        $requiredRepeatedResourceNameCommon = [];
         $requiredRepeatedFixed32 = [];
         $requiredRepeatedFixed64 = [];
         $requiredMap = [];
 
         try {
-            $client->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
+            $client->testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularResourceNameCommon, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $formattedRequiredRepeatedResourceName, $formattedRequiredRepeatedResourceNameOneof, $requiredRepeatedResourceNameCommon, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap);
             // If the $client method call did not throw, fail the test
             $this->fail('Expected an ApiException, but no exception was thrown.');
         } catch (ApiException $ex) {

--- a/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/py/py_library.baseline
@@ -1088,6 +1088,14 @@ class LibraryServiceClient(object):
         )
 
     @classmethod
+    def project_path(cls, project):
+        """Return a fully-qualified project string."""
+        return google.api_core.path_template.expand(
+            'projects/{project}',
+            project=project,
+        )
+
+    @classmethod
     def archived_book_path(cls, archive_path, book_id):
         """Return a fully-qualified archived_book string."""
         return google.api_core.path_template.expand(
@@ -2886,6 +2894,7 @@ class LibraryServiceClient(object):
             required_singular_message,
             required_singular_resource_name,
             required_singular_resource_name_oneof,
+            required_singular_resource_name_common,
             required_singular_fixed32,
             required_singular_fixed64,
             required_repeated_int32,
@@ -2899,6 +2908,7 @@ class LibraryServiceClient(object):
             required_repeated_message,
             required_repeated_resource_name,
             required_repeated_resource_name_oneof,
+            required_repeated_resource_name_common,
             required_repeated_fixed32,
             required_repeated_fixed64,
             required_map,
@@ -2913,6 +2923,7 @@ class LibraryServiceClient(object):
             optional_singular_message=None,
             optional_singular_resource_name=None,
             optional_singular_resource_name_oneof=None,
+            optional_singular_resource_name_common=None,
             optional_singular_fixed32=None,
             optional_singular_fixed64=None,
             optional_repeated_int32=None,
@@ -2926,6 +2937,7 @@ class LibraryServiceClient(object):
             optional_repeated_message=None,
             optional_repeated_resource_name=None,
             optional_repeated_resource_name_oneof=None,
+            optional_repeated_resource_name_common=None,
             optional_repeated_fixed32=None,
             optional_repeated_fixed64=None,
             optional_map=None,
@@ -2974,6 +2986,9 @@ class LibraryServiceClient(object):
             >>> # TODO: Initialize ``required_singular_resource_name_oneof``:
             >>> required_singular_resource_name_oneof = ''
             >>>
+            >>> # TODO: Initialize ``required_singular_resource_name_common``:
+            >>> required_singular_resource_name_common = ''
+            >>>
             >>> # TODO: Initialize ``required_singular_fixed32``:
             >>> required_singular_fixed32 = 0
             >>>
@@ -3013,6 +3028,9 @@ class LibraryServiceClient(object):
             >>> # TODO: Initialize ``required_repeated_resource_name_oneof``:
             >>> required_repeated_resource_name_oneof = []
             >>>
+            >>> # TODO: Initialize ``required_repeated_resource_name_common``:
+            >>> required_repeated_resource_name_common = []
+            >>>
             >>> # TODO: Initialize ``required_repeated_fixed32``:
             >>> required_repeated_fixed32 = []
             >>>
@@ -3022,7 +3040,7 @@ class LibraryServiceClient(object):
             >>> # TODO: Initialize ``required_map``:
             >>> required_map = {}
             >>>
-            >>> response = client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_fixed32, required_repeated_fixed64, required_map)
+            >>> response = client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
 
         Args:
             required_singular_int32 (int)
@@ -3037,6 +3055,7 @@ class LibraryServiceClient(object):
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             required_singular_resource_name (str)
             required_singular_resource_name_oneof (str)
+            required_singular_resource_name_common (str)
             required_singular_fixed32 (int)
             required_singular_fixed64 (long)
             required_repeated_int32 (list[int])
@@ -3051,6 +3070,7 @@ class LibraryServiceClient(object):
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             required_repeated_resource_name (list[str])
             required_repeated_resource_name_oneof (list[str])
+            required_repeated_resource_name_common (list[str])
             required_repeated_fixed32 (list[int])
             required_repeated_fixed64 (list[long])
             required_map (dict[int -> str])
@@ -3066,6 +3086,7 @@ class LibraryServiceClient(object):
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             optional_singular_resource_name (str)
             optional_singular_resource_name_oneof (str)
+            optional_singular_resource_name_common (str)
             optional_singular_fixed32 (int)
             optional_singular_fixed64 (long)
             optional_repeated_int32 (list[int])
@@ -3080,6 +3101,7 @@ class LibraryServiceClient(object):
                 message :class:`~google.cloud.example.library_v1.types.InnerMessage`
             optional_repeated_resource_name (list[str])
             optional_repeated_resource_name_oneof (list[str])
+            optional_repeated_resource_name_common (list[str])
             optional_repeated_fixed32 (list[int])
             optional_repeated_fixed64 (list[long])
             optional_map (dict[int -> str])
@@ -3117,6 +3139,7 @@ class LibraryServiceClient(object):
             required_singular_message=required_singular_message,
             required_singular_resource_name=required_singular_resource_name,
             required_singular_resource_name_oneof=required_singular_resource_name_oneof,
+            required_singular_resource_name_common=required_singular_resource_name_common,
             required_singular_fixed32=required_singular_fixed32,
             required_singular_fixed64=required_singular_fixed64,
             required_repeated_int32=required_repeated_int32,
@@ -3130,6 +3153,7 @@ class LibraryServiceClient(object):
             required_repeated_message=required_repeated_message,
             required_repeated_resource_name=required_repeated_resource_name,
             required_repeated_resource_name_oneof=required_repeated_resource_name_oneof,
+            required_repeated_resource_name_common=required_repeated_resource_name_common,
             required_repeated_fixed32=required_repeated_fixed32,
             required_repeated_fixed64=required_repeated_fixed64,
             required_map=required_map,
@@ -3144,6 +3168,7 @@ class LibraryServiceClient(object):
             optional_singular_message=optional_singular_message,
             optional_singular_resource_name=optional_singular_resource_name,
             optional_singular_resource_name_oneof=optional_singular_resource_name_oneof,
+            optional_singular_resource_name_common=optional_singular_resource_name_common,
             optional_singular_fixed32=optional_singular_fixed32,
             optional_singular_fixed64=optional_singular_fixed64,
             optional_repeated_int32=optional_repeated_int32,
@@ -3157,6 +3182,7 @@ class LibraryServiceClient(object):
             optional_repeated_message=optional_repeated_message,
             optional_repeated_resource_name=optional_repeated_resource_name,
             optional_repeated_resource_name_oneof=optional_repeated_resource_name_oneof,
+            optional_repeated_resource_name_common=optional_repeated_resource_name_common,
             optional_repeated_fixed32=optional_repeated_fixed32,
             optional_repeated_fixed64=optional_repeated_fixed64,
             optional_map=optional_map,
@@ -4714,6 +4740,7 @@ class TestLibraryServiceClient(object):
         required_singular_message = {}
         required_singular_resource_name = 'requiredSingularResourceName-1701575020'
         required_singular_resource_name_oneof = 'requiredSingularResourceNameOneof-25303726'
+        required_singular_resource_name_common = 'requiredSingularResourceNameCommon-1126805002'
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
         required_repeated_int32 = []
@@ -4727,15 +4754,16 @@ class TestLibraryServiceClient(object):
         required_repeated_message = []
         required_repeated_resource_name = []
         required_repeated_resource_name_oneof = []
+        required_repeated_resource_name_common = []
         required_repeated_fixed32 = []
         required_repeated_fixed64 = []
         required_map = {}
 
-        response = client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_fixed32, required_repeated_fixed64, required_map)
+        response = client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
         assert expected_response == response
 
         assert len(channel.requests) == 1
-        expected_request = library_pb2.TestOptionalRequiredFlatteningParamsRequest(required_singular_int32=required_singular_int32, required_singular_int64=required_singular_int64, required_singular_float=required_singular_float, required_singular_double=required_singular_double, required_singular_bool=required_singular_bool, required_singular_enum=required_singular_enum, required_singular_string=required_singular_string, required_singular_bytes=required_singular_bytes, required_singular_message=required_singular_message, required_singular_resource_name=required_singular_resource_name, required_singular_resource_name_oneof=required_singular_resource_name_oneof, required_singular_fixed32=required_singular_fixed32, required_singular_fixed64=required_singular_fixed64, required_repeated_int32=required_repeated_int32, required_repeated_int64=required_repeated_int64, required_repeated_float=required_repeated_float, required_repeated_double=required_repeated_double, required_repeated_bool=required_repeated_bool, required_repeated_enum=required_repeated_enum, required_repeated_string=required_repeated_string, required_repeated_bytes=required_repeated_bytes, required_repeated_message=required_repeated_message, required_repeated_resource_name=required_repeated_resource_name, required_repeated_resource_name_oneof=required_repeated_resource_name_oneof, required_repeated_fixed32=required_repeated_fixed32, required_repeated_fixed64=required_repeated_fixed64, required_map=required_map)
+        expected_request = library_pb2.TestOptionalRequiredFlatteningParamsRequest(required_singular_int32=required_singular_int32, required_singular_int64=required_singular_int64, required_singular_float=required_singular_float, required_singular_double=required_singular_double, required_singular_bool=required_singular_bool, required_singular_enum=required_singular_enum, required_singular_string=required_singular_string, required_singular_bytes=required_singular_bytes, required_singular_message=required_singular_message, required_singular_resource_name=required_singular_resource_name, required_singular_resource_name_oneof=required_singular_resource_name_oneof, required_singular_resource_name_common=required_singular_resource_name_common, required_singular_fixed32=required_singular_fixed32, required_singular_fixed64=required_singular_fixed64, required_repeated_int32=required_repeated_int32, required_repeated_int64=required_repeated_int64, required_repeated_float=required_repeated_float, required_repeated_double=required_repeated_double, required_repeated_bool=required_repeated_bool, required_repeated_enum=required_repeated_enum, required_repeated_string=required_repeated_string, required_repeated_bytes=required_repeated_bytes, required_repeated_message=required_repeated_message, required_repeated_resource_name=required_repeated_resource_name, required_repeated_resource_name_oneof=required_repeated_resource_name_oneof, required_repeated_resource_name_common=required_repeated_resource_name_common, required_repeated_fixed32=required_repeated_fixed32, required_repeated_fixed64=required_repeated_fixed64, required_map=required_map)
         actual_request = channel.requests[0][1]
         assert expected_request == actual_request
 
@@ -4757,6 +4785,7 @@ class TestLibraryServiceClient(object):
         required_singular_message = {}
         required_singular_resource_name = 'requiredSingularResourceName-1701575020'
         required_singular_resource_name_oneof = 'requiredSingularResourceNameOneof-25303726'
+        required_singular_resource_name_common = 'requiredSingularResourceNameCommon-1126805002'
         required_singular_fixed32 = 720656715
         required_singular_fixed64 = 720656810
         required_repeated_int32 = []
@@ -4770,10 +4799,11 @@ class TestLibraryServiceClient(object):
         required_repeated_message = []
         required_repeated_resource_name = []
         required_repeated_resource_name_oneof = []
+        required_repeated_resource_name_common = []
         required_repeated_fixed32 = []
         required_repeated_fixed64 = []
         required_map = {}
 
         with pytest.raises(CustomException):
-            client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_fixed32, required_repeated_fixed64, required_map)
+            client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -6892,6 +6892,7 @@ describe Library::V1::LibraryServiceClient do
             required_singular_message,
             required_singular_resource_name,
             required_singular_resource_name_oneof,
+            required_singular_resource_name_common,
             required_singular_fixed32,
             required_singular_fixed64,
             required_repeated_int32,
@@ -6905,6 +6906,7 @@ describe Library::V1::LibraryServiceClient do
             required_repeated_message,
             formatted_required_repeated_resource_name,
             formatted_required_repeated_resource_name_oneof,
+            required_repeated_resource_name_common,
             required_repeated_fixed32,
             required_repeated_fixed64,
             required_map

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_doc_library.baseline
@@ -2167,6 +2167,8 @@ module Google
         #   @return [String]
         # @!attribute [rw] required_singular_resource_name_oneof
         #   @return [String]
+        # @!attribute [rw] required_singular_resource_name_common
+        #   @return [String]
         # @!attribute [rw] required_singular_fixed32
         #   @return [Integer]
         # @!attribute [rw] required_singular_fixed64
@@ -2192,6 +2194,8 @@ module Google
         # @!attribute [rw] required_repeated_resource_name
         #   @return [Array<String>]
         # @!attribute [rw] required_repeated_resource_name_oneof
+        #   @return [Array<String>]
+        # @!attribute [rw] required_repeated_resource_name_common
         #   @return [Array<String>]
         # @!attribute [rw] required_repeated_fixed32
         #   @return [Array<Integer>]
@@ -2221,6 +2225,8 @@ module Google
         #   @return [String]
         # @!attribute [rw] optional_singular_resource_name_oneof
         #   @return [String]
+        # @!attribute [rw] optional_singular_resource_name_common
+        #   @return [String]
         # @!attribute [rw] optional_singular_fixed32
         #   @return [Integer]
         # @!attribute [rw] optional_singular_fixed64
@@ -2246,6 +2252,8 @@ module Google
         # @!attribute [rw] optional_repeated_resource_name
         #   @return [Array<String>]
         # @!attribute [rw] optional_repeated_resource_name_oneof
+        #   @return [Array<String>]
+        # @!attribute [rw] optional_repeated_resource_name_common
         #   @return [Array<String>]
         # @!attribute [rw] optional_repeated_fixed32
         #   @return [Array<Integer>]
@@ -2501,6 +2509,12 @@ module Library
 
       private_constant :RETURN_PATH_TEMPLATE
 
+      PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+        "projects/{project}"
+      )
+
+      private_constant :PROJECT_PATH_TEMPLATE
+
       ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "archives/{archive_path}/books/{book_id=**}"
       )
@@ -2537,6 +2551,15 @@ module Library
           :"shelf" => shelf,
           :"book" => book,
           :"return" => return_
+        )
+      end
+
+      # Returns a fully-qualified project resource name string.
+      # @param project [String]
+      # @return [String]
+      def self.project_path project
+        PROJECT_PATH_TEMPLATE.render(
+          :"project" => project
         )
       end
 
@@ -3829,6 +3852,7 @@ module Library
       #   can also be provided.
       # @param required_singular_resource_name [String]
       # @param required_singular_resource_name_oneof [String]
+      # @param required_singular_resource_name_common [String]
       # @param required_singular_fixed32 [Integer]
       # @param required_singular_fixed64 [Integer]
       # @param required_repeated_int32 [Array<Integer>]
@@ -3844,6 +3868,7 @@ module Library
       #   can also be provided.
       # @param required_repeated_resource_name [Array<String>]
       # @param required_repeated_resource_name_oneof [Array<String>]
+      # @param required_repeated_resource_name_common [Array<String>]
       # @param required_repeated_fixed32 [Array<Integer>]
       # @param required_repeated_fixed64 [Array<Integer>]
       # @param required_map [Hash{Integer => String}]
@@ -3860,6 +3885,7 @@ module Library
       #   can also be provided.
       # @param optional_singular_resource_name [String]
       # @param optional_singular_resource_name_oneof [String]
+      # @param optional_singular_resource_name_common [String]
       # @param optional_singular_fixed32 [Integer]
       # @param optional_singular_fixed64 [Integer]
       # @param optional_repeated_int32 [Array<Integer>]
@@ -3875,6 +3901,7 @@ module Library
       #   can also be provided.
       # @param optional_repeated_resource_name [Array<String>]
       # @param optional_repeated_resource_name_oneof [Array<String>]
+      # @param optional_repeated_resource_name_common [Array<String>]
       # @param optional_repeated_fixed32 [Array<Integer>]
       # @param optional_repeated_fixed64 [Array<Integer>]
       # @param optional_map [Hash{Integer => String}]
@@ -3921,6 +3948,9 @@ module Library
       #   # TODO: Initialize +required_singular_resource_name_oneof+:
       #   required_singular_resource_name_oneof = ''
       #
+      #   # TODO: Initialize +required_singular_resource_name_common+:
+      #   required_singular_resource_name_common = ''
+      #
       #   # TODO: Initialize +required_singular_fixed32+:
       #   required_singular_fixed32 = 0
       #
@@ -3960,6 +3990,9 @@ module Library
       #   # TODO: Initialize +formatted_required_repeated_resource_name_oneof+:
       #   formatted_required_repeated_resource_name_oneof = []
       #
+      #   # TODO: Initialize +required_repeated_resource_name_common+:
+      #   required_repeated_resource_name_common = []
+      #
       #   # TODO: Initialize +required_repeated_fixed32+:
       #   required_repeated_fixed32 = []
       #
@@ -3968,7 +4001,7 @@ module Library
       #
       #   # TODO: Initialize +required_map+:
       #   required_map = {}
-      #   response = library_service_client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_fixed32, required_repeated_fixed64, required_map)
+      #   response = library_service_client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
 
       def test_optional_required_flattening_params \
           required_singular_int32,
@@ -3982,6 +4015,7 @@ module Library
           required_singular_message,
           required_singular_resource_name,
           required_singular_resource_name_oneof,
+          required_singular_resource_name_common,
           required_singular_fixed32,
           required_singular_fixed64,
           required_repeated_int32,
@@ -3995,6 +4029,7 @@ module Library
           required_repeated_message,
           required_repeated_resource_name,
           required_repeated_resource_name_oneof,
+          required_repeated_resource_name_common,
           required_repeated_fixed32,
           required_repeated_fixed64,
           required_map,
@@ -4009,6 +4044,7 @@ module Library
           optional_singular_message: nil,
           optional_singular_resource_name: nil,
           optional_singular_resource_name_oneof: nil,
+          optional_singular_resource_name_common: nil,
           optional_singular_fixed32: nil,
           optional_singular_fixed64: nil,
           optional_repeated_int32: nil,
@@ -4022,6 +4058,7 @@ module Library
           optional_repeated_message: nil,
           optional_repeated_resource_name: nil,
           optional_repeated_resource_name_oneof: nil,
+          optional_repeated_resource_name_common: nil,
           optional_repeated_fixed32: nil,
           optional_repeated_fixed64: nil,
           optional_map: nil,
@@ -4038,6 +4075,7 @@ module Library
           required_singular_message: required_singular_message,
           required_singular_resource_name: required_singular_resource_name,
           required_singular_resource_name_oneof: required_singular_resource_name_oneof,
+          required_singular_resource_name_common: required_singular_resource_name_common,
           required_singular_fixed32: required_singular_fixed32,
           required_singular_fixed64: required_singular_fixed64,
           required_repeated_int32: required_repeated_int32,
@@ -4051,6 +4089,7 @@ module Library
           required_repeated_message: required_repeated_message,
           required_repeated_resource_name: required_repeated_resource_name,
           required_repeated_resource_name_oneof: required_repeated_resource_name_oneof,
+          required_repeated_resource_name_common: required_repeated_resource_name_common,
           required_repeated_fixed32: required_repeated_fixed32,
           required_repeated_fixed64: required_repeated_fixed64,
           required_map: required_map,
@@ -4065,6 +4104,7 @@ module Library
           optional_singular_message: optional_singular_message,
           optional_singular_resource_name: optional_singular_resource_name,
           optional_singular_resource_name_oneof: optional_singular_resource_name_oneof,
+          optional_singular_resource_name_common: optional_singular_resource_name_common,
           optional_singular_fixed32: optional_singular_fixed32,
           optional_singular_fixed64: optional_singular_fixed64,
           optional_repeated_int32: optional_repeated_int32,
@@ -4078,6 +4118,7 @@ module Library
           optional_repeated_message: optional_repeated_message,
           optional_repeated_resource_name: optional_repeated_resource_name,
           optional_repeated_resource_name_oneof: optional_repeated_resource_name_oneof,
+          optional_repeated_resource_name_common: optional_repeated_resource_name_common,
           optional_repeated_fixed32: optional_repeated_fixed32,
           optional_repeated_fixed64: optional_repeated_fixed64,
           optional_map: optional_map
@@ -6469,6 +6510,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
+      required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
       required_repeated_int32 = []
@@ -6482,6 +6524,7 @@ describe Library::V1::LibraryServiceClient do
       required_repeated_message = []
       formatted_required_repeated_resource_name = []
       formatted_required_repeated_resource_name_oneof = []
+      required_repeated_resource_name_common = []
       required_repeated_fixed32 = []
       required_repeated_fixed64 = []
       required_map = {}
@@ -6504,6 +6547,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
+        assert_equal(required_singular_resource_name_common, request.required_singular_resource_name_common)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)
         assert_equal(required_singular_fixed64, request.required_singular_fixed64)
         assert_equal(required_repeated_int32, request.required_repeated_int32)
@@ -6520,6 +6564,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_repeated_message, request.required_repeated_message)
         assert_equal(formatted_required_repeated_resource_name, request.required_repeated_resource_name)
         assert_equal(formatted_required_repeated_resource_name_oneof, request.required_repeated_resource_name_oneof)
+        assert_equal(required_repeated_resource_name_common, request.required_repeated_resource_name_common)
         assert_equal(required_repeated_fixed32, request.required_repeated_fixed32)
         assert_equal(required_repeated_fixed64, request.required_repeated_fixed64)
         assert_equal(required_map, request.required_map)
@@ -6547,6 +6592,7 @@ describe Library::V1::LibraryServiceClient do
             required_singular_message,
             required_singular_resource_name,
             required_singular_resource_name_oneof,
+            required_singular_resource_name_common,
             required_singular_fixed32,
             required_singular_fixed64,
             required_repeated_int32,
@@ -6560,6 +6606,7 @@ describe Library::V1::LibraryServiceClient do
             required_repeated_message,
             formatted_required_repeated_resource_name,
             formatted_required_repeated_resource_name_oneof,
+            required_repeated_resource_name_common,
             required_repeated_fixed32,
             required_repeated_fixed64,
             required_map
@@ -6584,6 +6631,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
+      required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
       required_repeated_int32 = []
@@ -6597,6 +6645,7 @@ describe Library::V1::LibraryServiceClient do
       required_repeated_message = []
       formatted_required_repeated_resource_name = []
       formatted_required_repeated_resource_name_oneof = []
+      required_repeated_resource_name_common = []
       required_repeated_fixed32 = []
       required_repeated_fixed64 = []
       required_map = {}
@@ -6615,6 +6664,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
+        assert_equal(required_singular_resource_name_common, request.required_singular_resource_name_common)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)
         assert_equal(required_singular_fixed64, request.required_singular_fixed64)
         assert_equal(required_repeated_int32, request.required_repeated_int32)
@@ -6631,6 +6681,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_repeated_message, request.required_repeated_message)
         assert_equal(formatted_required_repeated_resource_name, request.required_repeated_resource_name)
         assert_equal(formatted_required_repeated_resource_name_oneof, request.required_repeated_resource_name_oneof)
+        assert_equal(required_repeated_resource_name_common, request.required_repeated_resource_name_common)
         assert_equal(required_repeated_fixed32, request.required_repeated_fixed32)
         assert_equal(required_repeated_fixed64, request.required_repeated_fixed64)
         assert_equal(required_map, request.required_map)
@@ -6659,6 +6710,7 @@ describe Library::V1::LibraryServiceClient do
               required_singular_message,
               required_singular_resource_name,
               required_singular_resource_name_oneof,
+              required_singular_resource_name_common,
               required_singular_fixed32,
               required_singular_fixed64,
               required_repeated_int32,
@@ -6672,6 +6724,7 @@ describe Library::V1::LibraryServiceClient do
               required_repeated_message,
               formatted_required_repeated_resource_name,
               formatted_required_repeated_resource_name_oneof,
+              required_repeated_resource_name_common,
               required_repeated_fixed32,
               required_repeated_fixed64,
               required_map

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -954,6 +954,12 @@ module Library
 
       private_constant :RETURN_PATH_TEMPLATE
 
+      PROJECT_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
+        "projects/{project}"
+      )
+
+      private_constant :PROJECT_PATH_TEMPLATE
+
       ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "archives/{archive_path}/books/{book_id=**}"
       )
@@ -990,6 +996,15 @@ module Library
           :"shelf" => shelf,
           :"book" => book,
           :"return" => return_
+        )
+      end
+
+      # Returns a fully-qualified project resource name string.
+      # @param project [String]
+      # @return [String]
+      def self.project_path project
+        PROJECT_PATH_TEMPLATE.render(
+          :"project" => project
         )
       end
 
@@ -2282,6 +2297,7 @@ module Library
       #   can also be provided.
       # @param required_singular_resource_name [String]
       # @param required_singular_resource_name_oneof [String]
+      # @param required_singular_resource_name_common [String]
       # @param required_singular_fixed32 [Integer]
       # @param required_singular_fixed64 [Integer]
       # @param required_repeated_int32 [Array<Integer>]
@@ -2297,6 +2313,7 @@ module Library
       #   can also be provided.
       # @param required_repeated_resource_name [Array<String>]
       # @param required_repeated_resource_name_oneof [Array<String>]
+      # @param required_repeated_resource_name_common [Array<String>]
       # @param required_repeated_fixed32 [Array<Integer>]
       # @param required_repeated_fixed64 [Array<Integer>]
       # @param required_map [Hash{Integer => String}]
@@ -2313,6 +2330,7 @@ module Library
       #   can also be provided.
       # @param optional_singular_resource_name [String]
       # @param optional_singular_resource_name_oneof [String]
+      # @param optional_singular_resource_name_common [String]
       # @param optional_singular_fixed32 [Integer]
       # @param optional_singular_fixed64 [Integer]
       # @param optional_repeated_int32 [Array<Integer>]
@@ -2328,6 +2346,7 @@ module Library
       #   can also be provided.
       # @param optional_repeated_resource_name [Array<String>]
       # @param optional_repeated_resource_name_oneof [Array<String>]
+      # @param optional_repeated_resource_name_common [Array<String>]
       # @param optional_repeated_fixed32 [Array<Integer>]
       # @param optional_repeated_fixed64 [Array<Integer>]
       # @param optional_map [Hash{Integer => String}]
@@ -2374,6 +2393,9 @@ module Library
       #   # TODO: Initialize +required_singular_resource_name_oneof+:
       #   required_singular_resource_name_oneof = ''
       #
+      #   # TODO: Initialize +required_singular_resource_name_common+:
+      #   required_singular_resource_name_common = ''
+      #
       #   # TODO: Initialize +required_singular_fixed32+:
       #   required_singular_fixed32 = 0
       #
@@ -2413,6 +2435,9 @@ module Library
       #   # TODO: Initialize +formatted_required_repeated_resource_name_oneof+:
       #   formatted_required_repeated_resource_name_oneof = []
       #
+      #   # TODO: Initialize +required_repeated_resource_name_common+:
+      #   required_repeated_resource_name_common = []
+      #
       #   # TODO: Initialize +required_repeated_fixed32+:
       #   required_repeated_fixed32 = []
       #
@@ -2421,7 +2446,7 @@ module Library
       #
       #   # TODO: Initialize +required_map+:
       #   required_map = {}
-      #   response = library_service_client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_fixed32, required_repeated_fixed64, required_map)
+      #   response = library_service_client.test_optional_required_flattening_params(required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_resource_name_common, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, formatted_required_repeated_resource_name, formatted_required_repeated_resource_name_oneof, required_repeated_resource_name_common, required_repeated_fixed32, required_repeated_fixed64, required_map)
 
       def test_optional_required_flattening_params \
           required_singular_int32,
@@ -2435,6 +2460,7 @@ module Library
           required_singular_message,
           required_singular_resource_name,
           required_singular_resource_name_oneof,
+          required_singular_resource_name_common,
           required_singular_fixed32,
           required_singular_fixed64,
           required_repeated_int32,
@@ -2448,6 +2474,7 @@ module Library
           required_repeated_message,
           required_repeated_resource_name,
           required_repeated_resource_name_oneof,
+          required_repeated_resource_name_common,
           required_repeated_fixed32,
           required_repeated_fixed64,
           required_map,
@@ -2462,6 +2489,7 @@ module Library
           optional_singular_message: nil,
           optional_singular_resource_name: nil,
           optional_singular_resource_name_oneof: nil,
+          optional_singular_resource_name_common: nil,
           optional_singular_fixed32: nil,
           optional_singular_fixed64: nil,
           optional_repeated_int32: nil,
@@ -2475,6 +2503,7 @@ module Library
           optional_repeated_message: nil,
           optional_repeated_resource_name: nil,
           optional_repeated_resource_name_oneof: nil,
+          optional_repeated_resource_name_common: nil,
           optional_repeated_fixed32: nil,
           optional_repeated_fixed64: nil,
           optional_map: nil,
@@ -2491,6 +2520,7 @@ module Library
           required_singular_message: required_singular_message,
           required_singular_resource_name: required_singular_resource_name,
           required_singular_resource_name_oneof: required_singular_resource_name_oneof,
+          required_singular_resource_name_common: required_singular_resource_name_common,
           required_singular_fixed32: required_singular_fixed32,
           required_singular_fixed64: required_singular_fixed64,
           required_repeated_int32: required_repeated_int32,
@@ -2504,6 +2534,7 @@ module Library
           required_repeated_message: required_repeated_message,
           required_repeated_resource_name: required_repeated_resource_name,
           required_repeated_resource_name_oneof: required_repeated_resource_name_oneof,
+          required_repeated_resource_name_common: required_repeated_resource_name_common,
           required_repeated_fixed32: required_repeated_fixed32,
           required_repeated_fixed64: required_repeated_fixed64,
           required_map: required_map,
@@ -2518,6 +2549,7 @@ module Library
           optional_singular_message: optional_singular_message,
           optional_singular_resource_name: optional_singular_resource_name,
           optional_singular_resource_name_oneof: optional_singular_resource_name_oneof,
+          optional_singular_resource_name_common: optional_singular_resource_name_common,
           optional_singular_fixed32: optional_singular_fixed32,
           optional_singular_fixed64: optional_singular_fixed64,
           optional_repeated_int32: optional_repeated_int32,
@@ -2531,6 +2563,7 @@ module Library
           optional_repeated_message: optional_repeated_message,
           optional_repeated_resource_name: optional_repeated_resource_name,
           optional_repeated_resource_name_oneof: optional_repeated_resource_name_oneof,
+          optional_repeated_resource_name_common: optional_repeated_resource_name_common,
           optional_repeated_fixed32: optional_repeated_fixed32,
           optional_repeated_fixed64: optional_repeated_fixed64,
           optional_map: optional_map
@@ -4922,6 +4955,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
+      required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
       required_repeated_int32 = []
@@ -4935,6 +4969,7 @@ describe Library::V1::LibraryServiceClient do
       required_repeated_message = []
       formatted_required_repeated_resource_name = []
       formatted_required_repeated_resource_name_oneof = []
+      required_repeated_resource_name_common = []
       required_repeated_fixed32 = []
       required_repeated_fixed64 = []
       required_map = {}
@@ -4957,6 +4992,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
+        assert_equal(required_singular_resource_name_common, request.required_singular_resource_name_common)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)
         assert_equal(required_singular_fixed64, request.required_singular_fixed64)
         assert_equal(required_repeated_int32, request.required_repeated_int32)
@@ -4973,6 +5009,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_repeated_message, request.required_repeated_message)
         assert_equal(formatted_required_repeated_resource_name, request.required_repeated_resource_name)
         assert_equal(formatted_required_repeated_resource_name_oneof, request.required_repeated_resource_name_oneof)
+        assert_equal(required_repeated_resource_name_common, request.required_repeated_resource_name_common)
         assert_equal(required_repeated_fixed32, request.required_repeated_fixed32)
         assert_equal(required_repeated_fixed64, request.required_repeated_fixed64)
         assert_equal(required_map, request.required_map)
@@ -5000,6 +5037,7 @@ describe Library::V1::LibraryServiceClient do
             required_singular_message,
             required_singular_resource_name,
             required_singular_resource_name_oneof,
+            required_singular_resource_name_common,
             required_singular_fixed32,
             required_singular_fixed64,
             required_repeated_int32,
@@ -5013,6 +5051,7 @@ describe Library::V1::LibraryServiceClient do
             required_repeated_message,
             formatted_required_repeated_resource_name,
             formatted_required_repeated_resource_name_oneof,
+            required_repeated_resource_name_common,
             required_repeated_fixed32,
             required_repeated_fixed64,
             required_map
@@ -5037,6 +5076,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
+      required_singular_resource_name_common = ''
       required_singular_fixed32 = 0
       required_singular_fixed64 = 0
       required_repeated_int32 = []
@@ -5050,6 +5090,7 @@ describe Library::V1::LibraryServiceClient do
       required_repeated_message = []
       formatted_required_repeated_resource_name = []
       formatted_required_repeated_resource_name_oneof = []
+      required_repeated_resource_name_common = []
       required_repeated_fixed32 = []
       required_repeated_fixed64 = []
       required_map = {}
@@ -5068,6 +5109,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
+        assert_equal(required_singular_resource_name_common, request.required_singular_resource_name_common)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)
         assert_equal(required_singular_fixed64, request.required_singular_fixed64)
         assert_equal(required_repeated_int32, request.required_repeated_int32)
@@ -5084,6 +5126,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_repeated_message, request.required_repeated_message)
         assert_equal(formatted_required_repeated_resource_name, request.required_repeated_resource_name)
         assert_equal(formatted_required_repeated_resource_name_oneof, request.required_repeated_resource_name_oneof)
+        assert_equal(required_repeated_resource_name_common, request.required_repeated_resource_name_common)
         assert_equal(required_repeated_fixed32, request.required_repeated_fixed32)
         assert_equal(required_repeated_fixed64, request.required_repeated_fixed64)
         assert_equal(required_map, request.required_map)
@@ -5112,6 +5155,7 @@ describe Library::V1::LibraryServiceClient do
               required_singular_message,
               required_singular_resource_name,
               required_singular_resource_name_oneof,
+              required_singular_resource_name_common,
               required_singular_fixed32,
               required_singular_fixed64,
               required_repeated_int32,
@@ -5125,6 +5169,7 @@ describe Library::V1::LibraryServiceClient do
               required_repeated_message,
               formatted_required_repeated_resource_name,
               formatted_required_repeated_resource_name_oneof,
+              required_repeated_resource_name_common,
               required_repeated_fixed32,
               required_repeated_fixed64,
               required_map

--- a/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby/ruby_library.baseline
@@ -5337,6 +5337,7 @@ describe Library::V1::LibraryServiceClient do
             required_singular_message,
             required_singular_resource_name,
             required_singular_resource_name_oneof,
+            required_singular_resource_name_common,
             required_singular_fixed32,
             required_singular_fixed64,
             required_repeated_int32,
@@ -5350,6 +5351,7 @@ describe Library::V1::LibraryServiceClient do
             required_repeated_message,
             formatted_required_repeated_resource_name,
             formatted_required_repeated_resource_name_oneof,
+            required_repeated_resource_name_common,
             required_repeated_fixed32,
             required_repeated_fixed64,
             required_map

--- a/src/test/java/com/google/api/codegen/testsrc/library.proto
+++ b/src/test/java/com/google/api/codegen/testsrc/library.proto
@@ -644,6 +644,7 @@ message TestOptionalRequiredFlatteningParamsRequest {
     InnerMessage required_singular_message = 9;
     string required_singular_resource_name = 10;
     string required_singular_resource_name_oneof = 11;
+    string required_singular_resource_name_common = 14;
     fixed32 required_singular_fixed32 = 12;
     fixed64 required_singular_fixed64 = 13;
 
@@ -658,6 +659,7 @@ message TestOptionalRequiredFlatteningParamsRequest {
     repeated InnerMessage required_repeated_message = 29;
     repeated string required_repeated_resource_name = 30;
     repeated string required_repeated_resource_name_oneof = 31;
+    repeated string required_repeated_resource_name_common = 34;
     repeated fixed32 required_repeated_fixed32 = 32;
     repeated fixed64 required_repeated_fixed64 = 33;
 
@@ -674,6 +676,7 @@ message TestOptionalRequiredFlatteningParamsRequest {
     InnerMessage optional_singular_message = 59;
     string optional_singular_resource_name = 60;
     string optional_singular_resource_name_oneof = 61;
+    string optional_singular_resource_name_common = 64;
     fixed32 optional_singular_fixed32 = 62;
     fixed64 optional_singular_fixed64 = 63;
 
@@ -688,6 +691,7 @@ message TestOptionalRequiredFlatteningParamsRequest {
     repeated InnerMessage optional_repeated_message = 79;
     repeated string optional_repeated_resource_name = 80;
     repeated string optional_repeated_resource_name_oneof = 81;
+    repeated string optional_repeated_resource_name_common = 84;
     repeated fixed32 optional_repeated_fixed32 = 82;
     repeated fixed64 optional_repeated_fixed64 = 83;
 

--- a/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/library_gapic.yaml
@@ -82,6 +82,11 @@ interfaces:
   # a language keyword. See: https://github.com/googleapis/toolkit/issues/618
   - name_pattern: shelves/{shelf}/books/{book}/returns/{return}
     entity_name: return
+  - name_pattern: projects/{project}
+    entity_name: project
+    language_overrides:
+    - language: csharp
+      common_resource_name: Google.Api.Gax.ResourceNames.ProjectName
   smoke_test:
     method: UpdateBook
     init_fields:
@@ -635,6 +640,7 @@ interfaces:
         - required_singular_message
         - required_singular_resource_name
         - required_singular_resource_name_oneof
+        - required_singular_resource_name_common
         - required_singular_fixed32
         - required_singular_fixed64
         - required_repeated_int32
@@ -648,6 +654,7 @@ interfaces:
         - required_repeated_message
         - required_repeated_resource_name
         - required_repeated_resource_name_oneof
+        - required_repeated_resource_name_common
         - required_repeated_fixed32
         - required_repeated_fixed64
         - required_map
@@ -662,6 +669,7 @@ interfaces:
         - optional_singular_message
         - optional_singular_resource_name
         - optional_singular_resource_name_oneof
+        - optional_singular_resource_name_common
         - optional_singular_fixed32
         - optional_singular_fixed64
         - optional_repeated_int32
@@ -675,6 +683,7 @@ interfaces:
         - optional_repeated_message
         - optional_repeated_resource_name
         - optional_repeated_resource_name_oneof
+        - optional_repeated_resource_name_common
         - optional_repeated_fixed32
         - optional_repeated_fixed64
         - optional_map
@@ -690,6 +699,7 @@ interfaces:
     - required_singular_message
     - required_singular_resource_name
     - required_singular_resource_name_oneof
+    - required_singular_resource_name_common
     - required_singular_fixed32
     - required_singular_fixed64
     - required_repeated_int32
@@ -703,6 +713,7 @@ interfaces:
     - required_repeated_message
     - required_repeated_resource_name
     - required_repeated_resource_name_oneof
+    - required_repeated_resource_name_common
     - required_repeated_fixed32
     - required_repeated_fixed64
     - required_map
@@ -789,9 +800,13 @@ resource_name_generation:
   field_entity_map:
     required_singular_resource_name: book
     required_singular_resource_name_oneof: book_oneof
+    required_singular_resource_name_common: project
     required_repeated_resource_name: book
     required_repeated_resource_name_oneof: book_oneof
+    required_repeated_resource_name_common: project
     optional_singular_resource_name: book
     optional_singular_resource_name_oneof: book_oneof
+    optional_singular_resource_name_common: project
     optional_repeated_resource_name: book
     optional_repeated_resource_name_oneof: book_oneof
+    optional_repeated_resource_name_common: project


### PR DESCRIPTION
Java generation is not correct.
@garrettjonesgoogle I'll look at the Java generation tomorrow, but if you get a change to have a look at this PR that'd be helpful. Or can point someone else at it.
@jskeet The C# generated code should be correct. Please feel free to review if you have a few minutes.