### PR TITLE
C# Fully qualify resource-name types in resource partials

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp/csharp_library.baseline
@@ -12763,11 +12763,11 @@ namespace Google.Example.Library.V1
     public partial class Book
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookName BookName
+        public Google.Example.Library.V1.BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12776,11 +12776,11 @@ namespace Google.Example.Library.V1
     public partial class BookFromAnywhere
     {
         /// <summary>
-        /// <see cref="BookNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookNameOneof BookNameOneof
+        public Google.Example.Library.V1.BookNameOneof BookNameOneof
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookNameOneof.Parse(Name, true); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12789,11 +12789,11 @@ namespace Google.Example.Library.V1
     public partial class BookFromArchive
     {
         /// <summary>
-        /// <see cref="ArchivedBookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ArchivedBookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ArchivedBookName ArchivedBookName
+        public Google.Example.Library.V1.ArchivedBookName ArchivedBookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ArchivedBookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ArchivedBookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12802,11 +12802,11 @@ namespace Google.Example.Library.V1
     public partial class CreateBookRequest
     {
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ShelfName ShelfName
+        public Google.Example.Library.V1.ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12815,11 +12815,11 @@ namespace Google.Example.Library.V1
     public partial class DeleteBookRequest
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookName BookName
+        public Google.Example.Library.V1.BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12828,11 +12828,11 @@ namespace Google.Example.Library.V1
     public partial class DeleteShelfRequest
     {
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ShelfName ShelfName
+        public Google.Example.Library.V1.ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12883,20 +12883,20 @@ namespace Google.Example.Library.V1
     public partial class GetBookFromAnywhereRequest
     {
         /// <summary>
-        /// <see cref="BookNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookNameOneof"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookNameOneof BookNameOneof
+        public Google.Example.Library.V1.BookNameOneof BookNameOneof
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookNameOneof.Parse(Name, true); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookNameOneof.Parse(Name, true); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="BookNameOneof"/>-typed view over the <see cref="AltBookName"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookNameOneof"/>-typed view over the <see cref="AltBookName"/> resource name property.
         /// </summary>
-        public BookNameOneof AltBookNameAsBookNameOneof
+        public Google.Example.Library.V1.BookNameOneof AltBookNameAsBookNameOneof
         {
-            get { return string.IsNullOrEmpty(AltBookName) ? null : BookNameOneof.Parse(AltBookName, true); }
+            get { return string.IsNullOrEmpty(AltBookName) ? null : Google.Example.Library.V1.BookNameOneof.Parse(AltBookName, true); }
             set { AltBookName = value != null ? value.ToString() : ""; }
         }
 
@@ -12905,11 +12905,11 @@ namespace Google.Example.Library.V1
     public partial class GetBookFromArchiveRequest
     {
         /// <summary>
-        /// <see cref="ArchivedBookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ArchivedBookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ArchivedBookName ArchivedBookName
+        public Google.Example.Library.V1.ArchivedBookName ArchivedBookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ArchivedBookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ArchivedBookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12918,11 +12918,11 @@ namespace Google.Example.Library.V1
     public partial class GetBookRequest
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookName BookName
+        public Google.Example.Library.V1.BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12931,11 +12931,11 @@ namespace Google.Example.Library.V1
     public partial class GetShelfRequest
     {
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ShelfName ShelfName
+        public Google.Example.Library.V1.ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12944,11 +12944,11 @@ namespace Google.Example.Library.V1
     public partial class ListBooksRequest
     {
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ShelfName ShelfName
+        public Google.Example.Library.V1.ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -12981,20 +12981,20 @@ namespace Google.Example.Library.V1
     public partial class MergeShelvesRequest
     {
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ShelfName ShelfName
+        public Google.Example.Library.V1.ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="OtherShelfName"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="OtherShelfName"/> resource name property.
         /// </summary>
-        public ShelfName OtherShelfNameAsShelfName
+        public Google.Example.Library.V1.ShelfName OtherShelfNameAsShelfName
         {
-            get { return string.IsNullOrEmpty(OtherShelfName) ? null : ShelfName.Parse(OtherShelfName); }
+            get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
             set { OtherShelfName = value != null ? value.ToString() : ""; }
         }
 
@@ -13003,20 +13003,20 @@ namespace Google.Example.Library.V1
     public partial class MoveBookRequest
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookName BookName
+        public Google.Example.Library.V1.BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="OtherShelfName"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="OtherShelfName"/> resource name property.
         /// </summary>
-        public ShelfName OtherShelfNameAsShelfName
+        public Google.Example.Library.V1.ShelfName OtherShelfNameAsShelfName
         {
-            get { return string.IsNullOrEmpty(OtherShelfName) ? null : ShelfName.Parse(OtherShelfName); }
+            get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
             set { OtherShelfName = value != null ? value.ToString() : ""; }
         }
 
@@ -13025,11 +13025,11 @@ namespace Google.Example.Library.V1
     public partial class Shelf
     {
         /// <summary>
-        /// <see cref="ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.ShelfName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public ShelfName ShelfName
+        public Google.Example.Library.V1.ShelfName ShelfName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : ShelfName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -13038,20 +13038,20 @@ namespace Google.Example.Library.V1
     public partial class TestOptionalRequiredFlatteningParamsRequest
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="RequiredSingularResourceName"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="RequiredSingularResourceName"/> resource name property.
         /// </summary>
-        public BookName RequiredSingularResourceNameAsBookName
+        public Google.Example.Library.V1.BookName RequiredSingularResourceNameAsBookName
         {
-            get { return string.IsNullOrEmpty(RequiredSingularResourceName) ? null : BookName.Parse(RequiredSingularResourceName); }
+            get { return string.IsNullOrEmpty(RequiredSingularResourceName) ? null : Google.Example.Library.V1.BookName.Parse(RequiredSingularResourceName); }
             set { RequiredSingularResourceName = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="BookNameOneof"/>-typed view over the <see cref="RequiredSingularResourceNameOneof"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookNameOneof"/>-typed view over the <see cref="RequiredSingularResourceNameOneof"/> resource name property.
         /// </summary>
-        public BookNameOneof RequiredSingularResourceNameOneofAsBookNameOneof
+        public Google.Example.Library.V1.BookNameOneof RequiredSingularResourceNameOneofAsBookNameOneof
         {
-            get { return string.IsNullOrEmpty(RequiredSingularResourceNameOneof) ? null : BookNameOneof.Parse(RequiredSingularResourceNameOneof, true); }
+            get { return string.IsNullOrEmpty(RequiredSingularResourceNameOneof) ? null : Google.Example.Library.V1.BookNameOneof.Parse(RequiredSingularResourceNameOneof, true); }
             set { RequiredSingularResourceNameOneof = value != null ? value.ToString() : ""; }
         }
 
@@ -13086,20 +13086,20 @@ namespace Google.Example.Library.V1
                 str => gaxres::ProjectName.Parse(str));
 
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="OptionalSingularResourceName"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="OptionalSingularResourceName"/> resource name property.
         /// </summary>
-        public BookName OptionalSingularResourceNameAsBookName
+        public Google.Example.Library.V1.BookName OptionalSingularResourceNameAsBookName
         {
-            get { return string.IsNullOrEmpty(OptionalSingularResourceName) ? null : BookName.Parse(OptionalSingularResourceName); }
+            get { return string.IsNullOrEmpty(OptionalSingularResourceName) ? null : Google.Example.Library.V1.BookName.Parse(OptionalSingularResourceName); }
             set { OptionalSingularResourceName = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
-        /// <see cref="BookNameOneof"/>-typed view over the <see cref="OptionalSingularResourceNameOneof"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookNameOneof"/>-typed view over the <see cref="OptionalSingularResourceNameOneof"/> resource name property.
         /// </summary>
-        public BookNameOneof OptionalSingularResourceNameOneofAsBookNameOneof
+        public Google.Example.Library.V1.BookNameOneof OptionalSingularResourceNameOneofAsBookNameOneof
         {
-            get { return string.IsNullOrEmpty(OptionalSingularResourceNameOneof) ? null : BookNameOneof.Parse(OptionalSingularResourceNameOneof, true); }
+            get { return string.IsNullOrEmpty(OptionalSingularResourceNameOneof) ? null : Google.Example.Library.V1.BookNameOneof.Parse(OptionalSingularResourceNameOneof, true); }
             set { OptionalSingularResourceNameOneof = value != null ? value.ToString() : ""; }
         }
 
@@ -13138,11 +13138,11 @@ namespace Google.Example.Library.V1
     public partial class UpdateBookIndexRequest
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookName BookName
+        public Google.Example.Library.V1.BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 
@@ -13151,11 +13151,11 @@ namespace Google.Example.Library.V1
     public partial class UpdateBookRequest
     {
         /// <summary>
-        /// <see cref="BookName"/>-typed view over the <see cref="Name"/> resource name property.
+        /// <see cref="Google.Example.Library.V1.BookName"/>-typed view over the <see cref="Name"/> resource name property.
         /// </summary>
-        public BookName BookName
+        public Google.Example.Library.V1.BookName BookName
         {
-            get { return string.IsNullOrEmpty(Name) ? null : BookName.Parse(Name); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
             set { Name = value != null ? value.ToString() : ""; }
         }
 


### PR DESCRIPTION
To avoid name collisions between class name and property name